### PR TITLE
Querverweise: 0.2C-Helfer entfernt (Adapter rechnet aus Kapazität)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ SESSION-HANDOVER.md
 # Superpowers-Planungs-/Arbeitsartefakte — nicht versionieren
 .superpowers/
 docs/superpowers/
+
+# Privates Canonical-Mapping mit echten Entitäts-IDs — nicht committen
+packages/opti_mapping.yaml

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Prognosebasierte & manuelle Akku-Ladesteuerung für den **SMA STP SE Hybrid-Wech
 Prognosebasierte Akku-Ladesteuerung für Home Assistant — **hardware-agnostisch** über einen
 separaten Modbus-Adapter, komplett als HA-Packages paketiert.
 
+**Prognosebasierter Ziel-SoC** (Kernfeature, `sensor.opti_target_soc`)  
+Lädt den Akku morgens **nicht** stumpf auf 100 %, sondern nur so weit, dass die erwartete
+Rest-PV des Tages ihn bis zum Abend von selbst voll macht — schont die Zellen und maximiert
+den PV-Eigenverbrauch. Der Zielwert ergibt sich aus Solcast-Restprognose, Hausverbrauch und
+Restzeit bis Sonnenuntergang, als Stufenkennlinie mit echter Hysterese (kein Flattern).
+→ **[Herleitung in docs/strategie-logik.md](docs/strategie-logik.md#der-intelligente-ziel-soc--herzstück-der-akkuschonung)**
+
 **Strategie** (`automations/opti_strategie.yaml`)  
 Entscheidet prognosebasiert, welcher Modus wann gilt: Lädt bei schlechter PV-Prognose aus
 dem Netz (gestaffelt nach SoC und Preisniveau), nutzt PV-Überschuss tagsüber und schützt

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ die Modbus-Konfiguration gebündelt mit.
 | `packages/opti_derived.yaml` | Abgeleitete Entscheidungs-Sensoren (Score, Ziel-SoC, Preisniveau, …) |
 | `packages/sma_modbus.yaml` | Modbus-TCP-Verbindung zum WR |
 | `packages/sma_helpers.yaml` | Alle Helfer (input_select, input_number, input_boolean, counter) |
-| `packages/sma_templates.yaml` | Template-Sensoren (dyn. Ladestärke, Ziel-SoC, Prognose-Bewertung) |
+| `packages/sma_templates.yaml` | Legacy-Template-Sensoren — teils durch `opti_derived.yaml` abgelöst (Ziel-SoC, Ladestärke, Prognose-Score, Preisniveau, Laufzeit), teils noch ohne Canonical-Äquivalent (Sollkurve/P-Regler, Abregelung) |
 | `packages/sma_statistik.yaml` | Gleitende Mittelwert-Sensoren für Verbrauch & Batterielast |
 | `automations/opti_strategie.yaml` | Strategie-Automation (editierbar, kein Blueprint) |
 
@@ -127,7 +127,7 @@ Verzeichnis kopieren:
 | `opti_derived.yaml` | Abgeleitete Entscheidungs-Sensoren (Score, Ziel-SoC, Preisniveau, …) |
 | `sma_modbus.yaml` | Modbus-TCP-Verbindung zum WR (nur **IP** anpassen) |
 | `sma_helpers.yaml` | alle `input_select`/`input_number`/`input_boolean`/`counter` (Modus, Sollwerte, SoC-Grenzen …) |
-| `sma_templates.yaml` | Template-Sensoren (dyn. Ladestärke, Ziel-SoC, Prognose-Bewertung, Laufzeit) |
+| `sma_templates.yaml` | Legacy-Template-Sensoren (nur noch teilweise gebraucht — siehe Hinweis oben in der Dateitabelle) |
 | `sma_statistik.yaml` | gleitende Mittelwerte (Verbrauch, Batterielast) |
 
 **4. Home Assistant neu starten** → Helfer, Templates, Statistik & Modbus sind da.
@@ -136,7 +136,8 @@ Verzeichnis kopieren:
 [`ha-modbus-akku-adapter`](https://github.com/Optic00/ha-modbus-akku-adapter) per Raw-URL
 importieren (*Einstellungen → Automatisierungen & Szenen → Blueprints → importieren*) und
 beim Anlegen der Automation die Eingaben auf deine Entitäten mappen
-(Modbus-Hub, WR-Status-Sensor, Modus-Select `input_select.akkusteuerung_modus`, dyn. Ladestärke).
+(Modbus-Hub, WR-Status-Sensor, Modus-Select `input_select.akkusteuerung_modus`,
+dyn. Ladestärke `sensor.opti_charge_power_w`).
 
 **6. Strategie einspielen:** die Opti-Automatik (steuert *welcher Modus wann*) – siehe
 `automations/opti_strategie.yaml`. Sie ist bewusst **editierbar** (kein Blueprint), damit

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ die Modbus-Konfiguration gebündelt mit.
 | `packages/opti_mapping.yaml` | **Dein** Hardware-Mapping (gitignored — enthält echte Entitäts-IDs) |
 | `packages/opti_derived.yaml` | Abgeleitete Entscheidungs-Sensoren (Score, Ziel-SoC, Preisniveau, …) |
 | `packages/sma_modbus.yaml` | Modbus-TCP-Verbindung zum WR |
-| `packages/sma_helpers.yaml` | Alle Helfer (input_select, input_number, input_boolean, counter) |
+| `packages/sma_helpers.yaml` | Alle Helfer (input_select, input_number, input_boolean, counter, input_text/input_datetime für Adapter-Write-on-Change ab v1.2.0) |
 | `packages/sma_templates.yaml` | Legacy-Template-Sensoren — teils durch `opti_derived.yaml` abgelöst (Ziel-SoC, Ladestärke, Prognose-Score, Preisniveau, Laufzeit), teils noch ohne Canonical-Äquivalent (Sollkurve/P-Regler, Abregelung) |
 | `packages/sma_statistik.yaml` | Gleitende Mittelwert-Sensoren für Verbrauch & Batterielast |
 | `automations/opti_strategie.yaml` | Strategie-Automation (editierbar, kein Blueprint) |

--- a/README.md
+++ b/README.md
@@ -13,18 +13,23 @@ separaten Modbus-Adapter, komplett als HA-Packages paketiert.
 
 **Strategie** (`automations/opti_strategie.yaml`)  
 Entscheidet prognosebasiert, welcher Modus wann gilt: Lädt bei schlechter PV-Prognose aus
-dem Netz (gestaffelt nach SoC und Preisniveau), nutzt PV-Überschuss tagsüber, schützt
-MinSOC-Grenzen und leitet drohende Abregelung in den Akku um. Schreibt ausschließlich
-`input_select.akkusteuerung_modus` — keine direkte Hardware-Ansteuerung.
+dem Netz (gestaffelt nach SoC und Preisniveau), nutzt PV-Überschuss tagsüber und schützt
+MinSOC-Grenzen. Schreibt primär `input_select.akkusteuerung_modus` — keine direkte
+Hardware-Ansteuerung.
 
 **Hardware-Adapter** (separates Repo: [`ha-modbus-akku-adapter`](https://github.com/Optic00/ha-modbus-akku-adapter))  
 Liest den Modus aus `input_select.akkusteuerung_modus` und steuert den WR via Modbus TCP.
 Läuft als eigenständiger Blueprint-Adapter — Strategie und Hardware-Ansteuerung sind
 bewusst getrennt. Single-Writer-Regel: immer nur ein Adapter aktiv.
 
+**Canonical-Layer** (`opti_mapping.example.yaml` → `packages/opti_mapping.yaml`)  
+Bildet hardware-spezifische Entitäten (SMA, Huawei oder andere WR) auf 13 kanonische
+`sensor.opti_*`-Sensoren ab. Strategie und abgeleitete Sensoren konsumieren nur diese
+kanonischen Namen — keine Seriennummern im Code. → **[docs/canonical-layer.md](docs/canonical-layer.md)**
+
 **Packages** (`packages/`) — per `!include_dir_named packages/` in `configuration.yaml`:  
-Liefert alle Helfer, Template-Sensoren, Statistik-Sensoren und die Modbus-Konfiguration
-gebündelt mit.
+Liefert alle Helfer, Template-Sensoren, abgeleitete Opti-Sensoren, Statistik-Sensoren und
+die Modbus-Konfiguration gebündelt mit.
 
 > **Legacy-Flachdateien** (`old/`): Die alten Einzeldateien im Repo-Root wurden nach `old/`
 > verschoben und werden nicht mehr gepflegt. Der empfohlene Weg ist die Package-Struktur.
@@ -48,6 +53,9 @@ gebündelt mit.
 
 | Pfad | Beschreibung |
 |---|---|
+| `opti_mapping.example.yaml` | Vorlage für das Hardware-Mapping (→ nach `packages/opti_mapping.yaml` kopieren, Platzhalter ersetzen) |
+| `packages/opti_mapping.yaml` | **Dein** Hardware-Mapping (gitignored — enthält echte Entitäts-IDs) |
+| `packages/opti_derived.yaml` | Abgeleitete Entscheidungs-Sensoren (Score, Ziel-SoC, Preisniveau, …) |
 | `packages/sma_modbus.yaml` | Modbus-TCP-Verbindung zum WR |
 | `packages/sma_helpers.yaml` | Alle Helfer (input_select, input_number, input_boolean, counter) |
 | `packages/sma_templates.yaml` | Template-Sensoren (dyn. Ladestärke, Ziel-SoC, Prognose-Bewertung) |
@@ -74,10 +82,10 @@ Die Strategie-Automation entscheidet ausschließlich den **Modus** via
 am Wechselrichter auslöst, übernimmt der Hardware-Adapter (Single-Writer-Regel). Das macht
 die Strategie unabhängig vom konkreten Speicherfabrikat.
 
-Eine vollständige laienverständliche Block-für-Block-Erklärung aller 12 Entscheidungsoptionen,
-der Preisstufenlogik (`sensor.strompreis_niveau`, anbieter-agnostisches Perzentil-Enum),
-des MinSOC-Schutzes, der Wintermodus-Blöcke und der neuen Bausteine (P10-Sicherheitsnetz,
-Decision-Trace, Abregelungs-Umleitung) findet sich unter:
+Eine vollständige laienverständliche Block-für-Block-Erklärung aller Entscheidungsoptionen,
+der Preisstufenlogik (`sensor.opti_price_level`, anbieter-agnostisches Perzentil-Enum),
+des MinSOC-Schutzes, der Wintermodus-Blöcke und der Bausteine (P10-Sicherheitsnetz,
+Decision-Trace) findet sich unter:
 **[docs/strategie-logik.md](docs/strategie-logik.md)**
 
 > **Adapter-Repo:** Die Modbus-/Hardware-Ansteuerung lebt in einem separaten Repository
@@ -89,9 +97,10 @@ Decision-Trace, Abregelungs-Umleitung) findet sich unter:
 ## Schnell-Nachbau über Packages (empfohlen)
 
 > 🆕 Neue, paketbasierte Installation – liefert **alle Helfer, Templates, Statistik-
-> Sensoren und die Modbus-Konfiguration mit** (kein manuelles Anlegen mehr). Die
-> hardwareseitige Modbus-Ansteuerung läuft als separater Blueprint-Adapter, sodass die
-> Strategie sauber von der WR-Ansteuerung getrennt ist.
+> Sensoren und die Modbus-Konfiguration mit** (kein manuelles Anlegen nötig). Der
+> Canonical-Layer (`opti_mapping.yaml`) macht die Strategie hardware-agnostisch —
+> funktioniert mit SMA, Huawei und anderen Wechselrichtern. Die hardwareseitige
+> Modbus-Ansteuerung läuft als separater Blueprint-Adapter.
 
 **1. Packages aktivieren** (einmalig) in deiner `configuration.yaml`:
 ```yaml
@@ -99,29 +108,34 @@ homeassistant:
   packages: !include_dir_named packages/
 ```
 
-**2. Package-Dateien** aus dem Ordner [`packages/`](packages/) in dein HA-`packages/`-
+**2. Hardware-Mapping anlegen:** `opti_mapping.example.yaml` nach `packages/opti_mapping.yaml`
+kopieren und alle `DEIN_*`-Platzhalter durch echte Entitäts-IDs ersetzen.
+→ Ausführliche Anleitung: **[docs/canonical-layer.md](docs/canonical-layer.md)**
+
+**3. Package-Dateien** aus dem Ordner [`packages/`](packages/) in dein HA-`packages/`-
 Verzeichnis kopieren:
 
 | Datei | Inhalt |
 |---|---|
+| `opti_derived.yaml` | Abgeleitete Entscheidungs-Sensoren (Score, Ziel-SoC, Preisniveau, …) |
 | `sma_modbus.yaml` | Modbus-TCP-Verbindung zum WR (nur **IP** anpassen) |
 | `sma_helpers.yaml` | alle `input_select`/`input_number`/`input_boolean`/`counter` (Modus, Sollwerte, SoC-Grenzen …) |
-| `sma_templates.yaml` | Template-Sensoren (dyn. Ladestärke, Ziel-SoC, Prognose-Bewertung, Laufzeit) – ⚙️-Platzhalter auf eigene Entitäten anpassen |
+| `sma_templates.yaml` | Template-Sensoren (dyn. Ladestärke, Ziel-SoC, Prognose-Bewertung, Laufzeit) |
 | `sma_statistik.yaml` | gleitende Mittelwerte (Verbrauch, Batterielast) |
 
-**3. Home Assistant neu starten** → Helfer, Templates, Statistik & Modbus sind da.
+**4. Home Assistant neu starten** → Helfer, Templates, Statistik & Modbus sind da.
 
-**4. Hardware-Adapter importieren:** Blueprint aus
+**5. Hardware-Adapter importieren:** Blueprint aus
 [`ha-modbus-akku-adapter`](https://github.com/Optic00/ha-modbus-akku-adapter) per Raw-URL
 importieren (*Einstellungen → Automatisierungen & Szenen → Blueprints → importieren*) und
 beim Anlegen der Automation die Eingaben auf deine Entitäten mappen
 (Modbus-Hub, WR-Status-Sensor, Modus-Select `input_select.akkusteuerung_modus`, dyn. Ladestärke).
 
-**5. Strategie einspielen:** die Opti-Automatik (steuert *welcher Modus wann*) – siehe
+**6. Strategie einspielen:** die Opti-Automatik (steuert *welcher Modus wann*) – siehe
 `automations/opti_strategie.yaml`. Sie ist bewusst **editierbar** (kein Blueprint), damit
 du sie an deine Anlage/Strategie anpassen kannst.
 
-**6. Feinjustieren:** SoC-Grenzen, Lade-/Entladegrenzen, Prognose-Schwellen über die
+**7. Feinjustieren:** SoC-Grenzen, Lade-/Entladegrenzen, Prognose-Schwellen über die
 HA-Oberfläche (alle als Helfer vorhanden).
 
 > ⚠️ **Single-Writer-Regel:** Nur **eine** Automation darf den WR via Modbus schreiben.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Liest den Modus aus `input_select.akkusteuerung_modus` und steuert den WR via Mo
 Läuft als eigenständiger Blueprint-Adapter — Strategie und Hardware-Ansteuerung sind
 bewusst getrennt. Single-Writer-Regel: immer nur ein Adapter aktiv.
 
-**Canonical-Layer** (`opti_mapping.example.yaml` → `packages/opti_mapping.yaml`)  
+**Canonical-Layer** (`opti_mapping.example.yaml` → `packages/opti_mapping.yaml`)
 Bildet hardware-spezifische Entitäten (SMA, Huawei oder andere WR) auf 13 kanonische
 `sensor.opti_*`-Sensoren ab. Strategie und abgeleitete Sensoren konsumieren nur diese
 kanonischen Namen — keine Seriennummern im Code. → **[docs/canonical-layer.md](docs/canonical-layer.md)**

--- a/README.md
+++ b/README.md
@@ -379,57 +379,9 @@ cards:
 
 ---
 
-## Konzepte erklärt
-
-### Welcher Sensor ist `sensor.betriebsstatus_sma_stp_se_10_0`?
-
-Das ist der Betriebsstatus-Sensor aus der Modbus-Konfiguration. In der mitgelieferten `configuration.yaml` heißt er `sensor.sma_stp_se_33003_betriebsstatus` (Adresse 33003). Ältere Versionen dieses Repos nutzten noch den anderen Namen – bitte in der Automation entsprechend anpassen.
-
----
-
-### Woher kommt `sensor.akkusteuerung_dynamische_ladestaerke`?
-
-Dieser Template-Sensor ist in `templates.yaml` definiert und berechnet die optimale Ladestärke anhand von **Akku-SoC** und **Temperatur** – abgestimmt auf BYD LiFePO4-Chemie:
-
-| SoC | C-Rate | Begründung |
-|---|---|---|
-| < 30 % | 0.5C | Schnell laden bei kritisch niedrigem SoC |
-| 30–60 % | 0.3C | Optimale Langlebigkeit |
-| 60–85 % | 0.2C | Ausgewogen |
-| 85–MaxSoC | 0.1C | Schonend bei hohem SoC |
-| > MaxSoC | 0.05C | Minimal |
-| > 45 °C oder < 0 °C | reduziert/0 | Temperaturschutz |
-
----
-
-### Was ist `sensor.akku_target_soc_intelligent`?
-
-Berechnet anhand der **verbleibenden Solcast-Prognose** und dem geschätzten **Hausverbrauch bis Sonnenuntergang**, wie weit der Akku *jetzt* geladen werden sollte. Je weniger PV-Produktion noch zu erwarten ist, desto höher der Ziel-SoC:
-
-| Verh. Restproduktion / Akkukapazität | Ziel-SoC |
-|---|---|
-| > 3× | 50 % |
-| 2–3× | 60 % |
-| 1.5–2× | 70 % |
-| 1–1.5× | 80 % |
-| 0.5–1× | 90 % |
-| < 0.5× | MaxSoC |
-
----
-
-### Was ist der Unterschied zwischen Ladestärke, min/max Ladestärke?
-
-| Helfer | Wann aktiv | Beschreibung |
-|---|---|---|
-| `akkusteuerung_ladestaerke_soll` | Modus "Schnell Laden" | Feste Ziel-Ladestärke für den manuellen Modus |
-| _0.2C Laden_ (kein Helfer) | Modus "0.2C Laden" | Ladeleistung wird vom Hardware-Adapter automatisch aus der Batteriekapazität berechnet (0,2 × Kapazität) |
-| `akkusteuerung_min_ladestaerke` | Immer (Dynamisch-Betrieb) | Untere Grenze, die der WR nie unterschreiten soll |
-| `akkusteuerung_max_ladestaerke` | Immer (Dynamisch-Betrieb) | Obere Grenze – wird durch dynamische Ladestärke weiter begrenzt |
-| `sensor.akkusteuerung_dynamische_ladestaerke` | Immer (Dynamisch-Betrieb) | Automatisch berechneter Sollwert (SoC + Temperatur) |
-
-Empfehlung: Min auf `0`, Max auf z.B. `5000`, dann übernimmt die dynamische Berechnung die Feinsteuerung.
-
----
+> 💡 Nutzt du noch die alten Sensor-Namen (`akkusteuerung_dynamische_ladestaerke`,
+> `akku_target_soc_intelligent`)? Erklärung und Alt↔Neu-Mapping:
+> **[old/README.md#konzepte-legacy-namen](old/README.md#konzepte-legacy-namen-oldtemplatesyaml)**
 
 ### Modbus-Register Referenz
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ kanonischen Namen — keine Seriennummern im Code. → **[docs/canonical-layer.m
 Liefert alle Helfer, Template-Sensoren, abgeleitete Opti-Sensoren, Statistik-Sensoren und
 die Modbus-Konfiguration gebündelt mit.
 
+### Wer liefert was — und in welcher Reihenfolge?
+
+| Kommt aus | Was | GUI oder YAML |
+|---|---|---|
+| Adapter-Repo | Modbus-Hub zum WR | YAML (`configuration.yaml`/Package) |
+| Adapter-Repo | Modus-Dropdown + 6 Leistungs-Helfer | GUI oder YAML (Package) |
+| Adapter-Repo | 2 Write-on-Change-Helfer (`input_text`/`input_datetime`) | GUI oder YAML (Package) |
+| Adapter-Repo | Blueprint (übersetzt Modus → Modbus) | Blueprint-Import |
+| Opti-Repo | `opti_mapping.yaml` (Hardware → kanonische Sensoren) | YAML, von dir ausgefüllt |
+| Opti-Repo | `opti_derived.yaml` (Score, Ziel-SoC, Preisniveau) | YAML (Package) |
+| Opti-Repo | Strategie-Automation (setzt den Modus) | YAML (editierbar, kein Blueprint) |
+
+**Verbindliche Reihenfolge, wenn du beide Repos zusammen nutzt:**
+
+1. Modbus-Verbindung + Helfer anlegen (Adapter-Repo, Schritt 1–2)
+2. Opti-Packages aktivieren + `opti_mapping.yaml` ausfüllen (Opti-Repo)
+3. Home Assistant neu starten — `sensor.opti_*` prüfen
+4. Adapter-Blueprint importieren, Inputs auf `sensor.opti_charge_power_w` /
+   `sensor.opti_target_soc` setzen (nicht ungeprüft die Blueprint-Vorschlagswerte
+   übernehmen, falls sie abweichen)
+5. Strategie-Automation (`automations/opti_strategie.yaml`) aktivieren
+
+```
+Strategie  →  input_select.akkusteuerung_modus  →  [ ADAPTER-BLUEPRINT ]  →  Modbus-Register  →  WR
+(setzt Modus)        (+ input_number.* in W)              übersetzt
+```
+
 > **Legacy-Flachdateien** (`old/`): Die alten Einzeldateien im Repo-Root wurden nach `old/`
 > verschoben und werden nicht mehr gepflegt. Der empfohlene Weg ist die Package-Struktur.
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ die Modbus-Konfiguration gebündelt mit.
 | Kommt aus | Was | GUI oder YAML |
 |---|---|---|
 | Adapter-Repo | Modbus-Hub zum WR | YAML (`configuration.yaml`/Package) |
-| Adapter-Repo | Modus-Dropdown + 6 Leistungs-Helfer | GUI oder YAML (Package) |
-| Adapter-Repo | 2 Write-on-Change-Helfer (`input_text`/`input_datetime`) | GUI oder YAML (Package) |
+| Adapter-Repo (**oder** Opti-Repo, siehe unten) | Modus-Dropdown + 6 Leistungs-Helfer | GUI oder YAML (Package) |
+| Adapter-Repo (**oder** Opti-Repo, siehe unten) | 2 Write-on-Change-Helfer (`input_text`/`input_datetime`) | GUI oder YAML (Package) |
 | Adapter-Repo | Blueprint (übersetzt Modus → Modbus) | Blueprint-Import |
 | Opti-Repo | `opti_mapping.yaml` (Hardware → kanonische Sensoren) | YAML, von dir ausgefüllt |
 | Opti-Repo | `opti_derived.yaml` (Score, Ziel-SoC, Preisniveau) | YAML (Package) |
@@ -52,13 +52,20 @@ die Modbus-Konfiguration gebündelt mit.
 
 **Verbindliche Reihenfolge, wenn du beide Repos zusammen nutzt:**
 
-1. Modbus-Verbindung + Helfer anlegen (Adapter-Repo, Schritt 1–2)
+1. Modbus-Verbindung anlegen (Adapter-Repo, Schritt 1). Helfer NICHT hier anlegen, wenn du Schritt 2 nutzt — siehe Hinweis unten.
 2. Opti-Packages aktivieren + `opti_mapping.yaml` ausfüllen (Opti-Repo)
 3. Home Assistant neu starten — `sensor.opti_*` prüfen
 4. Adapter-Blueprint importieren, Inputs auf `sensor.opti_charge_power_w` /
    `sensor.opti_target_soc` setzen (nicht ungeprüft die Blueprint-Vorschlagswerte
    übernehmen, falls sie abweichen)
 5. Strategie-Automation (`automations/opti_strategie.yaml`) aktivieren
+
+> ⚠️ **Helfer nur aus einer Quelle:** Bei kombinierter Nutzung liefert
+> `ha-opti-akkusteuerung/packages/sma_helpers.yaml` bereits alle Helfer (Modus-Dropdown,
+> 6 Leistungs-Helfer, 2 Write-on-Change-Helfer). Die Adapter-GUI-Anleitung bzw. das
+> Adapter-Package dann NICHT zusätzlich verwenden — zwei Packages mit denselben
+> Entity-IDs führen zu einem Duplicate-Key-Fehler im HA-Log. Nutzt du den Adapter
+> **ohne** das Opti-Repo (eigene Strategie), gilt die Adapter-Anleitung normal.
 
 ```
 Strategie  →  input_select.akkusteuerung_modus  →  [ ADAPTER-BLUEPRINT ]  →  Modbus-Register  →  WR

--- a/README.md
+++ b/README.md
@@ -257,7 +257,6 @@ Entweder manuell über die HA-Oberfläche oder per YAML. Alle Helfer auf einen B
 | `akku_opti_automatik` | input_boolean | – | Opti-Automatik Ein/Aus |
 | `akkusteuerung_ladestaerke_soll` | input_number | 100–10000 W | Ladestärke (manuell) |
 | `akkusteuerung_entladestaerke_soll` | input_number | 100–10000 W | Entladestärke (manuell) |
-| `akkusteuerung_02c_ladestaerke` | input_number | 100–10000 W | 0.2C Ladestärke |
 | `akkusteuerung_min_ladestaerke` | input_number | 0–2000 W | Minimale Ladestärke |
 | `akkusteuerung_max_ladestaerke` | input_number | 0–10000 W | Maximale Ladestärke |
 | `akkusteuerung_min_entladestaerke` | input_number | 0–2000 W | Minimale Entladestärke |
@@ -346,8 +345,6 @@ cards:
       - entity: input_number.akkusteuerung_ladestaerke_soll
       - entity: input_number.akkusteuerung_entladestaerke_soll
         name: Entladestärke
-      - entity: input_number.akkusteuerung_02c_ladestaerke
-        name: Ladestärke 0.2C
       - entity: input_number.akkusteuerung_wr_ac_ueberschuss_grenze
         name: WR AC-Grenze
       - entity: input_number.akkusteuerung_wr_70proz_ueberschuss_grenze
@@ -416,7 +413,8 @@ Berechnet anhand der **verbleibenden Solcast-Prognose** und dem geschätzten **H
 
 | Helfer | Wann aktiv | Beschreibung |
 |---|---|---|
-| `akkusteuerung_ladestaerke_soll` | Modi "Schnell Laden" / "0.2C Laden" | Feste Ziel-Ladestärke für manuelle Modi |
+| `akkusteuerung_ladestaerke_soll` | Modus "Schnell Laden" | Feste Ziel-Ladestärke für den manuellen Modus |
+| _0.2C Laden_ (kein Helfer) | Modus "0.2C Laden" | Ladeleistung wird vom Hardware-Adapter automatisch aus der Batteriekapazität berechnet (0,2 × Kapazität) |
 | `akkusteuerung_min_ladestaerke` | Immer (Dynamisch-Betrieb) | Untere Grenze, die der WR nie unterschreiten soll |
 | `akkusteuerung_max_ladestaerke` | Immer (Dynamisch-Betrieb) | Obere Grenze – wird durch dynamische Ladestärke weiter begrenzt |
 | `sensor.akkusteuerung_dynamische_ladestaerke` | Immer (Dynamisch-Betrieb) | Automatisch berechneter Sollwert (SoC + Temperatur) |

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -490,9 +490,9 @@
               target:
                 entity_id: input_boolean.hausakku_aus_netz_laden
             - action: input_number.set_value
-              alias: "Ladepreis Helfer nach aktuellem Strompreis (ct/kWh)"
+              alias: "Ladepreis Helfer nach aktuellem Strompreis (EUR/kWh)"
               data:
-                value: "{{ states('sensor.opti_price_current_ct_kwh') | float(0) }}"
+                value: "{{ states('sensor.opti_price_current_ct_kwh') | float(0) / 100 }}"
               target:
                 entity_id: input_number.ladepreis
             - action: input_select.select_option

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -490,9 +490,9 @@
               target:
                 entity_id: input_boolean.hausakku_aus_netz_laden
             - action: input_number.set_value
-              alias: "Ladepreis Helfer nach aktuellem Strompreis (ct→EUR)"
+              alias: "Ladepreis Helfer nach aktuellem Strompreis (ct/kWh)"
               data:
-                value: "{{ states('sensor.opti_price_current_ct_kwh') | float(0) / 100 }}"
+                value: "{{ states('sensor.opti_price_current_ct_kwh') | float(0) }}"
               target:
                 entity_id: input_number.ladepreis
             - action: input_select.select_option

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -192,13 +192,11 @@
             - stop: "fertig"
 
         # Winter-/Prognose-Ladeblock (SOC < 75 %). Preis nur bis NORMAL.
+        # opti_winter_charging_allowed hier NICHT — opportunistischer Block, soll ganzjährig greifen.
         - alias: "Laden wenn morgen und heute schlecht und SOC unter 75% (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
-              state: "on"
-            - condition: state
-              entity_id: binary_sensor.opti_winter_charging_allowed
               state: "on"
             - condition: template
               value_template: >-
@@ -280,13 +278,12 @@
             - stop: "fertig"
 
         # Winter-/Prognose-Ladeblock (SOC < 15 %, Notfall). Nur heute-Score.
+        # KEIN opti_winter_charging_allowed-Gate — Notfall-Netzladen DARF NIE durch das
+        # Saisonal-Gate blockiert werden. Dieser Block muss ganzjährig und im Sommer greifen.
         - alias: "Laden wenn heute schlecht, SOC unter 15% (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
-              state: "on"
-            - condition: state
-              entity_id: binary_sensor.opti_winter_charging_allowed
               state: "on"
             - condition: template
               value_template: "{{ has_value('sensor.opti_forecast_score') }}"
@@ -320,13 +317,11 @@
             - stop: "fertig"
 
         # Winter-/Prognose-Ladeblock (SOC < 45 %, nur sehr günstig). Nur heute-Score.
+        # opti_winter_charging_allowed hier NICHT — Opportunistik-Block, soll ganzjährig greifen.
         - alias: "Laden wenn heute schlecht, SOC unter 45% und Strom sehr günstig (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
-              state: "on"
-            - condition: state
-              entity_id: binary_sensor.opti_winter_charging_allowed
               state: "on"
             - condition: template
               value_template: "{{ has_value('sensor.opti_forecast_score') }}"

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -1,37 +1,37 @@
 - id: "1757405050598"
   alias: "Akku Lade- Entladesteuerung Opti 2.0"
   description: >-
-    (inkl. Preisladung, 70% und AC-Überschuss) – v2.5: Prognosebasierte
-    Ladeblöcke tag+nacht, PV-Überschussblöcke nur tagsüber, korrekte
-    Mitternacht-Prognose-Reaktion
+    Strategie auf dem Canonical-opti_*-Layer (Paket 3). Setzt ausschliesslich
+    input_select.akkusteuerung_modus. Prognosebasierte SOC-Ladeblöcke
+    (Score+Preis), PV-/AC-Überschussblöcke, MinSOC-Schutz und Cleanup.
+    Quellen/Gates getauscht; aufgeschobene und arbitrage-basierte Zweige entfernt.
   mode: single
   triggers:
-    # Preisniveau-Quelle: anbieter-agnostischer sensor.strompreis_niveau (Perzentil), nicht mehr Tibber.
+    # Preisniveau (Enum) statt Tibber-Rohsensor
     - trigger: state
       entity_id:
-        - sensor.strompreis_niveau
-      from: null
-      to: null
-      id: "Tibber Preislevel Änderung"
-      enabled: true
+        - sensor.opti_price_level
+      id: "Preisniveau geändert"
     - trigger: state
       entity_id:
         - input_boolean.akku_opti_automatik
       to: "on"
       id: "Akku Opti-Automatik AN/AUS"
+    # Batterie-SoC (Canonical) statt Hardware-Rohsensor
     - trigger: state
       entity_id:
-        - sensor.sn_SERIENNUMMER_battery_soc_total
-      id: "BYD Änderung"
+        - sensor.opti_soc
+      id: "SoC Änderung"
+    # Entladeschwelle: beide Werte jetzt ct/kWh (Canonical)
     - trigger: numeric_state
       entity_id:
-        - sensor.mindestentladepreis
-      below: sensor.DEIN_STROMPREIS
+        - sensor.opti_mindestentladepreis_ct_kwh
+      below: sensor.opti_price_current_ct_kwh
       id: "Entladeschwelle"
-      enabled: true
+    # AC-Überschuss = PV-Leistung über Grenze
     - trigger: numeric_state
       entity_id:
-        - sensor.sn_SERIENNUMMER_pv_power
+        - sensor.opti_pv_power_w
       above: input_number.akkusteuerung_wr_ac_ueberschuss_grenze
       for:
         hours: 0
@@ -40,16 +40,17 @@
       id: "AC-Überschuss"
     - trigger: numeric_state
       entity_id:
-        - sensor.sn_SERIENNUMMER_pv_power
+        - sensor.opti_pv_power_w
       below: input_number.akkusteuerung_wr_ac_ueberschuss_grenze
       for:
         hours: 0
         minutes: 0
         seconds: 30
       id: "AC-Überschuss-Aus"
+    # 70%-Überschuss = Netzeinspeisung über Grenze
     - trigger: numeric_state
       entity_id:
-        - sensor.ueberschuss_pv_watt
+        - sensor.opti_grid_export_w
       above: input_number.akkusteuerung_wr_70proz_ueberschuss_grenze
       for:
         hours: 0
@@ -58,29 +59,33 @@
       id: "PV-70%-Überschuss"
     - trigger: numeric_state
       entity_id:
-        - sensor.ueberschuss_pv_watt
+        - sensor.opti_grid_export_w
       below: input_number.akkusteuerung_wr_70proz_ueberschuss_grenze
       for:
         hours: 0
         minutes: 0
         seconds: 30
       id: "PV-70%-Überschuss-Aus"
+    # Prognose-Scores statt PV-Forecast-Bewertungslabels
     - trigger: state
       entity_id:
-        - sensor.pv_forecast_bewertung_heute
-        - sensor.pv_forecast_bewertung_morgen
-      id: "PV Prognose Bewertung geändert"
+        - sensor.opti_forecast_score
+        - sensor.opti_forecast_score_tomorrow
+      id: "Prognose-Score geändert"
+    # Dynamische Ladestärke (Canonical)
     - trigger: state
       entity_id:
-        - sensor.akkusteuerung_dynamische_ladestaerke
+        - sensor.opti_charge_power_w
       id: "Dynamische Ladestärke geändert"
+    # Ziel-SoC (Canonical)
     - trigger: state
       entity_id:
-        - sensor.akku_target_soc_intelligent
-      id: "Target SoC erreicht"
+        - sensor.opti_target_soc
+      id: "Target SoC geändert"
+    # Akku voll
     - trigger: numeric_state
       entity_id:
-        - sensor.sn_SERIENNUMMER_battery_soc_total
+        - sensor.opti_soc
       above: 99
       id: "Akku ist voll"
     - trigger: state
@@ -91,25 +96,31 @@
       entity_id:
         - input_number.maxsoc
       id: "MaxSOC geändert"
-    - above: 100
-      entity_id: ["sensor.akku_abregelungsleistung"]
-      for:
-        hours: 0
-        minutes: 0
-        seconds: 30
-      id: "Abregelung droht"
-      trigger: numeric_state
+    # Neue Gates/Toggles (Paket 3)
+    - trigger: state
+      entity_id:
+        - input_boolean.opti_prognose_netzladen
+      id: "Prognose-Netzladen-Toggle geändert"
+    - trigger: state
+      entity_id:
+        - input_boolean.opti_pv_ueberschuss_ladung
+      id: "PV-Überschuss-Toggle geändert"
+    - trigger: state
+      entity_id:
+        - binary_sensor.opti_winter_charging_allowed
+      id: "Winterladefreigabe geändert"
   conditions:
     - condition: state
       entity_id: input_boolean.akku_opti_automatik
       state: "on"
   actions:
+    # CLEANUP (immer, kein has_value-/Toggle-Gate): Counter bei vollem Akku zurücksetzen
     - alias: "Counter auf 0 setzen bei 100% SoC"
       choose:
         - conditions:
-            - condition: trigger
-              id:
-                - "Akku ist voll"
+            - condition: numeric_state
+              entity_id: sensor.opti_soc
+              above: 99
           sequence:
             - action: counter.reset
               target:
@@ -117,12 +128,13 @@
 
     - alias: "Zwischen Speicherszenarien wählen"
       choose:
-        # OBERSTE PRIORITÄT: Entladesperre <minsoc — diese Option wird vor allen anderen geprüft
-        # und sperrt das Entladen sofort, sobald der SoC unter den konfigurierten MinSOC-Wert fällt.
+        # OBERSTE PRIORITÄT: Entladesperre <minsoc — vor allen anderen geprüft.
+        # Läuft IMMER (kein has_value-Gate); fehlt opti_soc, greift die
+        # numeric_state-Bedingung schlicht nicht (fail-safe).
         - alias: "MinSOC Schutz – Entladen sperren wenn SOC unter MinSOC (gilt tag und nacht)"
           conditions:
             - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
+              entity_id: sensor.opti_soc
               below: input_number.minsoc
           sequence:
             - action: input_select.select_option
@@ -132,64 +144,45 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "MinSOC Schutz aktiv – Entladen gesperrt"
 
-        # Intent: Winter-/Prognose-Ladeblock (SOC < 20 %).
-        # Diese und die folgenden SOC-gestuften Blöcke (< 20 / < 15 / < 45 / < 75 / < 80 %) halten den SoC
-        # praktisch im ~40–60 %-Band und shaven Preisspitzen (Peak-Shaving). Bewährt, nicht perfekt —
-        # explizite Bandregelung ist ein offener Verbesserungskandidat.
+        # Winter-/Prognose-Ladeblock (SOC < 20 %).
+        # Quelle: heute+morgen schlecht → Score<3 (beide); Preis VERY_CHEAP..EXPENSIVE.
+        # Gates: opti_prognose_netzladen on + opti_winter_charging_allowed on.
         - alias: "Laden wenn morgen und heute schlecht und SOC unter 20% (tag+nacht)"
           conditions:
-            - condition: trigger
-              id:
-                - "AC-Überschuss-Aus"
-                - "AC-Überschuss"
-                - "Akku Opti-Automatik AN/AUS"
-                - "PV-70%-Überschuss"
-                - "PV-70%-Überschuss-Aus"
-                - "BYD Änderung"
-                - "Tibber Preislevel Änderung"
-                - "PV Prognose Bewertung geändert"
             - condition: state
-              entity_id: input_boolean.akku_opti_automatik
+              entity_id: input_boolean.opti_prognose_netzladen
               state: "on"
             - condition: state
-              entity_id: input_boolean.hausakku_aus_netz_laden
-              state: "off"
+              entity_id: binary_sensor.opti_winter_charging_allowed
+              state: "on"
+            - condition: template
+              value_template: >-
+                {{ has_value('sensor.opti_forecast_score')
+                   and has_value('sensor.opti_forecast_score_tomorrow') }}
             - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
+              entity_id: sensor.opti_soc
               below: 20
-            - alias: "Heute Kritisch oder Mangelhaft"
-              condition: or
-              conditions:
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_heute
-                  state: "Mangelhaft"
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_heute
-                  state: "Kritisch"
+            - condition: numeric_state
+              entity_id: sensor.opti_forecast_score
+              below: 3
+            - condition: numeric_state
+              entity_id: sensor.opti_forecast_score_tomorrow
+              below: 3
             - alias: "Aktuelles Preisniveau VERY_CHEAP bis EXPENSIVE"
               condition: or
               conditions:
                 - condition: state
-                  entity_id: sensor.strompreis_niveau
-                  state: "CHEAP"
-                - condition: state
-                  entity_id: sensor.strompreis_niveau
+                  entity_id: sensor.opti_price_level
                   state: "VERY_CHEAP"
                 - condition: state
-                  entity_id: sensor.strompreis_niveau
+                  entity_id: sensor.opti_price_level
+                  state: "CHEAP"
+                - condition: state
+                  entity_id: sensor.opti_price_level
                   state: "NORMAL"
                 - condition: state
-                  entity_id: sensor.strompreis_niveau
+                  entity_id: sensor.opti_price_level
                   state: "EXPENSIVE"
-            - alias: "Morgen Kritisch oder Mangelhaft"
-              condition: or
-              conditions:
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_morgen
-                  state: "Mangelhaft"
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_morgen
-                  state: "Kritisch"
           sequence:
             - action: input_select.select_option
               data:
@@ -198,60 +191,40 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
 
-        # Intent: Winter-/Prognose-Ladeblock (SOC < 75 %).
-        # Greift bei schlechter Prognose für heute UND morgen, aber nur bis NORMAL-Preis (kein EXPENSIVE).
-        # Teil des bewährten SoC-~40–60 %-Band + Peak-Shaving-Musters; explizite Bandregelung = offener Kandidat.
+        # Winter-/Prognose-Ladeblock (SOC < 75 %). Preis nur bis NORMAL.
         - alias: "Laden wenn morgen und heute schlecht und SOC unter 75% (tag+nacht)"
           conditions:
-            - condition: trigger
-              id:
-                - "AC-Überschuss-Aus"
-                - "AC-Überschuss"
-                - "Akku Opti-Automatik AN/AUS"
-                - "PV-70%-Überschuss"
-                - "PV-70%-Überschuss-Aus"
-                - "BYD Änderung"
-                - "Tibber Preislevel Änderung"
-                - "PV Prognose Bewertung geändert"
             - condition: state
-              entity_id: input_boolean.akku_opti_automatik
+              entity_id: input_boolean.opti_prognose_netzladen
               state: "on"
             - condition: state
-              entity_id: input_boolean.hausakku_aus_netz_laden
-              state: "off"
+              entity_id: binary_sensor.opti_winter_charging_allowed
+              state: "on"
+            - condition: template
+              value_template: >-
+                {{ has_value('sensor.opti_forecast_score')
+                   and has_value('sensor.opti_forecast_score_tomorrow') }}
             - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
+              entity_id: sensor.opti_soc
               below: 75
-            - alias: "Heute Kritisch oder Mangelhaft"
-              condition: or
-              conditions:
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_heute
-                  state: "Mangelhaft"
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_heute
-                  state: "Kritisch"
+            - condition: numeric_state
+              entity_id: sensor.opti_forecast_score
+              below: 3
+            - condition: numeric_state
+              entity_id: sensor.opti_forecast_score_tomorrow
+              below: 3
             - alias: "Aktuelles Preisniveau VERY_CHEAP bis NORMAL"
               condition: or
               conditions:
                 - condition: state
-                  entity_id: sensor.strompreis_niveau
-                  state: "CHEAP"
-                - condition: state
-                  entity_id: sensor.strompreis_niveau
+                  entity_id: sensor.opti_price_level
                   state: "VERY_CHEAP"
                 - condition: state
-                  entity_id: sensor.strompreis_niveau
+                  entity_id: sensor.opti_price_level
+                  state: "CHEAP"
+                - condition: state
+                  entity_id: sensor.opti_price_level
                   state: "NORMAL"
-            - alias: "Morgen Kritisch oder Mangelhaft"
-              condition: or
-              conditions:
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_morgen
-                  state: "Mangelhaft"
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_morgen
-                  state: "Kritisch"
           sequence:
             - action: input_select.select_option
               data:
@@ -260,70 +233,44 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
 
-        # Intent: Winter-/Prognose-Ladeblock (SOC < 80 %, Wintermodus-Gate).
-        # Sichert den Akku aggressiv auf (bis 80 %) wenn PV-Rest < 15 kWh, kein Sommermodus und beide Tage schlecht.
-        # Teil des bewährten SoC-~40–60 %-Band + Peak-Shaving-Musters; explizite Bandregelung = offener Kandidat.
-        - alias: "Laden wenn heute+morgen schlecht, Strom fast aufgebraucht, Wintermodus, SOC unter 80% (tag+nacht)"
+        # Winter-/Prognose-Ladeblock (SOC < 80 %, Wintermodus-Gate).
+        # Sommermodus-Gate der Quelle → binary_sensor.opti_winter_charging_allowed.
+        - alias: "Laden wenn heute+morgen schlecht, Wintermodus, SOC unter 80% (tag+nacht)"
           conditions:
-            - condition: trigger
-              id:
-                - "AC-Überschuss-Aus"
-                - "AC-Überschuss"
-                - "Akku Opti-Automatik AN/AUS"
-                - "PV-70%-Überschuss"
-                - "PV-70%-Überschuss-Aus"
-                - "BYD Änderung"
-                - "Tibber Preislevel Änderung"
-                - "PV Prognose Bewertung geändert"
             - condition: state
-              entity_id: input_boolean.akku_opti_automatik
+              entity_id: input_boolean.opti_prognose_netzladen
               state: "on"
             - condition: state
-              entity_id: input_boolean.hausakku_aus_netz_laden
-              state: "off"
+              entity_id: binary_sensor.opti_winter_charging_allowed
+              state: "on"
+            - condition: template
+              value_template: >-
+                {{ has_value('sensor.opti_forecast_score')
+                   and has_value('sensor.opti_forecast_score_tomorrow') }}
             - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
+              entity_id: sensor.opti_soc
               below: 80
             - condition: numeric_state
-              entity_id: sensor.solcast_pv_forecast_prognose_verbleibende_leistung_heute
-              below: 15
-            # optional: Sommermodus-Gate; falls nicht vorhanden, diese Bedingung entfernen
-            - condition: state
-              entity_id: binary_sensor.DEIN_SOMMERMODUS_GATE
-              state: "off"
-            - alias: "Heute Kritisch oder Mangelhaft"
-              condition: or
-              conditions:
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_heute
-                  state: "Mangelhaft"
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_heute
-                  state: "Kritisch"
-            - alias: "Morgen Kritisch oder Mangelhaft"
-              condition: or
-              conditions:
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_morgen
-                  state: "Mangelhaft"
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_morgen
-                  state: "Kritisch"
+              entity_id: sensor.opti_forecast_score
+              below: 3
+            - condition: numeric_state
+              entity_id: sensor.opti_forecast_score_tomorrow
+              below: 3
             - alias: "Aktuelles Preisniveau VERY_CHEAP bis EXPENSIVE"
               condition: or
               conditions:
                 - condition: state
-                  entity_id: sensor.strompreis_niveau
-                  state: "EXPENSIVE"
+                  entity_id: sensor.opti_price_level
+                  state: "VERY_CHEAP"
                 - condition: state
-                  entity_id: sensor.strompreis_niveau
-                  state: "NORMAL"
-                - condition: state
-                  entity_id: sensor.strompreis_niveau
+                  entity_id: sensor.opti_price_level
                   state: "CHEAP"
                 - condition: state
-                  entity_id: sensor.strompreis_niveau
-                  state: "VERY_CHEAP"
+                  entity_id: sensor.opti_price_level
+                  state: "NORMAL"
+                - condition: state
+                  entity_id: sensor.opti_price_level
+                  state: "EXPENSIVE"
           sequence:
             - action: input_select.select_option
               data:
@@ -332,57 +279,38 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
 
-        # Intent: Winter-/Prognose-Ladeblock (SOC < 15 %, Notfall-Schwelle).
-        # Sehr niedriger Trigger: greift auch unabhängig von morgen-Prognose, wenn PV-Rest < 20 kWh.
-        # Teil des bewährten SoC-~40–60 %-Band + Peak-Shaving-Musters; explizite Bandregelung = offener Kandidat.
-        - alias: "Laden wenn heute schlecht, wenig PV-Rest, SOC unter 15% (tag+nacht)"
+        # Winter-/Prognose-Ladeblock (SOC < 15 %, Notfall). Nur heute-Score.
+        - alias: "Laden wenn heute schlecht, SOC unter 15% (tag+nacht)"
           conditions:
-            - condition: trigger
-              id:
-                - "AC-Überschuss-Aus"
-                - "AC-Überschuss"
-                - "Akku Opti-Automatik AN/AUS"
-                - "PV-70%-Überschuss"
-                - "PV-70%-Überschuss-Aus"
-                - "BYD Änderung"
-                - "Tibber Preislevel Änderung"
-                - "PV Prognose Bewertung geändert"
             - condition: state
-              entity_id: input_boolean.akku_opti_automatik
+              entity_id: input_boolean.opti_prognose_netzladen
               state: "on"
             - condition: state
-              entity_id: input_boolean.hausakku_aus_netz_laden
-              state: "off"
+              entity_id: binary_sensor.opti_winter_charging_allowed
+              state: "on"
+            - condition: template
+              value_template: "{{ has_value('sensor.opti_forecast_score') }}"
             - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
+              entity_id: sensor.opti_soc
               below: 15
             - condition: numeric_state
-              entity_id: sensor.solcast_pv_forecast_prognose_verbleibende_leistung_heute
-              below: 20
-            - alias: "Heute Kritisch oder Mangelhaft"
-              condition: or
-              conditions:
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_heute
-                  state: "Mangelhaft"
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_heute
-                  state: "Kritisch"
+              entity_id: sensor.opti_forecast_score
+              below: 3
             - alias: "Aktuelles Preisniveau VERY_CHEAP bis EXPENSIVE"
               condition: or
               conditions:
                 - condition: state
-                  entity_id: sensor.strompreis_niveau
-                  state: "EXPENSIVE"
+                  entity_id: sensor.opti_price_level
+                  state: "VERY_CHEAP"
                 - condition: state
-                  entity_id: sensor.strompreis_niveau
-                  state: "NORMAL"
-                - condition: state
-                  entity_id: sensor.strompreis_niveau
+                  entity_id: sensor.opti_price_level
                   state: "CHEAP"
                 - condition: state
-                  entity_id: sensor.strompreis_niveau
-                  state: "VERY_CHEAP"
+                  entity_id: sensor.opti_price_level
+                  state: "NORMAL"
+                - condition: state
+                  entity_id: sensor.opti_price_level
+                  state: "EXPENSIVE"
           sequence:
             - action: input_select.select_option
               data:
@@ -391,51 +319,32 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
 
-        # Intent: Winter-/Prognose-Ladeblock (SOC < 45 %, nur bei CHEAP/VERY_CHEAP).
-        # Peak-Shaving-Variante: lädt opportunistisch bei sehr günstigen Preisen (kein NORMAL/EXPENSIVE).
-        # Teil des bewährten SoC-~40–60 %-Band + Peak-Shaving-Musters; explizite Bandregelung = offener Kandidat.
-        - alias: "Laden wenn heute schlecht, wenig PV-Rest, SOC unter 45% und Strom sehr günstig (tag+nacht)"
+        # Winter-/Prognose-Ladeblock (SOC < 45 %, nur sehr günstig). Nur heute-Score.
+        - alias: "Laden wenn heute schlecht, SOC unter 45% und Strom sehr günstig (tag+nacht)"
           conditions:
-            - condition: trigger
-              id:
-                - "AC-Überschuss-Aus"
-                - "AC-Überschuss"
-                - "Akku Opti-Automatik AN/AUS"
-                - "PV-70%-Überschuss"
-                - "PV-70%-Überschuss-Aus"
-                - "BYD Änderung"
-                - "Tibber Preislevel Änderung"
-                - "PV Prognose Bewertung geändert"
             - condition: state
-              entity_id: input_boolean.akku_opti_automatik
+              entity_id: input_boolean.opti_prognose_netzladen
               state: "on"
             - condition: state
-              entity_id: input_boolean.hausakku_aus_netz_laden
-              state: "off"
+              entity_id: binary_sensor.opti_winter_charging_allowed
+              state: "on"
+            - condition: template
+              value_template: "{{ has_value('sensor.opti_forecast_score') }}"
             - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
+              entity_id: sensor.opti_soc
               below: 45
             - condition: numeric_state
-              entity_id: sensor.solcast_pv_forecast_prognose_verbleibende_leistung_heute
-              below: 20
-            - alias: "Heute Kritisch oder Mangelhaft"
-              condition: or
-              conditions:
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_heute
-                  state: "Mangelhaft"
-                - condition: state
-                  entity_id: sensor.pv_forecast_bewertung_heute
-                  state: "Kritisch"
+              entity_id: sensor.opti_forecast_score
+              below: 3
             - alias: "Aktuelles Preisniveau VERY_CHEAP oder CHEAP"
               condition: or
               conditions:
                 - condition: state
-                  entity_id: sensor.strompreis_niveau
-                  state: "CHEAP"
-                - condition: state
-                  entity_id: sensor.strompreis_niveau
+                  entity_id: sensor.opti_price_level
                   state: "VERY_CHEAP"
+                - condition: state
+                  entity_id: sensor.opti_price_level
+                  state: "CHEAP"
           sequence:
             - action: input_select.select_option
               data:
@@ -444,24 +353,24 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
 
-        - alias: "Drohende Abregelung in Akku umleiten (nur tagsüber)"
-          # D3: Erzeugung über WR-/Einspeiselimit (sonst gekappt) → Überschuss in den Akku
-          # lenken statt am Dach-Limit zu verlieren. Setzt Modus Akku Dynamisch.
+        # ENTFERNT: Zweig zur Umleitung bei drohender Erzeugungskappung (aufgeschoben, Paket >3).
+
+        # Überschuss-Block: 70%-Einspeise-Überschuss in den Akku (nur tagsüber).
+        - alias: "Bei 70% Überschuss diesen in den Akku Laden (nur tagsüber)"
           conditions:
             - condition: state
-              entity_id: input_boolean.akku_opti_automatik
+              entity_id: input_boolean.opti_pv_ueberschuss_ladung
               state: "on"
-            - condition: state
-              entity_id: input_boolean.hausakku_aus_netz_laden
-              state: "off"
+            - condition: template
+              value_template: "{{ has_value('sensor.opti_grid_export_w') }}"
             - condition: sun
               after: sunrise
               before: sunset
             - condition: numeric_state
-              entity_id: sensor.akku_abregelungsleistung
-              above: 100
+              entity_id: sensor.opti_grid_export_w
+              above: input_number.akkusteuerung_wr_70proz_ueberschuss_grenze
             - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
+              entity_id: sensor.opti_soc
               below: 100
           sequence:
             - action: input_select.select_option
@@ -471,66 +380,23 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
 
-        - alias: "Bei 70% Überschuss diesen in den Akku Laden (nur tagsüber)"
-          conditions:
-            - condition: trigger
-              id:
-                - "AC-Überschuss-Aus"
-                - "AC-Überschuss"
-                - "Akku Opti-Automatik AN/AUS"
-                - "PV-70%-Überschuss"
-                - "PV-70%-Überschuss-Aus"
-                - "BYD Änderung"
-                - "Tibber Preislevel Änderung"
-            - condition: state
-              entity_id: input_boolean.akku_opti_automatik
-              state: "on"
-            - condition: state
-              entity_id: input_boolean.hausakku_aus_netz_laden
-              state: "off"
-            - condition: sun
-              after: sunrise
-              before: sunset
-            - condition: numeric_state
-              entity_id: sensor.ueberschuss_pv_watt
-              above: input_number.akkusteuerung_wr_70proz_ueberschuss_grenze
-            - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
-              below: "100"
-          sequence:
-            - action: input_select.select_option
-              data:
-                option: "Akku Dynamisch"
-              target:
-                entity_id: input_select.akkusteuerung_modus
-            - stop: "fertig"
-
+        # Überschuss-Block: AC-Überschuss (PV-Leistung über Grenze) in den Akku (nur tagsüber).
         - alias: "Bei AC Überschuss diesen in den Akku Laden (nur tagsüber)"
           conditions:
-            - condition: trigger
-              id:
-                - "AC-Überschuss-Aus"
-                - "AC-Überschuss"
-                - "Akku Opti-Automatik AN/AUS"
-                - "PV-70%-Überschuss"
-                - "PV-70%-Überschuss-Aus"
-                - "BYD Änderung"
-                - "Tibber Preislevel Änderung"
             - condition: state
-              entity_id: input_boolean.akku_opti_automatik
+              entity_id: input_boolean.opti_pv_ueberschuss_ladung
               state: "on"
-            - condition: state
-              entity_id: input_boolean.hausakku_aus_netz_laden
-              state: "off"
+            - condition: template
+              value_template: "{{ has_value('sensor.opti_pv_power_w') }}"
             - condition: sun
               after: sunrise
               before: sunset
             - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_pv_power
+              entity_id: sensor.opti_pv_power_w
               above: input_number.akkusteuerung_wr_ac_ueberschuss_grenze
             - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
-              below: "100"
+              entity_id: sensor.opti_soc
+              below: 100
           sequence:
             - action: input_select.select_option
               data:
@@ -539,25 +405,15 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
 
+        # Modus-Set-Zweig: voller Akku → Dynamisch.
         - alias: "Bei vollem Akku auf Dynamisch schalten"
           conditions:
-            - condition: trigger
-              id:
-                - "AC-Überschuss-Aus"
-                - "AC-Überschuss"
-                - "Akku Opti-Automatik AN/AUS"
-                - "PV-70%-Überschuss"
-                - "PV-70%-Überschuss-Aus"
-                - "BYD Änderung"
-                - "Tibber Preislevel Änderung"
-            - condition: state
-              entity_id: input_boolean.akku_opti_automatik
-              state: "on"
-            - condition: state
-              entity_id: input_boolean.hausakku_aus_netz_laden
-              state: "off"
+            - condition: template
+              value_template: >-
+                {{ has_value('sensor.opti_soc')
+                   and has_value('sensor.opti_battery_capacity_kwh') }}
             - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
+              entity_id: sensor.opti_soc
               above: 99
           sequence:
             - action: input_select.select_option
@@ -567,27 +423,17 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
 
+        # Modus-Set-Zweig: dynamisch laden zwischen MinSoC und Ziel-SoC (nur tagsüber).
         - alias: "Dynamisch laden wenn SOC zwischen MinSoC und DynZielSoC (nur tagsüber)"
           conditions:
-            - condition: trigger
-              id:
-                - "AC-Überschuss-Aus"
-                - "AC-Überschuss"
-                - "Akku Opti-Automatik AN/AUS"
-                - "PV-70%-Überschuss"
-                - "PV-70%-Überschuss-Aus"
-                - "BYD Änderung"
-                - "Tibber Preislevel Änderung"
-            - condition: state
-              entity_id: input_boolean.akku_opti_automatik
-              state: "on"
-            - condition: state
-              entity_id: input_boolean.hausakku_aus_netz_laden
-              state: "off"
+            - condition: template
+              value_template: >-
+                {{ has_value('sensor.opti_soc')
+                   and has_value('sensor.opti_battery_capacity_kwh') }}
             - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
+              entity_id: sensor.opti_soc
               above: input_number.minsoc
-              below: sensor.akku_target_soc_intelligent
+              below: sensor.opti_target_soc
             - condition: sun
               after: sunrise
               before: sunset
@@ -599,30 +445,16 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
 
+        # Modus-Set-Zweig: nur Entladen wenn SOC über Ziel-SoC.
         - alias: "Nur Entladen wenn SOC über DynZielSoC"
           conditions:
-            - condition: trigger
-              id:
-                - "AC-Überschuss-Aus"
-                - "AC-Überschuss"
-                - "Akku Opti-Automatik AN/AUS"
-                - "PV-70%-Überschuss"
-                - "PV-70%-Überschuss-Aus"
-                - "BYD Änderung"
-                - "Tibber Preislevel Änderung"
-            - condition: state
-              entity_id: input_boolean.akku_opti_automatik
-              state: "on"
-            - condition: state
-              entity_id: input_boolean.hausakku_aus_netz_laden
-              state: "off"
+            - condition: template
+              value_template: >-
+                {{ has_value('sensor.opti_soc')
+                   and has_value('sensor.opti_battery_capacity_kwh') }}
             - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
-              above: sensor.akku_target_soc_intelligent
-            - condition: state
-              entity_id: sensor.pv_forecast_bewertung_morgen
-              state: "Hervorragend"
-              enabled: false
+              entity_id: sensor.opti_soc
+              above: sensor.opti_target_soc
           sequence:
             - action: input_select.select_option
               data:
@@ -631,220 +463,45 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
 
+      # Default (Modus-Set): nur setzen wenn opti_soc UND opti_battery_capacity_kwh
+      # verfügbar sind – sonst tut die Strategie nichts (fail-safe).
       default:
-        - action: input_select.select_option
-          data:
-            option: "Akku Dynamisch"
-          target:
-            entity_id: input_select.akkusteuerung_modus
+        - choose:
+            - conditions:
+                - condition: template
+                  value_template: >-
+                    {{ has_value('sensor.opti_soc')
+                       and has_value('sensor.opti_battery_capacity_kwh') }}
+              sequence:
+                - action: input_select.select_option
+                  data:
+                    option: "Akku Dynamisch"
+                  target:
+                    entity_id: input_select.akkusteuerung_modus
 
+    # CLEANUP (immer, kein has_value-/Toggle-Gate): Netzlade-Booster bei vollem Akku aus.
     - alias: "Netzladen: Booster deaktivieren wenn Akku voll"
       choose:
         - conditions:
-            - condition: trigger
-              id:
-                - "Akku ist voll"
+            - condition: numeric_state
+              entity_id: sensor.opti_soc
+              above: 99
             - condition: state
               entity_id: input_boolean.hausakku_aus_netz_laden
               state: "on"
-              enabled: true
           sequence:
             - action: input_boolean.turn_off
               data: {}
               target:
                 entity_id: input_boolean.hausakku_aus_netz_laden
             - action: input_number.set_value
-              alias: "Ladepreis Helfer nach aktuellem Strompreis"
+              alias: "Ladepreis Helfer nach aktuellem Strompreis (ct→EUR)"
               data:
-                value: "{{ states('sensor.DEIN_STROMPREIS')| float(0) }}"
+                value: "{{ states('sensor.opti_price_current_ct_kwh') | float(0) / 100 }}"
               target:
                 entity_id: input_number.ladepreis
             - action: input_select.select_option
               data:
                 option: "Akku nur Laden"
-              target:
-                entity_id: input_select.akkusteuerung_modus
-
-    # Intent: Zweite Lade-Aktionsstufe — Prognosebasiertes Aufladen bei günstigem Strom.
-    # Greift nachgelagert zur choose-Logik oben: hält den SoC praktisch im ~40–60 %-Band
-    # und shaved Preisspitzen (Peak-Shaving). Bewährt, nicht perfekt —
-    # explizite Bandregelung ist ein offener Verbesserungskandidat.
-    - alias: "Akku Nur Laden wenn Prognose schlecht und aufsparen bei CHEAP & VERY_CHEAP & NORMAL"
-      choose:
-        - conditions:
-            - condition: or
-              conditions:
-                - alias: "Wenn SoC <80%, PV <15kWh, Wintermodus und morgen schlecht"
-                  condition: and
-                  conditions:
-                    - condition: numeric_state
-                      entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
-                      below: 80
-                    - condition: numeric_state
-                      entity_id: sensor.solcast_pv_forecast_prognose_verbleibende_leistung_heute
-                      below: 15
-                    - alias: "Strom morgen mangelhaft oder kritisch"
-                      condition: or
-                      conditions:
-                        - condition: state
-                          entity_id: sensor.pv_forecast_bewertung_morgen
-                          state: "Mangelhaft"
-                        - condition: state
-                          entity_id: sensor.pv_forecast_bewertung_morgen
-                          state: "Kritisch"
-                    # optional: Sommermodus-Gate; falls nicht vorhanden, diese Bedingung entfernen
-                    - condition: state
-                      entity_id: binary_sensor.DEIN_SOMMERMODUS_GATE
-                      state: "off"
-                - condition: and
-                  conditions:
-                    - condition: time
-                      after: "13:00:00"
-                      before: "23:59:59"
-                    - condition: numeric_state
-                      entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
-                      below: 30
-                    - condition: numeric_state
-                      entity_id: sensor.solcast_pv_forecast_prognose_verbleibende_leistung_heute
-                      below: 20
-                    - alias: "Strom morgen mangelhaft oder kritisch"
-                      condition: or
-                      conditions:
-                        - condition: state
-                          entity_id: sensor.pv_forecast_bewertung_morgen
-                          state: "Mangelhaft"
-                        - condition: state
-                          entity_id: sensor.pv_forecast_bewertung_morgen
-                          state: "Kritisch"
-                - condition: and
-                  conditions:
-                    - condition: time
-                      after: "00:00:01"
-                      before: "12:59:59"
-                    - condition: numeric_state
-                      entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
-                      below: 30
-                    - alias: "Strom heute mangelhaft oder kritisch"
-                      condition: or
-                      conditions:
-                        - condition: state
-                          entity_id: sensor.pv_forecast_bewertung_heute
-                          state: "Mangelhaft"
-                        - condition: state
-                          entity_id: sensor.pv_forecast_bewertung_heute
-                          state: "Kritisch"
-            - alias: "Wenn CHEAP bis NORMAL Preisniveau ist"
-              condition: or
-              conditions:
-                - condition: state
-                  entity_id: sensor.strompreis_niveau
-                  state: "CHEAP"
-                - condition: state
-                  entity_id: sensor.strompreis_niveau
-                  state: "VERY_CHEAP"
-                  enabled: true
-                - condition: state
-                  entity_id: sensor.strompreis_niveau
-                  state: "NORMAL"
-                  enabled: true
-          sequence:
-            - action: input_select.select_option
-              data:
-                option: "Akku nur Laden"
-              target:
-                entity_id: input_select.akkusteuerung_modus
-
-    # Optionaler Legacy-Block (Tibber-spezifisch), bleibt deaktiviert.
-    - alias: "Tibber Preis-Ladesteuerung (deaktiviert – im Winter kaum wirtschaftlich)"
-      enabled: false
-      choose:
-        - alias: "Netz-Laden wenn Preisspanne lohnt und Funktion aktiviert"
-          conditions:
-            - condition: trigger
-              id:
-                - "Tibber Preislevel Änderung"
-            - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
-              below: 50
-            - condition: numeric_state
-              entity_id: sensor.solcast_pv_forecast_prognose_verbleibende_leistung_heute
-              below: 10
-            - condition: numeric_state
-              entity_id: sensor.tibber_preisspanne_heute
-              above: 8
-            - condition: numeric_state
-              entity_id: sensor.tibber_aktueller_preis_ist_tageshochstpreis
-              below: 20
-            - condition: state
-              entity_id: input_boolean.akku_nach_preis_laden
-              state: "on"
-          sequence:
-            - action: input_boolean.turn_on
-              data: {}
-              target:
-                entity_id: input_boolean.speicher_eco_netzladen
-            - action: input_boolean.turn_on
-              data: {}
-              target:
-                entity_id:
-                  - input_boolean.hausakku_aus_netz_laden
-                  - input_boolean.hausakku_wurde_netzgeladen
-            - action: input_select.select_option
-              data:
-                option: "Akku Dynamisch"
-              target:
-                entity_id: input_select.akkusteuerung_modus
-
-        - alias: "Akku Automatisch wenn PV-Ertrag gut und Akku hoch (ohne Netzladen)"
-          conditions:
-            - condition: numeric_state
-              entity_id: sensor.solcast_pv_forecast_prognose_verbleibende_leistung_heute
-              above: 25
-            - condition: numeric_state
-              entity_id: sensor.sn_SERIENNUMMER_battery_soc_total
-              above: 60
-            - condition: sun
-              after: sunset
-              before: sunrise
-            - condition: numeric_state
-              entity_id: sensor.maximaler_ueberschuss_fuer_akkuladung_watt
-              below: 1
-          sequence:
-            - action: input_select.select_option
-              data:
-                option: "Akku Automatisch"
-              target:
-                entity_id: input_select.akkusteuerung_modus
-            - action: input_boolean.turn_off
-              data: {}
-              target:
-                entity_id:
-                  - input_boolean.hausakku_aus_netz_laden
-                  - input_boolean.hausakku_wurde_netzgeladen
-
-        - alias: "Akku Automatisch wenn morgen oder heute ausreichend PV"
-          conditions:
-            - condition: or
-              conditions:
-                - condition: numeric_state
-                  entity_id: sensor.solcast_pv_forecast_prognose_morgen
-                  above: 25
-                - condition: numeric_state
-                  entity_id: sensor.solcast_pv_forecast_prognose_verbleibende_leistung_heute
-                  above: 25
-          sequence:
-            - action: input_boolean.turn_off
-              data: {}
-              target:
-                entity_id: input_boolean.speicher_eco_netzladen
-            - action: input_number.set_value
-              alias: "Ladepreis Helfer nach aktuellem Strompreis"
-              data:
-                value: "{{ states('sensor.DEIN_STROMPREIS')| float(0) }}"
-              target:
-                entity_id: input_number.ladepreis
-            - action: input_select.select_option
-              data:
-                option: "Akku Automatisch"
               target:
                 entity_id: input_select.akkusteuerung_modus

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -1,10 +1,13 @@
-- id: "1757405050598"
-  alias: "Akku Lade- Entladesteuerung Opti 2.0"
+- id: "opti_canonical_strategie"
+  alias: "Akku Opti Strategie"
   description: >-
     Strategie auf dem Canonical-opti_*-Layer (Paket 3). Setzt ausschliesslich
     input_select.akkusteuerung_modus. Prognosebasierte SOC-Ladeblöcke
     (Score+Preis), PV-/AC-Überschussblöcke, MinSOC-Schutz und Cleanup.
     Quellen/Gates getauscht; aufgeschobene und arbitrage-basierte Zweige entfernt.
+    id/Alias sind der Live-Realität angeglichen (2026-07-01): id war zuvor eine
+    HA-generierte Zahl ohne Bedeutung, Alias hieß zuvor "Akku Lade-
+    Entladesteuerung Opti 2.0" bzw. live "Akku Opti Canonical (opti_*-Layer)".
   mode: single
   triggers:
     # Preisniveau (Enum) statt Tibber-Rohsensor

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -131,7 +131,7 @@
         # OBERSTE PRIORITÄT: Entladesperre <minsoc — vor allen anderen geprüft.
         # Läuft IMMER (kein has_value-Gate); fehlt opti_soc, greift die
         # numeric_state-Bedingung schlicht nicht (fail-safe).
-        - alias: "MinSOC Schutz – Entladen sperren wenn SOC unter MinSOC (gilt tag und nacht)"
+        - alias: "Modus 'nur Laden' (Entladesperre): MinSOC-Schutz, SOC unter MinSOC (tag+nacht)"
           conditions:
             - condition: numeric_state
               entity_id: sensor.opti_soc
@@ -147,7 +147,7 @@
         # Winter-/Prognose-Ladeblock (SOC < 20 %).
         # Quelle: heute+morgen schlecht → Score<3 (beide); Preis VERY_CHEAP..EXPENSIVE.
         # Gates: opti_prognose_netzladen on + opti_winter_charging_allowed on.
-        - alias: "Laden wenn morgen und heute schlecht und SOC unter 20% (tag+nacht)"
+        - alias: "Modus 'nur Laden' (PV halten): Prognose heute+morgen schlecht, SOC unter 20% (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
@@ -193,7 +193,7 @@
 
         # Winter-/Prognose-Ladeblock (SOC < 75 %). Preis nur bis NORMAL.
         # opti_winter_charging_allowed hier NICHT — opportunistischer Block, soll ganzjährig greifen.
-        - alias: "Laden wenn morgen und heute schlecht und SOC unter 75% (tag+nacht)"
+        - alias: "Modus 'nur Laden' (PV halten): Prognose heute+morgen schlecht, SOC unter 75%, Preis bis NORMAL (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
@@ -233,7 +233,7 @@
 
         # Winter-/Prognose-Ladeblock (SOC < 80 %, Wintermodus-Gate).
         # Sommermodus-Gate der Quelle → binary_sensor.opti_winter_charging_allowed.
-        - alias: "Laden wenn heute+morgen schlecht, Wintermodus, SOC unter 80% (tag+nacht)"
+        - alias: "Modus 'nur Laden' (PV halten): Prognose schlecht, Wintermodus, SOC unter 80% (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
@@ -280,7 +280,7 @@
         # Winter-/Prognose-Ladeblock (SOC < 15 %, Notfall). Nur heute-Score.
         # KEIN opti_winter_charging_allowed-Gate — Notfall-Netzladen DARF NIE durch das
         # Saisonal-Gate blockiert werden. Dieser Block muss ganzjährig und im Sommer greifen.
-        - alias: "Laden wenn heute schlecht, SOC unter 15% (tag+nacht)"
+        - alias: "Modus 'nur Laden' (Reserve halten): heute schlecht, SOC unter 15% (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
@@ -318,7 +318,7 @@
 
         # Winter-/Prognose-Ladeblock (SOC < 45 %, nur sehr günstig). Nur heute-Score.
         # opti_winter_charging_allowed hier NICHT — Opportunistik-Block, soll ganzjährig greifen.
-        - alias: "Laden wenn heute schlecht, SOC unter 45% und Strom sehr günstig (tag+nacht)"
+        - alias: "Modus 'nur Laden' (PV halten): heute schlecht, SOC unter 45%, Strom sehr günstig (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
@@ -351,7 +351,7 @@
         # ENTFERNT: Zweig zur Umleitung bei drohender Erzeugungskappung (aufgeschoben, Paket >3).
 
         # Überschuss-Block: 70%-Einspeise-Überschuss in den Akku (nur tagsüber).
-        - alias: "Bei 70% Überschuss diesen in den Akku Laden (nur tagsüber)"
+        - alias: "Modus 'Dynamisch': 70% PV-Überschuss in den Akku (nur tagsüber)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_pv_ueberschuss_ladung
@@ -376,7 +376,7 @@
             - stop: "fertig"
 
         # Überschuss-Block: AC-Überschuss (PV-Leistung über Grenze) in den Akku (nur tagsüber).
-        - alias: "Bei AC Überschuss diesen in den Akku Laden (nur tagsüber)"
+        - alias: "Modus 'Dynamisch': AC-PV-Überschuss in den Akku (nur tagsüber)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_pv_ueberschuss_ladung
@@ -401,7 +401,7 @@
             - stop: "fertig"
 
         # Modus-Set-Zweig: voller Akku → Dynamisch.
-        - alias: "Bei vollem Akku auf Dynamisch schalten"
+        - alias: "Modus 'Dynamisch': Akku voll (SOC über 99%)"
           conditions:
             - condition: template
               value_template: >-
@@ -419,7 +419,7 @@
             - stop: "fertig"
 
         # Modus-Set-Zweig: dynamisch laden zwischen MinSoC und Ziel-SoC (nur tagsüber).
-        - alias: "Dynamisch laden wenn SOC zwischen MinSoC und DynZielSoC (nur tagsüber)"
+        - alias: "Modus 'Dynamisch': SOC zwischen MinSoC und Ziel-SoC (nur tagsüber)"
           conditions:
             - condition: template
               value_template: >-
@@ -441,7 +441,7 @@
             - stop: "fertig"
 
         # Modus-Set-Zweig: nur Entladen wenn SOC über Ziel-SoC.
-        - alias: "Nur Entladen wenn SOC über DynZielSoC"
+        - alias: "Modus 'nur Entladen': SOC über Ziel-SoC"
           conditions:
             - condition: template
               value_template: >-

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -421,14 +421,15 @@
         # Modus-Set-Zweig: dynamisch laden zwischen MinSoC und Ziel-SoC (nur tagsüber).
         - alias: "Modus 'Dynamisch': SOC zwischen MinSoC und Ziel-SoC (nur tagsüber)"
           conditions:
+            # Band H=3 %: native numeric_state kann 'entity - offset' nicht ausdruecken,
+            # daher Template-Bedingung (soc > minsoc UND soc < target - H).
             - condition: template
               value_template: >-
                 {{ has_value('sensor.opti_soc')
-                   and has_value('sensor.opti_battery_capacity_kwh') }}
-            - condition: numeric_state
-              entity_id: sensor.opti_soc
-              above: input_number.minsoc
-              below: sensor.opti_target_soc
+                   and has_value('sensor.opti_battery_capacity_kwh')
+                   and has_value('sensor.opti_target_soc')
+                   and (states('sensor.opti_soc') | float) > (states('input_number.minsoc') | float(10))
+                   and (states('sensor.opti_soc') | float) < (states('sensor.opti_target_soc') | float - 3) }}
             - condition: sun
               after: sunrise
               before: sunset
@@ -443,13 +444,13 @@
         # Modus-Set-Zweig: nur Entladen wenn SOC über Ziel-SoC.
         - alias: "Modus 'nur Entladen': SOC über Ziel-SoC"
           conditions:
+            # Band H=3 %: nur Entladen erst wenn soc > target + H (Template, da Offset).
             - condition: template
               value_template: >-
                 {{ has_value('sensor.opti_soc')
-                   and has_value('sensor.opti_battery_capacity_kwh') }}
-            - condition: numeric_state
-              entity_id: sensor.opti_soc
-              above: sensor.opti_target_soc
+                   and has_value('sensor.opti_battery_capacity_kwh')
+                   and has_value('sensor.opti_target_soc')
+                   and (states('sensor.opti_soc') | float) > (states('sensor.opti_target_soc') | float + 3) }}
           sequence:
             - action: input_select.select_option
               data:

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -147,7 +147,7 @@
         # Winter-/Prognose-Ladeblock (SOC < 20 %).
         # Quelle: heute+morgen schlecht → Score<3 (beide); Preis VERY_CHEAP..EXPENSIVE.
         # Gates: opti_prognose_netzladen on + opti_winter_charging_allowed on.
-        - alias: "Modus 'nur Laden' (PV halten): Prognose heute+morgen schlecht, SOC unter 20% (tag+nacht)"
+        - alias: "Modus 'nur Laden' (Reserve halten): Prognose heute+morgen schlecht, SOC unter 20% (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
@@ -193,7 +193,7 @@
 
         # Winter-/Prognose-Ladeblock (SOC < 75 %). Preis nur bis NORMAL.
         # opti_winter_charging_allowed hier NICHT — opportunistischer Block, soll ganzjährig greifen.
-        - alias: "Modus 'nur Laden' (PV halten): Prognose heute+morgen schlecht, SOC unter 75%, Preis bis NORMAL (tag+nacht)"
+        - alias: "Modus 'nur Laden' (Reserve halten): Prognose heute+morgen schlecht, SOC unter 75%, Preis bis NORMAL (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
@@ -233,7 +233,7 @@
 
         # Winter-/Prognose-Ladeblock (SOC < 80 %, Wintermodus-Gate).
         # Sommermodus-Gate der Quelle → binary_sensor.opti_winter_charging_allowed.
-        - alias: "Modus 'nur Laden' (PV halten): Prognose schlecht, Wintermodus, SOC unter 80% (tag+nacht)"
+        - alias: "Modus 'nur Laden' (Reserve halten): Prognose schlecht, Wintermodus, SOC unter 80% (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
@@ -318,7 +318,7 @@
 
         # Winter-/Prognose-Ladeblock (SOC < 45 %, nur sehr günstig). Nur heute-Score.
         # opti_winter_charging_allowed hier NICHT — Opportunistik-Block, soll ganzjährig greifen.
-        - alias: "Modus 'nur Laden' (PV halten): heute schlecht, SOC unter 45%, Strom sehr günstig (tag+nacht)"
+        - alias: "Modus 'nur Laden' (Reserve halten): heute schlecht, SOC unter 45%, Strom sehr günstig (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -232,6 +232,15 @@ des betreffenden Sensors testen — häufig ist der Quell-Sensor noch falsch ben
 | `sensor.opti_runtime_h` | Geschätzte Akku-Restlaufzeit (Stunden) |
 | `binary_sensor.opti_winter_charging_allowed` | Netzladefreigabe-Gate (Standard: `true`, fail-open) |
 
+> **Warnung — `opti_winter_charging_allowed`:** Dieses Gate ist **fail-open** (`{{ true }}`).
+> Solange kein realer Saisonal-Sensor gemappt ist, ist es immer `on`.
+> Wenn du einen echten Winter-/Sommer-Sensor anschließt, beachte:
+> Das Gate ist **ausschließlich** für die SOC<20- und SOC<80-Ladeblöcke vorgesehen.
+> **Keinesfalls** darf es den SOC<15-Notfall-Netzladeblock gaten — dieser muss auch
+> im Sommer jederzeit eingreifen können (tiefe Entladung vermeiden).
+> Die SOC<75- und SOC<45-Blöcke werden ebenfalls nicht gegated (opportunistische Blöcke,
+> sollen ganzjährig greifen).
+
 Diese Sensoren werden von `automations/opti_strategie.yaml` direkt konsumiert —
 du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
 

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -262,3 +262,28 @@ du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
 
 **Fail-safe-Verhalten:** Sind `sensor.opti_soc` oder `sensor.opti_battery_capacity_kwh`
 `unavailable`, setzt die Strategie keinen Modus — der bisherige Modus bleibt aktiv.
+
+---
+
+## Deployment als HA-Package & der „Migrieren"-Hinweis
+
+Sensoren, Helfer und die Strategie-Automation werden als **HA-Packages** geladen
+(`packages: !include_dir_named packages/` unter `homeassistant:`). Das hält alles
+versioniert und an einem Ort.
+
+Eine als Package geladene Automation zeigt im UI-Automationseditor die Warnung:
+
+> ⚠️ *„Diese Automation kann nicht über die Benutzeroberfläche bearbeitet werden,
+> da sie nicht in der Datei automations.yaml gespeichert ist oder keine ID hat."*
+> — mit einem **„Migrieren"**-Button.
+
+**Das ist normal und harmlos.** Die Automation läuft einwandfrei (sie *hat* eine
+`id`; die Meldung heißt nur „liegt nicht in `automations.yaml`"). **Ansehen und
+`Traces` funktionieren** — nur der *visuelle* Editor ist für Package-Automationen
+schreibgeschützt.
+
+**NICHT auf „Migrieren" klicken** — außer du willst die Automation **bewusst** aus
+dem Package herauslösen und vom Git-/Package-Stand entkoppeln, um sie künftig nur
+noch in der UI zu pflegen. „Migrieren" kopiert sie nach `.storage`; solange das
+Package sie weiter lädt, entsteht ein **Duplikat (zwei Automationen mit derselben
+`id`)**. Vorgesehener Weg: **Package-Datei bearbeiten** + HA neu laden/neu starten.

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -1,0 +1,255 @@
+# Canonical-Layer: opti_*-Sensoren — Nutzerleitfaden
+
+## Überblick
+
+Der Canonical-`opti_*`-Layer entkoppelt die Strategie von der konkreten Hardware.
+Eine einzige Mapping-Datei (`packages/opti_mapping.yaml`) übersetzt die eigenen
+Wechselrichter- und Preis-Entitäten auf 13 kanonische `sensor.opti_*`-Sensoren.
+Alle nachgelagerten Pakete (`packages/opti_derived.yaml`, `automations/opti_strategie.yaml`)
+konsumieren ausschließlich diese kanonischen Sensoren — keine Seriennummern, keine
+Anbieter-spezifischen IDs tauchen dort auf.
+
+```
+opti_mapping.yaml  →  sensor.opti_*  →  opti_derived.yaml  →  opti_strategie.yaml
+(deine Hardware)       (Canonical)       (Score/Preis/…)       (Modus-Entscheidung)
+```
+
+> **Gitignored:** `packages/opti_mapping.yaml` ist in `.gitignore` eingetragen.
+> Deine echten Entitäts-IDs werden nie ins öffentliche Repo hochgeladen.
+
+---
+
+## Mapping-Tabelle: alle 13 opti_*-Sensoren
+
+| opti-Sensor | Einheit | Wertebereich / Vorzeichen | SMA-Beispielquelle | Huawei-Beispielquelle | Umrechnung |
+|---|---|---|---|---|---|
+| `sensor.opti_soc` | % | 0–100 | `sensor.sma_battery_soc` | `sensor.huawei_battery_soc` | Direkt (`float(0)`) |
+| `sensor.opti_battery_temp` | °C | beliebig; **optional** (Default 20 °C) | `sensor.sma_battery_temp` | `sensor.huawei_battery_temp` | Direkt; kein Sensor → `float(20)` |
+| `sensor.opti_battery_capacity_kwh` | kWh | > 0 | `sensor.sma_battery_capacity` (Wh) | `sensor.huawei_battery_capacity` (kWh) | SMA: `float(0) / 1000`; Huawei: direkt |
+| `sensor.opti_pv_power_w` | W | ≥ 0 (AC-Ausgangsleistung) | `sensor.sma_pv_power` | `sensor.huawei_pv_power` | Direkt |
+| `sensor.opti_pv_generation_w` | W | ≥ 0 (DC-Eingangsleistung) | `sensor.sma_pv_generation` | `sensor.huawei_pv_generation` | Direkt |
+| `sensor.opti_grid_export_w` | W | **≥ 0** (positiv = Einspeisung) | `sensor.sma_grid_export_power` | `sensor.huawei_grid_export_power` | Einspeisung positiv: `[0, float(0)] \| max`; Einspeisung negativ: `[0, float(0) * -1] \| max` |
+| `sensor.opti_house_consumption_w` | W | ≥ 0 | `sensor.sma_house_consumption` | `sensor.huawei_house_consumption` | Direkt |
+| `sensor.opti_price_current_ct_kwh` | ct/kWh | beliebig | `sensor.tibber_electricity_price` (EUR/kWh) | `sensor.nordpool_electricity_price` (EUR/kWh) | `float(0) * 100` |
+| `sensor.opti_price_series` | ct/kWh | Attribut `today`/`tomorrow` = Listen in ct/kWh | `sensor.tibber_electricity_price` | `sensor.nordpool_electricity_price` | EUR-Attribut-Listen × 100 (im Mapping normalisiert) |
+| `sensor.opti_forecast_today_kwh` | kWh | ≥ 0; Attribut `estimate10` (P10) | `sensor.solcast_pv_forecast_forecast_today` | `sensor.solcast_pv_forecast_forecast_today` | Direkt |
+| `sensor.opti_forecast_tomorrow_kwh` | kWh | ≥ 0; Attribut `estimate10` (P10) | `sensor.solcast_pv_forecast_forecast_tomorrow` | `sensor.solcast_pv_forecast_forecast_tomorrow` | Direkt |
+| `sensor.opti_forecast_remaining_today_kwh` | kWh | ≥ 0 | `sensor.solcast_pv_forecast_forecast_remaining_today` | `sensor.solcast_pv_forecast_forecast_remaining_today` | Direkt |
+| `sensor.opti_battery_power_w` | W | **+= laden** (positiv = Batterie lädt) | Zwei Sensoren: `sensor.sma_battery_charge` und `sensor.sma_battery_discharge` (beide ≥ 0) | `sensor.huawei_battery_power` (signierter Sensor) | SMA: `charge - discharge`; Huawei: direkt (oder `* -1` wenn Quelle positiv = Entladen) |
+
+### Konventionen im Detail
+
+**Preise:** Die EUR→ct-Umrechnung (`×100`) findet **ausschließlich** in `opti_mapping.yaml` statt.
+Alle nachgelagerten Sensoren arbeiten intern mit ct/kWh.
+
+**Leistung:** Alle Leistungssensoren in Watt (W), alle Energie­größen in kWh.
+
+**`opti_grid_export_w`:** Immer ≥ 0. Positiv = Einspeisung ins Netz. Je nach Wechselrichter
+das Vorzeichen im Mapping korrigieren (Kommentare in `opti_mapping.example.yaml` unter
+Sensor 6 beschreiben beide Varianten).
+
+**`opti_battery_power_w`:** Positiv = Batterie lädt (`+=`-Konvention).
+- SMA: Zwei separate Sensoren für Laden/Entladen (beide ≥ 0) → `charge - discharge`
+- Huawei: Ein signierter Sensor → direkt übernehmen. Falls Quelle „positiv = Entladen": `* -1`
+
+**`opti_battery_temp` (optional):** Fehlt ein Temperatur-Sensor, einfach keinen Sensor
+angeben — das Mapping liefert dann `float(20)` als neutralen Default (20 °C). Es gibt keine
+Abregelung wegen fehlender Temperatur.
+
+---
+
+## Anbieter-Rezepte: Strompreis
+
+### Tibber
+
+Tibber liefert zwei relevante Sensoren:
+- **Aktueller Preis (Skalar):** `sensor.tibber_electricity_price` — Einheit EUR/kWh
+- **Preis-Reihe:** derselbe Sensor mit Attributen `today`/`tomorrow` als Listen von Dicts
+  `{total: …, startsAt: …}` (Schlüssel `total` = EUR/kWh-Wert)
+
+```yaml
+# opti_mapping.yaml — Tibber-Beispiel
+# Sensor 8 (aktueller Preis, EUR → ct):
+state: "{{ states('sensor.tibber_electricity_price') | float(0) * 100 }}"
+
+# Sensor 9 (Preis-Reihe, gleiche Quelle):
+availability: "{{ has_value('sensor.tibber_electricity_price') }}"
+state: "{{ states('sensor.tibber_electricity_price') | float(0) * 100 }}"
+# Attribute today/tomorrow werden automatisch normalisiert (Dict-Schlüssel
+# 'total', 'price' oder 'value' sowie skalare Einträge werden erkannt).
+```
+
+### Nordpool
+
+`sensor.nordpool_electricity_price` liefert den aktuellen Preis als Zustand (EUR/kWh)
+sowie `today`/`tomorrow` als Listen von Floats (Rohpreise in EUR/kWh).
+
+```yaml
+# opti_mapping.yaml — Nordpool-Beispiel
+state: "{{ states('sensor.nordpool_electricity_price') | float(0) * 100 }}"
+# today/tomorrow: skalare Listen → das Mapping-Template verarbeitet sie direkt.
+```
+
+### EPEX / aWATTar
+
+EPEX/aWATTar-Integrationen liefern typischerweise den aktuellen Preis als Skalarzustand.
+Die Preis-Reihe kann als `today`/`tomorrow`-Attribut mit Floats oder Dicts vorliegen.
+
+```yaml
+# opti_mapping.yaml — aWATTar-Beispiel (EUR/kWh-Quelle)
+state: "{{ states('sensor.awattar_current_price') | float(0) * 100 }}"
+```
+
+> **Hinweis:** Falls die Quelle bereits ct/kWh liefert, `* 100` weglassen und
+> den Availability-Check entsprechend anpassen.
+
+---
+
+## Solcast-Anbindung
+
+| opti-Sensor | Typischer Solcast-Sensor |
+|---|---|
+| `opti_forecast_today_kwh` | `sensor.solcast_pv_forecast_forecast_today` |
+| `opti_forecast_tomorrow_kwh` | `sensor.solcast_pv_forecast_forecast_tomorrow` |
+| `opti_forecast_remaining_today_kwh` | `sensor.solcast_pv_forecast_forecast_remaining_today` |
+
+**`estimate10`-Attribut (P10-Sicherheitsnetz):** Die `opti_forecast_*_kwh`-Sensoren reichen das
+Attribut `estimate10` durch (10. Perzentil der Prognose — pessimistischer Worst-Case-Wert).
+Der `opti_forecast_score` nutzt diesen Wert als konservative Untergrenze für die PV-Fit-Bewertung.
+
+```yaml
+# Im Mapping (Beispiel für heute):
+attributes:
+  estimate10: "{{ state_attr('sensor.solcast_pv_forecast_forecast_today', 'estimate10') | float(0) }}"
+```
+
+Fehlt `estimate10` im Quell-Sensor, greift `float(0)` als sicherer Fallback — der Score
+wird dann etwas konservativer, aber die Automation läuft fehlerfrei.
+
+---
+
+## Mindest-HA-Version
+
+Der Canonical-Layer verwendet das Template-Keyword `has_value()`, das ab
+**Home Assistant 2022.9** verfügbar ist. Mit älteren Versionen werden
+Availability-Checks als `false` ausgewertet, und alle `opti_*`-Sensoren erscheinen
+als `unavailable`.
+
+**Empfehlung:** Aktuelle HA-Release-Version verwenden. Falls `sensor.opti_soc` nach dem
+Einrichten auf `unavailable` bleibt, in den Entwicklerwerkzeugen → Template prüfen,
+ob `has_value('sensor.DEINE_QUELLE')` korrekt ausgewertet wird.
+
+---
+
+## Installation: Schritt-für-Schritt
+
+### 1. Mapping-Datei anlegen
+
+```bash
+cp opti_mapping.example.yaml packages/opti_mapping.yaml
+```
+
+### 2. Platzhalter ersetzen
+
+In `packages/opti_mapping.yaml` alle `DEIN_*`-Platzhalter durch die echten Entitäts-IDs ersetzen:
+
+| Platzhalter | SMA-Beispiel | Huawei-Beispiel |
+|---|---|---|
+| `sensor.DEIN_SOC` | `sensor.sma_battery_soc` | `sensor.huawei_battery_soc` |
+| `sensor.DEIN_BATTERIE_TEMP` | `sensor.sma_battery_temp` | `sensor.huawei_battery_temp` |
+| `sensor.DEIN_BATTERIE_KAPAZITAET` | `sensor.sma_battery_capacity` (Wh → `/1000`) | `sensor.huawei_battery_capacity` (kWh) |
+| `sensor.DEIN_PV_POWER` | `sensor.sma_pv_power` | `sensor.huawei_pv_power` |
+| `sensor.DEIN_PV_GENERATION` | `sensor.sma_pv_generation` | `sensor.huawei_pv_generation` |
+| `sensor.DEIN_GRID_EXPORT` | `sensor.sma_grid_export_power` | `sensor.huawei_grid_export_power` |
+| `sensor.DEIN_HAUSVERBRAUCH` | `sensor.sma_house_consumption` | `sensor.huawei_house_consumption` |
+| `sensor.DEIN_STROMPREIS` | `sensor.tibber_electricity_price` | `sensor.nordpool_electricity_price` |
+| `sensor.DEIN_PREIS_REIHE` | `sensor.tibber_electricity_price` | `sensor.nordpool_electricity_price` |
+| `sensor.DEIN_SOLCAST_HEUTE` | `sensor.solcast_pv_forecast_forecast_today` | ← gleich |
+| `sensor.DEIN_SOLCAST_MORGEN` | `sensor.solcast_pv_forecast_forecast_tomorrow` | ← gleich |
+| `sensor.DEIN_SOLCAST_VERBLEIBEND` | `sensor.solcast_pv_forecast_forecast_remaining_today` | ← gleich |
+| `sensor.DEIN_CHARGE_W` | `sensor.sma_battery_charge` | — (Huawei nutzt Einzel-Sensor) |
+| `sensor.DEIN_DISCHARGE_W` | `sensor.sma_battery_discharge` | — |
+
+**Huawei (Einzel-Sensor für Batterieleistung):** Den SMA-Block für `opti_battery_power_w`
+auskommentieren und den Huawei-Alternativ-Block einkommentieren. Kommentare in
+`opti_mapping.example.yaml` unter Sensor 13 beschreiben beide Varianten.
+
+### 3. Packages aktivieren
+
+In `configuration.yaml` einmalig eintragen (falls noch nicht geschehen):
+
+```yaml
+homeassistant:
+  packages: !include_dir_named packages/
+```
+
+### 4. HA neu starten
+
+*Einstellungen → System → Neustart* (oder `ha core restart`).
+
+### 5. Sensoren prüfen
+
+In den **Entwicklerwerkzeugen → Zustände** alle 13 `sensor.opti_*`-Sensoren suchen:
+
+```
+sensor.opti_soc
+sensor.opti_battery_temp
+sensor.opti_battery_capacity_kwh
+sensor.opti_pv_power_w
+sensor.opti_pv_generation_w
+sensor.opti_grid_export_w
+sensor.opti_house_consumption_w
+sensor.opti_price_current_ct_kwh
+sensor.opti_price_series
+sensor.opti_forecast_today_kwh
+sensor.opti_forecast_tomorrow_kwh
+sensor.opti_forecast_remaining_today_kwh
+sensor.opti_battery_power_w
+```
+
+Jeder Sensor sollte einen numerischen Wert liefern (nicht `unavailable` / `unknown`).
+Bei `unavailable`: unter *Entwicklerwerkzeuge → Template* die `availability`-Formel
+des betreffenden Sensors testen — häufig ist der Quell-Sensor noch falsch benannt.
+
+> **Gitignored:** `packages/opti_mapping.yaml` ist in `.gitignore` eingetragen —
+> deine echten Entitäts-IDs bleiben lokal und kommen nie ins öffentliche Repo.
+
+---
+
+## Abgeleitete Sensoren (opti_derived.yaml)
+
+`packages/opti_derived.yaml` erzeugt aus den Mapping-Sensoren folgende Entscheidungs-Sensoren
+(nicht bearbeiten — nur `opti_mapping.yaml` anpassen):
+
+| Sensor | Beschreibung |
+|---|---|
+| `sensor.opti_forecast_score` | PV-Fit heute (0–10); nutzt `estimate10` als P10-Sicherheitsnetz |
+| `sensor.opti_forecast_score_tomorrow` | PV-Fit morgen (0–10) |
+| `sensor.opti_target_soc` | Ziel-SoC (%) basierend auf Restprognose und Hausverbrauch |
+| `sensor.opti_charge_power_w` | Dynamische Ladestärke (W) nach SoC-Stufe und Forecast-Score |
+| `sensor.opti_price_level` | Preisniveau-Enum (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE / VERY_EXPENSIVE) |
+| `sensor.opti_mindestentladepreis_ct_kwh` | Mindestentladepreis = Ladepreis + Preisdifferenz (ct/kWh) |
+| `sensor.opti_runtime_h` | Geschätzte Akku-Restlaufzeit (Stunden) |
+| `binary_sensor.opti_winter_charging_allowed` | Netzladefreigabe-Gate (Standard: `true`, fail-open) |
+
+Diese Sensoren werden von `automations/opti_strategie.yaml` direkt konsumiert —
+du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
+
+---
+
+## Testfälle — Erwartetes Verhalten
+
+| Szenario | Relevante Eingaben | Erwarteter Modus | Hinweise |
+|---|---|---|---|
+| **Nacht / Netzladen** | `opti_forecast_score` ≤ 2, SoC < 30 %, `opti_price_level` CHEAP | **Akku nur Laden** | Gate `input_boolean.opti_prognose_netzladen` muss `on` sein |
+| **Nacht / kein Ladegrund** | Score ≤ 2, SoC > 60 %, Preis EXPENSIVE | **Akku Dynamisch** (Default) | Kein Ladeblock greift → Default-Pfad |
+| **Sonne / PV-Überschuss** | `opti_grid_export_w` > 70%-Grenze, SoC < 100 % | **Akku Dynamisch** | Gate `input_boolean.opti_pv_ueberschuss_ladung` muss `on` sein |
+| **Tagsüber unter Ziel-SoC** | SoC < `opti_target_soc`, nach Sonnenaufgang | **Akku Dynamisch** | Option „Dynamisch laden wenn SOC < ZielSoC" |
+| **Entladen über Ziel-SoC** | SoC > `opti_target_soc` | **Akku nur Entladen** | Option „Nur Entladen wenn SOC > DynZielSoC" |
+| **MinSOC-Schutz** | SoC < `input_number.minsoc` | **Akku nur Laden** | Höchste Priorität, überstimmt alle anderen Blöcke |
+| **Preis-morgen fehlt** | `opti_price_series`-Attribut `tomorrow` leer / < 4 Gesamtwerte | Preisniveau bleibt **NORMAL** | Fail-safe: `< 4 Preise gesamt → NORMAL` |
+| **Forecast fehlt** | `opti_forecast_remaining_today_kwh` → `unavailable` | Prognose-Blöcke inaktiv; MinSOC-Schutz und Cleanup laufen weiter | Default → **Akku Dynamisch** (nur wenn `opti_soc` + `opti_battery_capacity_kwh` verfügbar) |
+| **Voller Akku** | SoC > 99 % | **Akku Dynamisch**; Netzlade-Booster wird automatisch deaktiviert | Option „Bei vollem Akku auf Dynamisch" + Cleanup-Block |
+
+**Fail-safe-Verhalten:** Sind `sensor.opti_soc` oder `sensor.opti_battery_capacity_kwh`
+`unavailable`, setzt die Strategie keinen Modus — der bisherige Modus bleibt aktiv.

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -230,13 +230,13 @@ des betreffenden Sensors testen — häufig ist der Quell-Sensor noch falsch ben
 | `sensor.opti_price_level` | Preisniveau-Enum (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE / VERY_EXPENSIVE) |
 | `sensor.opti_mindestentladepreis_ct_kwh` | Mindestentladepreis = Ladepreis + Preisdifferenz (ct/kWh) |
 | `sensor.opti_runtime_h` | Geschätzte Akku-Restlaufzeit (Stunden) |
-| `binary_sensor.opti_winter_charging_allowed` | Netzladefreigabe-Gate (Standard: `true`, fail-open) |
+| `binary_sensor.opti_winter_charging_allowed` | Saisonales Lade-Gate (Standard: `true`, fail-open) |
 
 > **Warnung — `opti_winter_charging_allowed`:** Dieses Gate ist **fail-open** (`{{ true }}`).
 > Solange kein realer Saisonal-Sensor gemappt ist, ist es immer `on`.
 > Wenn du einen echten Winter-/Sommer-Sensor anschließt, beachte:
 > Das Gate ist **ausschließlich** für die SOC<20- und SOC<80-Ladeblöcke vorgesehen.
-> **Keinesfalls** darf es den SOC<15-Notfall-Netzladeblock gaten — dieser muss auch
+> **Keinesfalls** darf es den SOC<15-Notfall-Ladeblock (Entladesperre) gaten — dieser muss auch
 > im Sommer jederzeit eingreifen können (tiefe Entladung vermeiden).
 > Die SOC<75- und SOC<45-Blöcke werden ebenfalls nicht gegated (opportunistische Blöcke,
 > sollen ganzjährig greifen).
@@ -250,7 +250,7 @@ du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
 
 | Szenario | Relevante Eingaben | Erwarteter Modus | Hinweise |
 |---|---|---|---|
-| **Nacht / Netzladen** | `opti_forecast_score` ≤ 2, SoC < 30 %, `opti_price_level` CHEAP | **Akku nur Laden** | Gate `input_boolean.opti_prognose_netzladen` muss `on` sein |
+| **Nacht / Reserve halten (Entladesperre)** | `opti_forecast_score` ≤ 2, SoC < 30 %, `opti_price_level` CHEAP | **Akku nur Laden** | Gate `input_boolean.opti_prognose_netzladen` muss `on` sein |
 | **Nacht / kein Ladegrund** | Score ≤ 2, SoC > 60 %, Preis EXPENSIVE | **Akku Dynamisch** (Default) | Kein Ladeblock greift → Default-Pfad |
 | **Sonne / PV-Überschuss** | `opti_grid_export_w` > 70%-Grenze, SoC < 100 % | **Akku Dynamisch** | Gate `input_boolean.opti_pv_ueberschuss_ladung` muss `on` sein |
 | **Tagsüber unter Ziel-SoC** | SoC < `opti_target_soc`, nach Sonnenaufgang | **Akku Dynamisch** | Option „Dynamisch laden wenn SOC < ZielSoC" |
@@ -258,7 +258,7 @@ du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
 | **MinSOC-Schutz** | SoC < `input_number.minsoc` | **Akku nur Laden** | Höchste Priorität, überstimmt alle anderen Blöcke |
 | **Preis-morgen fehlt** | `opti_price_series`-Attribut `tomorrow` leer / < 4 Gesamtwerte | Preisniveau bleibt **NORMAL** | Fail-safe: `< 4 Preise gesamt → NORMAL` |
 | **Forecast fehlt** | `opti_forecast_remaining_today_kwh` → `unavailable` | Prognose-Blöcke inaktiv; MinSOC-Schutz und Cleanup laufen weiter | Default → **Akku Dynamisch** (nur wenn `opti_soc` + `opti_battery_capacity_kwh` verfügbar) |
-| **Voller Akku** | SoC > 99 % | **Akku Dynamisch**; Netzlade-Booster wird automatisch deaktiviert | Option „Bei vollem Akku auf Dynamisch" + Cleanup-Block |
+| **Voller Akku** | SoC > 99 % | **Akku Dynamisch**; Lade-Booster (Legacy) wird deaktiviert | Option „Bei vollem Akku auf Dynamisch" + Cleanup-Block |
 
 **Fail-safe-Verhalten:** Sind `sensor.opti_soc` oder `sensor.opti_battery_capacity_kwh`
 `unavailable`, setzt die Strategie keinen Modus — der bisherige Modus bleibt aktiv.

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -253,8 +253,8 @@ du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
 | **Nacht / Reserve halten (Entladesperre)** | `opti_forecast_score` ≤ 2, SoC < 30 %, `opti_price_level` CHEAP | **Akku nur Laden** | Gate `input_boolean.opti_prognose_netzladen` muss `on` sein |
 | **Nacht / kein Ladegrund** | Score ≤ 2, SoC > 60 %, Preis EXPENSIVE | **Akku Dynamisch** (Default) | Kein Ladeblock greift → Default-Pfad |
 | **Sonne / PV-Überschuss** | `opti_grid_export_w` > 70%-Grenze, SoC < 100 % | **Akku Dynamisch** | Gate `input_boolean.opti_pv_ueberschuss_ladung` muss `on` sein |
-| **Tagsüber unter Ziel-SoC** | SoC < `opti_target_soc`, nach Sonnenaufgang | **Akku Dynamisch** | Option „Dynamisch laden wenn SOC < ZielSoC" |
-| **Entladen über Ziel-SoC** | SoC > `opti_target_soc` | **Akku nur Entladen** | Option „Nur Entladen wenn SOC > DynZielSoC" |
+| **Tagsüber unter Ziel-SoC** | SoC < `opti_target_soc` **− 3 %**, nach Sonnenaufgang | **Akku Dynamisch** | Option „Dynamisch laden wenn SOC < ZielSoC"; das ±3 %-Band verhindert Modus-Pendeln direkt an der Ziel-Kante — siehe [strategie-logik.md](strategie-logik.md#der-intelligente-ziel-soc--herzstück-der-akkuschonung) |
+| **Entladen über Ziel-SoC** | SoC > `opti_target_soc` **+ 3 %** | **Akku nur Entladen** | Option „Nur Entladen wenn SOC > DynZielSoC" |
 | **MinSOC-Schutz** | SoC < `input_number.minsoc` | **Akku nur Laden** | Höchste Priorität, überstimmt alle anderen Blöcke |
 | **Preis-morgen fehlt** | `opti_price_series`-Attribut `tomorrow` leer / < 4 Gesamtwerte | Preisniveau bleibt **NORMAL** | Fail-safe: `< 4 Preise gesamt → NORMAL` |
 | **Forecast fehlt** | `opti_forecast_remaining_today_kwh` → `unavailable` | Prognose-Blöcke inaktiv; MinSOC-Schutz und Cleanup laufen weiter | Default → **Akku Dynamisch** (nur wenn `opti_soc` + `opti_battery_capacity_kwh` verfügbar) |
@@ -262,6 +262,57 @@ du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
 
 **Fail-safe-Verhalten:** Sind `sensor.opti_soc` oder `sensor.opti_battery_capacity_kwh`
 `unavailable`, setzt die Strategie keinen Modus — der bisherige Modus bleibt aktiv.
+
+---
+
+## Bekannte Lücken: Legacy-Sensoren (`sma_templates.yaml`) vs. Canonical-Layer
+
+`packages/sma_templates.yaml` ist der Vorläufer von `packages/opti_derived.yaml` (vor dem
+Canonical-Layer-Umbau) und läuft auf produktiven Installationen teils **parallel** zu den neuen
+`opti_*`-Sensoren weiter — er wurde nie aufgeräumt. Beim Abgleich von Dashboards gegen den neuen
+Stand (2026-07) hat sich gezeigt, dass nicht jeder alte Sensor ein sauberes `opti_*`-Äquivalent
+hat. Bereits durchgeführte Dashboard-Swaps (sicher, geprüft):
+
+| Alt (`sma_templates.yaml`) | Neu (`opti_derived.yaml`) | Status |
+|---|---|---|
+| `sensor.akkusteuerung_dynamische_ladestaerke` | `sensor.opti_charge_power_w` | Swap OK — SoC-/Temp-Staffelung 1:1 übernommen, nur die Tages-Güte-Klassifikation wurde bewusst von 5 Text-Kategorien auf 3 Score-Bänder umgebaut (nicht byte-identisch bei jedem Prognosewert, aber gleiche Kennlinie) |
+| `sensor.ueberschuss_pv_watt` | `sensor.opti_grid_export_w` | Swap OK — strukturell identische Formel (`max(0, Netzeinspeisung)`) |
+| `sensor.pv_forecast_bewertung_heute` | `sensor.opti_forecast_score` | Swap vertretbar — andere Formel (PV-Fit statt Kapazitäts-Multiples), aber `opti_forecast_score` ist der Sensor, den die Strategie tatsächlich konsumiert |
+| `sensor.akku_net_verfugbare_energie` | Attribut `net_available_kwh` von `sensor.opti_target_soc` | Swap OK — Formel äquivalent |
+
+**Noch offen (bewusst NICHT geswapt, brauchen eine Entscheidung):**
+
+- **`sensor.house_battery_runtime_raw` → `sensor.opti_runtime_h`:** unterschiedlicher Nenner —
+  Alt teilt durch `sensor.house_battery_load_30_mins` (gemessene Akku-Entladeleistung), Neu durch
+  `sensor.opti_house_consumption_w` (Hausverbrauch). Bei Netzbezug oder wenn Hausverbrauch ≠
+  Akku-Entladeleistung (z. B. gleichzeitige PV-Einspeisung) weichen beide Werte ab. Noch nicht an
+  einem Zeitpunkt mit tatsächlicher Akku-Entladung gegengecheckt.
+- **`sensor.akku_remaining_sun_hours` (Live-Name `sensor.verbleibende_sonnenstunden`) → Attribut
+  `remaining_hours` von `sensor.opti_target_soc`:** **nicht äquivalent** — Alt clampt auf
+  `[0, 12]` mit Fallback `0` (nachts also `0`), Neu clampt auf `[0.5, 12]` mit Fallback `6.0`
+  (nachts also `6.0`). Ein blinder Swap hätte nachts eine sichtbar falsche Anzeige erzeugt.
+- **`sensor.pv_forecast_bewertung_morgen` → `sensor.opti_forecast_score_tomorrow`:** siehe
+  eigener Abschnitt unten — unterschiedliche Formel UND steuerungsrelevant, keine reine
+  Anzeigefrage.
+
+## Inkonsistenz: `opti_forecast_score` vs. `opti_forecast_score_tomorrow`
+
+`opti_forecast_score` (heute, `packages/opti_derived.yaml` Sensor 1) nutzt einen "PV-Fit"-Ansatz:
+PV-Überschuss (Restprognose minus Hausverbrauch bis Sonnenuntergang) wird gegen die tatsächlich
+fehlende Energie bis Akku voll (`cap * (1 - soc/100)`) verglichen — SoC- und Sonnenstunden-bewusst.
+
+`opti_forecast_score_tomorrow` (Sensor 2) nutzt eine deutlich simplere Formel: Verhältnis
+morgiger Gesamtprognose zu einem geschätzten vollen Verbrauchstag
+(`hausverbrauch_w * 24h`) — ohne SoC-Bezug, ohne Sonnenstunden. Beide liefern zwar denselben
+Wertebereich (0–10), sind aber konzeptuell unterschiedliche Metriken (nicht nur unterschiedlich
+skaliert). Grund: die PV-Fit-Formel von "heute" braucht aktuellen SoC und Rest-Sonnenstunden,
+die für "morgen" schlicht noch nicht feststehen.
+
+**Praktische Auswirkung:** `opti_forecast_score_tomorrow` fließt live in Strategie-Bedingungen
+ein (`st < 3` in mehreren choose-Optionen, `automations/opti_strategie.yaml` bzw. der
+Sollmodus-Vorschau in `packages/opti_derived.yaml`). Eine Formel-Angleichung an "heute" wäre
+also eine **Steuerungsänderung**, keine reine Aufräumarbeit — braucht eine bewusste, separate
+Entscheidung (nicht nebenbei mitziehen).
 
 ---
 

--- a/docs/modbus-register-referenz.md
+++ b/docs/modbus-register-referenz.md
@@ -305,6 +305,35 @@ Shadefix zieht periodisch die Steuerung zurück. In den WR-Einstellungen auf 30 
 **Register-Adressen in HA vs. SMA-Dokumentation:**  
 SMA nummeriert Register ab 40001 (1-indexed). HA Modbus verwendet die Adresse direkt – die HA-Konfiguration nutzt dieselben Zahlen wie die SMA-Dokumentation.
 
+**Ladeleistungs-Spike (~10,7 kW) nach Moduswechsel „nur Entladen" → „Dynamisch":**  
+Live beobachtet und 2x reproduziert (2026-07-01, STP SE 10.0 + BYD HVS 12.8): Nach
+längerer Verweildauer (>~15 Min) in einem erzwungenen Modus (`CmpBMS.OpMod` = 2290,
+„nur Entladen") lädt der WR beim Rücksprung auf „Dynamisch" für ca. 2:20–2:50 Min mit
+nahezu Nennleistung, obwohl der Ziel-Sollwert (`CmpBMS.BatChaMaxW` / 40795) unverändert
+und kurz zuvor frisch geschrieben war. Der Spike endet abrupt beim nächsten *echten*
+Schreibzyklus der BMS-Leistungsgrenzen (40793–40801) – nicht beim ersten danach, sondern
+erst beim übernächsten. Kurze Verweildauer (Sekunden) im Forced-Modus löst den Effekt
+nicht aus. Vermutete Ursache: der WR verwirft/driftet die intern gültige Ladeleistungs-
+grenze, solange Laden im aktuellen Modus irrelevant ist, und übernimmt den korrekten Wert
+erst wieder mit dem nächsten tatsächlichen Schreibvorgang nach Rückkehr in „Dynamisch".
+Trat ausschließlich nach Umstellung auf einen Adapter/Strategie-Aufbau auf, der die
+BMS-Leistungsgrenzen-Registerfamilie (40793–40801/41259) überhaupt erstmals nutzt – vorher
+(reiner 40149/40151-Sollwertpfad) nie beobachtet.
+
+Verifizierter Fix (Adapter-Blueprint, lebt im separaten Repo
+[`ha-modbus-akku-adapter`](https://github.com/Optic00/ha-modbus-akku-adapter)):
+1. Moduswechsel erzwingt einen sofortigen Rewrite der BMS-Leistungsgrenzen (statt bis
+   zum nächsten Write-on-Change/Keepalive-Zyklus zu warten).
+2. Defensiver Sicherheits-Deckel (500 W) auf die Ladeleistungsgrenze für die ersten
+   ~5:30 Min nach jedem Eintritt in „Dynamisch", danach automatischer Rücksprung auf den
+   echten Sollwert.
+3. Hygiene: `CmpBMS.OpMod` für „Dynamisch" konsistent über 41259 (Sunspec, wie die
+   anderen 3 Modi und wie in der offiziellen SMA-Support-Antwort oben) statt über die
+   alternative Adresse 40236 geschrieben.
+Live verifiziert: mit Fix blieb die Ladeleistung im kritischen Fenster durchgehend
+≤ 625 W (vorher bis 10.748 W), sauberer Übergang auf den echten Sollwert nach
+Fensterablauf, kein Spike mehr.
+
 ---
 
 ## Quellen

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -1,8 +1,8 @@
-# Strategie-Logik: Akku Lade- und Entladesteuerung Opti 2.0
+# Strategie-Logik: Akku Opti Strategie
 
 ## Überblick
 
-Die Automation `Akku Lade- Entladesteuerung Opti 2.0` trifft **ausschließlich Modus-Entscheidungen**.
+Die Automation `Akku Opti Strategie` trifft **ausschließlich Modus-Entscheidungen**.
 Sie schreibt einen Wert in `input_select.akkusteuerung_modus` — und nur das.
 Welche Hardware-Befehle dieser Modus am Wechselrichter/Speicher auslöst, steuert ein separater
 Hardware-Adapter (ein eigener Automatisierungszweig). Diese Trennung macht die Strategie-Logik

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -54,9 +54,9 @@ den Modus auf „Akku nur Laden" setzen:
 |------------------------------------------------------|-------------|-------------------|-----------------------------|
 | Laden wenn morgen+heute schlecht, SOC < 20 %         | < 20 %      | bis EXPENSIVE     | heute UND morgen schlecht   |
 | Laden wenn morgen+heute schlecht, SOC < 75 %         | < 75 %      | bis NORMAL        | heute UND morgen schlecht   |
-| Laden wenn heute+morgen schlecht, PV-Rest, Winter, < 80 % | < 80 %  | bis EXPENSIVE     | heute UND morgen schlecht, PV-Rest < 15 kWh, `opti_winter_charging_allowed` = on |
-| Laden wenn heute schlecht, PV-Rest, SOC < 15 %       | < 15 %      | bis EXPENSIVE     | heute schlecht, PV-Rest < 20 kWh |
-| Laden wenn heute schlecht, PV-Rest, SOC < 45 %, günstig | < 45 %   | nur CHEAP/VERY_CHEAP | heute schlecht, PV-Rest < 20 kWh |
+| Laden wenn heute+morgen schlecht, Winter, < 80 % | < 80 %  | bis EXPENSIVE     | heute UND morgen schlecht, `opti_winter_charging_allowed` = on |
+| Laden wenn heute schlecht, SOC < 15 %       | < 15 %      | bis EXPENSIVE     | heute schlecht |
+| Laden wenn heute schlecht, SOC < 45 %, günstig | < 45 %   | nur CHEAP/VERY_CHEAP | heute schlecht |
 
 ### Warum diese Struktur funktioniert
 

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -12,12 +12,16 @@ Die Automation läuft im Modus `single`: nur eine Instanz gleichzeitig, keine Pa
 Trigger sind Preisniveau-Änderungen, BYD/SOC-Änderungen, PV-Prognose-Bewertungsänderungen
 und weitere Zustandswechsel relevanter Helfer.
 
-Zentrales Entitäts-Modell (Platzhalternamen, an das eigene System anpassen):
+Zentrales Entitäts-Modell (Canonical-`opti_*`-Layer):
 
-- `sensor.sn_SERIENNUMMER_battery_soc_total` — aktueller Speicher-SoC
-- `sensor.pv_forecast_bewertung_heute` / `_morgen` — Prognose-Bewertung (Kritisch/Mangelhaft/Normal/…)
-- `sensor.strompreis_niveau` — aktuelles Preislevel (VERY_CHEAP/CHEAP/NORMAL/EXPENSIVE/VERY_EXPENSIVE), anbieter-agnostisch (optional: Tibber o. ä. als Datenquelle dahinter)
-- `input_number.minsoc` / `input_number.maxsoc` — konfigurierbare Grenzen
+- `sensor.opti_soc` — aktueller Speicher-SoC (aus `opti_mapping.yaml` abgeleitet)
+- `sensor.opti_forecast_score` / `sensor.opti_forecast_score_tomorrow` — PV-Fit heute/morgen (0–10)
+- `sensor.opti_price_level` — aktuelles Preisniveau (VERY_CHEAP/CHEAP/NORMAL/EXPENSIVE/VERY_EXPENSIVE), anbieter-agnostisch
+- `sensor.opti_target_soc` — intelligenter Ziel-SoC (aus Restprognose + Hausverbrauch)
+- `input_number.minsoc` / `input_number.maxsoc` — konfigurierbare SoC-Grenzen
+- `input_boolean.opti_prognose_netzladen` — Gate für prognosebasiertes Netzladen
+- `input_boolean.opti_pv_ueberschuss_ladung` — Gate für PV-Überschuss-Laden
+- `binary_sensor.opti_winter_charging_allowed` — Winterladefreigabe (Standard: `true`)
 - `input_select.akkusteuerung_modus` — Ziel-Ausgang dieser Automation
 
 ---
@@ -27,7 +31,7 @@ Zentrales Entitäts-Modell (Platzhalternamen, an das eigene System anpassen):
 Die **erste** `choose`-Option im Block „Zwischen Speicherszenarien wählen" ist die Entladesperre:
 
 ```
-Bedingung: sensor.sn_SERIENNUMMER_battery_soc_total below input_number.minsoc
+Bedingung: sensor.opti_soc below input_number.minsoc
 Aktion:    input_select.akkusteuerung_modus → "Akku nur Laden"
            stop: "MinSOC Schutz aktiv – Entladen gesperrt"
 ```
@@ -50,13 +54,9 @@ den Modus auf „Akku nur Laden" setzen:
 |------------------------------------------------------|-------------|-------------------|-----------------------------|
 | Laden wenn morgen+heute schlecht, SOC < 20 %         | < 20 %      | bis EXPENSIVE     | heute UND morgen schlecht   |
 | Laden wenn morgen+heute schlecht, SOC < 75 %         | < 75 %      | bis NORMAL        | heute UND morgen schlecht   |
-| Laden wenn heute+morgen schlecht, PV-Rest, Winter, < 80 % | < 80 %  | bis EXPENSIVE     | heute UND morgen schlecht, PV-Rest < 15 kWh, kein Sommermodus |
+| Laden wenn heute+morgen schlecht, PV-Rest, Winter, < 80 % | < 80 %  | bis EXPENSIVE     | heute UND morgen schlecht, PV-Rest < 15 kWh, `opti_winter_charging_allowed` = on |
 | Laden wenn heute schlecht, PV-Rest, SOC < 15 %       | < 15 %      | bis EXPENSIVE     | heute schlecht, PV-Rest < 20 kWh |
 | Laden wenn heute schlecht, PV-Rest, SOC < 45 %, günstig | < 45 %   | nur CHEAP/VERY_CHEAP | heute schlecht, PV-Rest < 20 kWh |
-
-Nachgelagert gibt es außerdem den eigenständigen Aktionsblock:
-**„Akku Nur Laden wenn Prognose schlecht und aufsparen bei CHEAP & VERY_CHEAP & NORMAL"**
-— dieser greift auch dann, wenn die `choose`-Blöcke oben keinen `stop` ausgelöst haben.
 
 ### Warum diese Struktur funktioniert
 
@@ -88,7 +88,7 @@ Das ist bewusst als zukünftiger Task (nicht Teil dieser Portierung) zurückgest
 ## Block-für-Block-Übersicht
 
 Die Automation besteht aus mehreren Aktionsblöcken, die **sequenziell** ausgeführt werden.
-Der wichtigste ist „Zwischen Speicherszenarien wählen" mit 12 Optionen und einem Default-Pfad.
+Der wichtigste ist „Zwischen Speicherszenarien wählen" mit 11 Optionen und einem Default-Pfad.
 
 ---
 
@@ -129,7 +129,7 @@ Diese Option steht bewusst ganz oben und kann von keinem anderen Block überstim
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | SoC < 20 %, heute Kritisch/Mangelhaft, morgen Kritisch/Mangelhaft |
+| Bedingung | SoC < 20 %, `opti_forecast_score` ≤ 2, `opti_forecast_score_tomorrow` ≤ 2 |
 | Preis | bis EXPENSIVE (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE) |
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Laden** |
@@ -145,7 +145,7 @@ noch besser als kein Puffer. Diese Ausnahmeregelung gilt nur für diese kritisch
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | SoC < 75 %, heute Kritisch/Mangelhaft, morgen Kritisch/Mangelhaft |
+| Bedingung | SoC < 75 %, `opti_forecast_score` ≤ 2, `opti_forecast_score_tomorrow` ≤ 2 |
 | Preis | bis NORMAL (VERY_CHEAP / CHEAP / NORMAL — kein EXPENSIVE) |
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Laden** |
@@ -162,20 +162,18 @@ desto teureren Strom darf die Automatik akzeptieren.
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | SoC < 80 %, PV-Restproduktion heute < 15 kWh, beide Tage Kritisch/Mangelhaft, `binary_sensor.DEIN_SOMMERMODUS_GATE` = off |
+| Bedingung | SoC < 80 %, PV-Restproduktion heute < 15 kWh, `opti_forecast_score` ≤ 2 + `opti_forecast_score_tomorrow` ≤ 2, `binary_sensor.opti_winter_charging_allowed` = on |
 | Preis | bis EXPENSIVE (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE) |
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Laden** |
 
 **Warum:** Dieser Block ist der „Wintermodus-Booster". Er greift wenn die PV fast
-nichts mehr liefert (< 15 kWh verbleibend), beide Tage schlecht sind, und der Sommermodus
-deaktiviert ist — dann wird aggressiver bis 80 % geladen, auch bei EXPENSIVE-Preisen.
+nichts mehr liefert (< 15 kWh verbleibend), beide Tage schlecht sind und die Winterladefreigabe
+aktiv ist — dann wird aggressiver bis 80 % geladen, auch bei EXPENSIVE-Preisen.
 
-**Wichtiger Hinweis für Nachbauer:** Das Gate `binary_sensor.DEIN_SOMMERMODUS_GATE` muss
-als tatsächliche Entität in deinem HA existieren (z. B. ein `input_boolean`). Fehlt diese
-Entität, wertet HA die Bedingung als `false` — der Block **greift dann nie**, auch nicht
-im Winter. Entweder die Bedingung durch eine eigene Entität ersetzen oder den Gate-Check
-aus der YAML entfernen, wenn kein Sommermodus-Schalter vorhanden ist.
+**Hinweis:** `binary_sensor.opti_winter_charging_allowed` ist in `opti_derived.yaml`
+als fail-open Gate definiert (Standard: immer `true`). Es kann mit einem eigenen
+Sommermodus-Schalter überschrieben werden, wenn ein saisonales Gate gewünscht ist.
 
 ---
 
@@ -183,7 +181,7 @@ aus der YAML entfernen, wenn kein Sommermodus-Schalter vorhanden ist.
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | SoC < 15 %, PV-Rest heute < 20 kWh, heute Kritisch/Mangelhaft |
+| Bedingung | SoC < 15 %, PV-Rest heute < 20 kWh, `opti_forecast_score` ≤ 2 |
 | Preis | bis EXPENSIVE (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE) |
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Laden** |
@@ -198,7 +196,7 @@ schlecht ist, wird notgeladen — ohne Rücksicht auf morgen. Kurzfrist-Schutz.
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | SoC < 45 %, PV-Rest heute < 20 kWh, heute Kritisch/Mangelhaft |
+| Bedingung | SoC < 45 %, PV-Rest heute < 20 kWh, `opti_forecast_score` ≤ 2 |
 | Preis | nur VERY_CHEAP / CHEAP |
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Laden** |
@@ -210,52 +208,38 @@ Stunden rechtfertigen das Netzladen bei diesem SoC-Niveau.
 
 ---
 
-#### Option 7 — Drohende Abregelung in Akku umleiten (nur tagsüber)
+#### Option 7 — Bei 70%-Überschuss laden (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | Abregelungsleistung (`sensor.akku_abregelungsleistung`) > 100 W, SoC < 100 %, tagsüber |
+| Bedingung | `sensor.opti_grid_export_w` über der konfigurierten 70%-Grenze, SoC < 100 %, tagsüber |
 | Preis | irrelevant |
 | Tageszeit | nach Sonnenaufgang bis Sonnenuntergang |
 | Gesetzter Modus | **Akku Dynamisch** |
+| Gate | `input_boolean.opti_pv_ueberschuss_ladung` muss `on` sein |
 
-**Warum:** Wenn die PV-Anlage kurz vor der 70%-Einspeisekappung steht und Leistung
-verloren gehen würde, wird der Akku auf Dynamisch gesetzt — er nimmt dann den Überschuss
-auf, statt ihn am Dach-Limit zu verlieren. „Dynamisch" bedeutet hier: der Hardware-Adapter
-kann je nach Situation laden oder entladen, optimiert auf den aktuellen Bedarf.
-
----
-
-#### Option 8 — Bei 70%-Überschuss laden (nur tagsüber)
-
-| Eigenschaft | Wert |
-|---|---|
-| Bedingung | `sensor.ueberschuss_pv_watt` über der konfigurierten 70%-Grenze, SoC < 100 %, tagsüber |
-| Preis | irrelevant |
-| Tageszeit | nach Sonnenaufgang bis Sonnenuntergang |
-| Gesetzter Modus | **Akku Dynamisch** |
-
-**Warum:** Sobald die PV mehr produziert als ins Netz eingespeist werden darf (70%-Kappung),
+**Warum:** Sobald die PV mehr ins Netz einspeist als die konfigurierte 70%-Grenze erlaubt,
 soll dieser Überschuss in den Akku. „Dynamisch" gibt dem Adapter die Freiheit, genau die
 richtige Ladeleistung zu wählen.
 
 ---
 
-#### Option 9 — Bei AC-Überschuss laden (nur tagsüber)
+#### Option 8 — Bei AC-Überschuss laden (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | WR-AC-Ausgangsleistung über der konfigurierten WR-Nennleistungsgrenze, SoC < 100 %, tagsüber |
+| Bedingung | `sensor.opti_pv_power_w` über der konfigurierten WR-Nennleistungsgrenze, SoC < 100 %, tagsüber |
 | Preis | irrelevant |
 | Tageszeit | nach Sonnenaufgang bis Sonnenuntergang |
 | Gesetzter Modus | **Akku Dynamisch** |
+| Gate | `input_boolean.opti_pv_ueberschuss_ladung` muss `on` sein |
 
-**Warum:** Ähnlich wie Option 8, aber die Messgröße ist die WR-Ausgangsleistung statt
-der 70%-Schwelle. Nutzt verfügbare PV-Energie aktiv, bevor sie verschwendet oder gekappt wird.
+**Warum:** Ähnlich wie Option 7, aber die Messgröße ist die WR-AC-Ausgangsleistung statt
+der Netzeinspeisung. Nutzt verfügbare PV-Energie aktiv, bevor sie verschwendet wird.
 
 ---
 
-#### Option 10 — Bei vollem Akku auf Dynamisch schalten
+#### Option 9 — Bei vollem Akku auf Dynamisch schalten
 
 | Eigenschaft | Wert |
 |---|---|
@@ -270,96 +254,58 @@ einspeisen, bei Verbrauch den Akku nutzen — je nach aktuellem Systemzustand.
 
 ---
 
-#### Option 11 — Dynamisch laden wenn SoC zwischen MinSOC und Ziel-SoC (nur tagsüber)
+#### Option 10 — Dynamisch laden wenn SoC zwischen MinSOC und Ziel-SoC (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | SoC > MinSOC UND SoC < `sensor.akku_target_soc_intelligent`, tagsüber |
+| Bedingung | SoC > MinSOC UND SoC < `sensor.opti_target_soc`, tagsüber |
 | Preis | irrelevant |
 | Tageszeit | nach Sonnenaufgang bis Sonnenuntergang |
 | Gesetzter Modus | **Akku Dynamisch** |
 
 **Warum:** Tagsüber soll der Akku progressiv auf den intelligenten Ziel-SoC geladen werden.
-`sensor.akku_target_soc_intelligent` berechnet diesen Zielwert aus der Solcast-Restprognose
+`sensor.opti_target_soc` berechnet diesen Zielwert aus der Solcast-Restprognose
 und dem geschätzten Hausverbrauch bis Sonnenuntergang. Je weniger PV noch erwartet wird,
-desto höher der Ziel-SoC. Neue Bausteine darin: P10-Sicherheitsnetz (10. Perzentil der
-Prognose als konservativer Referenzwert) und ein P-Regler für sanfte Übergänge zwischen
-den Stufen. An `akku_target_soc_intelligent` hängen Decision-Trace-Attribute, die den
-aktuellen Berechnungspfad für Debugging nachvollziehbar machen.
+desto höher der Ziel-SoC. Bausteine: P10-Sicherheitsnetz (10. Perzentil der Prognose als
+konservativer Referenzwert) und Decision-Trace-Attribute für Debugging.
 
 ---
 
-#### Option 12 — Nur Entladen wenn SoC über Ziel-SoC
+#### Option 11 — Nur Entladen wenn SoC über Ziel-SoC
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | SoC > `sensor.akku_target_soc_intelligent` |
+| Bedingung | SoC > `sensor.opti_target_soc` |
 | Preis | irrelevant |
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Entladen** |
 
 **Warum:** Ist der Akku bereits über dem intelligenten Ziel-SoC, hat er genug Reserve
 für die Nacht. Weiteres Laden aus dem Netz wäre Verschwendung — stattdessen wird der
-Überschuss verbraucht bzw. eingespeist. (Hinweis: Eine zusätzliche Bedingung
-„morgen Hervorragend" ist in der YAML vorhanden, aber derzeit deaktiviert.)
+Überschuss verbraucht bzw. eingespeist.
 
 ---
 
 #### Default — Akku Dynamisch
 
-Trifft keine der 12 Optionen zu (z. B. nachts, kein Überschuss, kein Ladegrund),
+Trifft keine der 11 Optionen zu (z. B. nachts ohne Ladegrund, Preis zu hoch),
 wird der Modus auf **Akku Dynamisch** gesetzt. Der Adapter entscheidet dann
 situationsabhängig, ob leicht geladen oder entladen wird — ein sicherer Mittelweg.
 
----
-
-### Aktionsblock 3 — Netzladen-Booster deaktivieren bei vollem Akku
-
-**Was passiert:** Wenn der Trigger „Akku ist voll" (SoC > 99 %) feuert und der
-manuelle Netzlade-Booster (`input_boolean.hausakku_aus_netz_laden`) aktiv ist,
-wird dieser automatisch deaktiviert. Außerdem wird der Ladepreis-Helfer
-(`input_number.ladepreis`) auf den aktuellen Strompreis gesetzt und der Modus
-auf „Akku nur Laden" geschaltet.
-
-**Warum:** Ein aktivierter Netzladen-Booster bei vollem Akku wäre sinnlos und
-würde weiter Strom ziehen. Dieser Block putzt das automatisch auf.
+Der Default-Pfad greift nur wenn `sensor.opti_soc` und `sensor.opti_battery_capacity_kwh`
+verfügbar sind — Fail-safe bei unavailable Quellen.
 
 ---
 
-### Aktionsblock 4 — „Akku Nur Laden wenn Prognose schlecht und aufsparen" (nachgelagert)
+### Aktionsblock 3 — Cleanup: Netzladen-Booster deaktivieren bei vollem Akku
 
-Dieser Block läuft **nach** dem großen `choose`-Block und greift auch dann,
-wenn oben kein `stop` ausgelöst wurde. Er hat drei interne Unterbedingungen (OR):
+**Was passiert:** Wenn SoC > 99 % und der manuelle Netzlade-Booster
+(`input_boolean.hausakku_aus_netz_laden`) aktiv ist, wird dieser automatisch deaktiviert.
+Außerdem wird der Ladepreis-Helfer (`input_number.ladepreis`) auf den aktuellen Strompreis
+gesetzt (Einheit: EUR, `ct/kWh ÷ 100`) und der Modus auf „Akku nur Laden" geschaltet.
 
-1. **Wintermodus-Abend:** SoC < 80 %, PV-Rest < 15 kWh, morgen schlecht, kein Sommermodus
-2. **Nachmittags-Puffer (13:00–23:59):** SoC < 30 %, PV-Rest < 20 kWh, morgen schlecht
-3. **Nachts/Früh (00:00–12:59):** SoC < 30 %, heute schlecht
-
-Dazu muss das Preisniveau CHEAP / VERY_CHEAP / NORMAL sein.
-
-**Warum:** Dieser Block ist eine zweite Sicherheitsebene für prognosebasiertes Laden.
-Er stellt sicher, dass der Akku auch dann nachgeladen wird, wenn der Haupt-`choose`-Block
-keinen `stop` gesetzt hat (z. B. weil kein passender Trigger dabei war). Tageszeit-Logik
-(13:00-Schwelle) berücksichtigt, dass morgen-Prognosen am Nachmittag relevanter werden
-als am frühen Morgen.
-
----
-
-### Aktionsblock 5 — Legacy Tibber-Preis-Ladesteuerung (deaktiviert)
-
-Dieser Block ist in der YAML vorhanden, aber mit `enabled: false` vollständig deaktiviert.
-Er enthält drei Optionen:
-
-- **Netz-Laden wenn Preisspanne lohnt:** Zieht Tibber-spezifische Sensoren heran
-  (`sensor.tibber_preisspanne_heute`, `sensor.tibber_aktueller_preis_ist_tageshochstpreis`),
-  die in der neuen anbieter-agnostischen Strategie nicht mehr verwendet werden.
-- **Akku Automatisch wenn PV gut und Akku hoch (ohne Netzladen)**
-- **Akku Automatisch wenn morgen oder heute ausreichend PV**
-
-**Warum deaktiviert:** Im Winter ist diese Logik kaum wirtschaftlich (Kommentar in der YAML).
-Sie ist zur Referenz erhalten, wird aber nicht mehr gepflegt. Die neue Preisniveauquelle
-`sensor.strompreis_niveau` (anbieter-agnostisches Perzentil-Enum) macht Tibber-spezifische
-Sensoren in der Strategie obsolet.
+**Warum:** Ein aktivierter Netzladen-Booster bei vollem Akku wäre sinnlos. Dieser Block
+putzt den Zustand automatisch auf — er läuft immer (kein Toggle-Gate).
 
 ---
 
@@ -369,23 +315,24 @@ Sensoren in der Strategie obsolet.
 |---|---|
 | **Akku nur Laden** | SoC unter MinSOC (Notfall); schlechte Prognose + günstiger Strom; Wintermodus aktiv; Akku fast leer bei Schlechtwetter |
 | **Akku Dynamisch** | PV-Überschuss tagsüber; Akku zwischen MinSOC und Ziel-SoC; voller Akku; kein klarer Lade-/Entladegrund (Default) |
-| **Akku nur Entladen** | SoC über intelligentem Ziel-SoC (Akku hat genug Reserve für die Nacht) |
-| **Akku Automatisch** | Nur im deaktivierten Legacy-Tibber-Block — in der aktiven Strategie derzeit nicht vergeben |
+| **Akku nur Entladen** | SoC über intelligentem Ziel-SoC (`sensor.opti_target_soc`) — Akku hat genug Reserve für die Nacht |
 
 **Modus-Contract (Single-Writer-Regel):**
-Die Strategie-Automation schreibt ausschließlich in `input_select.akkusteuerung_modus`.
-Was dieser Modus am Wechselrichter/Speicher auslöst, entscheidet allein der Hardware-Adapter
-(Blueprint im Repo `ha-modbus-akku-adapter`). Nur eine Automation darf gleichzeitig
-via Modbus schreiben — keine zweite Steuer-Automation parallel aktiv lassen.
+Die Strategie-Automation schreibt primär `input_select.akkusteuerung_modus`. Im
+Cleanup-Block (Aktionsblock 3) werden zusätzlich `input_boolean.hausakku_aus_netz_laden`
+und `input_number.ladepreis` gesetzt. Was der Modus am Wechselrichter/Speicher auslöst,
+entscheidet allein der Hardware-Adapter (Blueprint im Repo `ha-modbus-akku-adapter`).
+Nur eine Automation darf gleichzeitig via Modbus schreiben — keine zweite
+Steuer-Automation parallel aktiv lassen.
 
 ---
 
-## Neue Bausteine (seit Task 5–6)
+## Bausteine des Canonical-Layers
 
 | Baustein | Beschreibung |
 |---|---|
-| **P10-Sicherheitsnetz** | `sensor.pv_forecast_bewertung_heute` / `_morgen` verwenden das 10. Perzentil der Solcast-Prognose als konservativen Referenzwert — schützt vor Überoptimismus bei unsicheren Prognosen |
-| **Decision-Trace-Attribute** | `akku_target_soc_intelligent` hängt Debugging-Attribute an (`branch`, `ratio`, `net_available_kwh`, `remaining_hours`), lesbar über HA-Entwicklerwerkzeuge |
-| **Sollkurve + P-Regler** | `sensor.akkusteuerung_dynamische_ladestaerke_p` ist ein eigenständiger Sensor (P-Regler), der die Basis-Ladestärke proportional zur Abweichung Ist-SOC vs. Sollkurve moduliert — sanfter Übergang statt abrupter Sprünge |
-| **Abregelungs-Umleitung** | Trigger + Option 7 erkennen drohende 70%-Kappung und leiten Überschuss aktiv in den Akku (statt Verlust am Dach-Limit) |
-| **`sensor.strompreis_niveau`** | Anbieter-agnostisches Preisniveau-Enum (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE / VERY_EXPENSIVE) auf Basis eines gleitenden Perzentils — ersetzt Tibber-spezifische Direktabfragen in der Strategie |
+| **P10-Sicherheitsnetz** | `sensor.opti_forecast_score` / `_tomorrow` verwenden das 10. Perzentil der Solcast-Prognose (`estimate10`) als konservativen Referenzwert — schützt vor Überoptimismus bei unsicheren Prognosen |
+| **Decision-Trace-Attribute** | `sensor.opti_target_soc` hängt Debugging-Attribute an (`branch`, `ratio`, `net_available_kwh`, `remaining_hours`), lesbar über HA-Entwicklerwerkzeuge |
+| **Forecast-Score-Bänder** | `sensor.opti_charge_power_w` variiert die C-Rate in drei Bändern (score ≤ 1: aggressiv; 2–4: moderat; ≥ 5: schonend) statt starrer Prognose-Labels |
+| **`sensor.opti_price_level`** | Anbieter-agnostisches Preisniveau-Enum (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE / VERY_EXPENSIVE) auf Basis eines gleitenden Perzentils über `today`/`tomorrow`-Preislisten |
+| **`binary_sensor.opti_winter_charging_allowed`** | Fail-open Gate für Winterladeblöcke (Standard: `true`); kann mit eigenem Sommermodus-Sensor überschrieben werden |

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -158,18 +158,17 @@ desto teureren Strom darf die Automatik akzeptieren.
 
 ---
 
-#### Option 4 — Laden wenn heute + morgen schlecht, PV-Rest < 15 kWh, Wintermodus, SoC < 80 % (Tag und Nacht)
+#### Option 4 — Laden wenn heute + morgen schlecht, Wintermodus, SoC < 80 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | SoC < 80 %, PV-Restproduktion heute < 15 kWh, `opti_forecast_score` ≤ 2 + `opti_forecast_score_tomorrow` ≤ 2, `binary_sensor.opti_winter_charging_allowed` = on |
+| Bedingung | SoC < 80 %, `opti_forecast_score` ≤ 2 + `opti_forecast_score_tomorrow` ≤ 2, `binary_sensor.opti_winter_charging_allowed` = on |
 | Preis | bis EXPENSIVE (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE) |
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Laden** |
 
-**Warum:** Dieser Block ist der „Wintermodus-Booster". Er greift wenn die PV fast
-nichts mehr liefert (< 15 kWh verbleibend), beide Tage schlecht sind und die Winterladefreigabe
-aktiv ist — dann wird aggressiver bis 80 % geladen, auch bei EXPENSIVE-Preisen.
+**Warum:** Dieser Block ist der „Wintermodus-Booster". Er greift wenn beide Tage schlecht sind
+und die Winterladefreigabe aktiv ist — dann wird aggressiver bis 80 % geladen, auch bei EXPENSIVE-Preisen.
 
 **Hinweis:** `binary_sensor.opti_winter_charging_allowed` ist in `opti_derived.yaml`
 als fail-open Gate definiert (Standard: immer `true`). Es kann mit einem eigenen
@@ -177,26 +176,26 @@ Sommermodus-Schalter überschrieben werden, wenn ein saisonales Gate gewünscht 
 
 ---
 
-#### Option 5 — Laden wenn heute schlecht, wenig PV-Rest, SoC < 15 % (Tag und Nacht)
+#### Option 5 — Laden wenn heute schlecht, SoC < 15 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | SoC < 15 %, PV-Rest heute < 20 kWh, `opti_forecast_score` ≤ 2 |
+| Bedingung | SoC < 15 %, `opti_forecast_score` ≤ 2 |
 | Preis | bis EXPENSIVE (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE) |
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Laden** |
 
 **Warum:** Ähnlich wie Option 2, aber unabhängig von der Morgen-Prognose. Wenn der Akku
-fast leer ist (< 15 %), heute nichts mehr kommt (< 20 kWh Rest) und die heutige Bewertung
-schlecht ist, wird notgeladen — ohne Rücksicht auf morgen. Kurzfrist-Schutz.
+fast leer ist (< 15 %) und die heutige Bewertung schlecht ist, wird notgeladen — ohne
+Rücksicht auf morgen. Kurzfrist-Schutz.
 
 ---
 
-#### Option 6 — Laden wenn heute schlecht, wenig PV-Rest, SoC < 45 %, Strom sehr günstig (Tag und Nacht)
+#### Option 6 — Laden wenn heute schlecht, SoC < 45 %, Strom sehr günstig (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | SoC < 45 %, PV-Rest heute < 20 kWh, `opti_forecast_score` ≤ 2 |
+| Bedingung | SoC < 45 %, `opti_forecast_score` ≤ 2 |
 | Preis | nur VERY_CHEAP / CHEAP |
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Laden** |

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -85,6 +85,104 @@ Das ist bewusst als zukünftiger Task (nicht Teil dieser Portierung) zurückgest
 
 ---
 
+## Der intelligente Ziel-SoC — Herzstück der Akkuschonung
+
+Das **Kernfeature** dieser Steuerung steckt nicht in der Strategie-Automation, sondern im
+abgeleiteten Sensor `sensor.opti_target_soc` (definiert in `packages/opti_derived.yaml`).
+Er beantwortet die Frage: *„Wie voll soll der Akku jetzt geladen werden?"* — **prognosebasiert**.
+
+### Warum überhaupt ein dynamischer Ziel-SoC?
+
+Ein Akku, der morgens schon auf 100 % steht, hat zwei Nachteile:
+
+1. **Zellalterung:** Lithium-Zellen altern kalendarisch schneller, je höher der SoC. Dauerhaft
+   bei 100 % zu stehen kostet Lebensdauer.
+2. **Verschenkte PV:** Ein voller Akku kann den PV-Überschuss des Tages nicht mehr aufnehmen —
+   der Strom wird (oft schlecht vergütet) eingespeist statt selbst genutzt.
+
+**Ziel:** Morgens nur so weit laden, dass die **erwartete Rest-PV des Tages** den Akku bis zum
+Abend von selbst voll macht. Gute Prognose → niedriger Ziel-SoC (Platz für PV lassen).
+Schlechte Prognose → hoher Ziel-SoC (mehr laden, notfalls aus dem Netz über die Ladeblöcke oben).
+
+### Wie der Zielwert berechnet wird
+
+Pro Aktualisierung rechnet der Sensor:
+
+```
+remaining_hours = Stunden bis Sonnenuntergang        (begrenzt auf 0.5…12 h; Fallback 6 h)
+net_available   = max(0, restproduktion_kWh − hausverbrauch_kW × remaining_hours)
+ratio           = net_available / akku_kapazität_kWh
+```
+
+- `restproduktion_kWh` = `sensor.opti_forecast_remaining_today_kwh` (Solcast-Restprognose, über
+  das **P10-Perzentil** konservativ gerechnet).
+- `hausverbrauch_kW` = `sensor.opti_house_consumption_w` / 1000.
+- `ratio` ist also der erwartete **PV-Überschuss bis Sonnenuntergang, ausgedrückt in
+  „Akku-Kapazitäten"** — wie viele Akkufüllungen an Überschuss noch kommen.
+
+Daraus eine **Stufenkennlinie** `ratio → Ziel-SoC`:
+
+| `ratio` (Überschuss / Kapazität) | Ziel-SoC | Bedeutung |
+|---|---|---|
+| < 0.375        | **maxsoc** | kaum Überschuss erwartet → voll laden |
+| 0.375 – 0.875  | **90 %** | |
+| 0.875 – 1.375  | **80 %** | |
+| 1.375 – 1.875  | **70 %** | |
+| 1.875 – 2.875  | **60 %** | |
+| ≥ 2.875        | **50 %** | viel Überschuss → niedrig halten, PV füllt auf |
+
+Abschließend auf `[minsoc, maxsoc]` begrenzt. Sonderfall: ist der manuelle Netzlade-Booster
+(`input_boolean.hausakku_aus_netz_laden`) aktiv, gilt direkt `maxsoc`.
+
+### Hysterese statt Flattern (Schmitt-Trigger)
+
+`ratio` driftet kontinuierlich (Sonnenuntergang rückt näher, Leistungssensoren zappeln). Sitzt
+der Wert auf einer Stufengrenze, würde der Ziel-SoC zwischen zwei Nachbarstufen oszillieren
+(z. B. 80 ↔ 90). Weil der reale SoC dann *zwischen* beiden Zielwerten liegt, kippte früher der
+**Modus** dutzendfach pro Tag zwischen „Dynamisch" und „nur Entladen".
+
+**Lösung:** ein echter **Schmitt-Trigger**. Die aktuelle Stufe wird im Attribut `level` des
+Sensors gehalten (Selbstbezug über `this.attributes`) und erst gewechselt, wenn `ratio` die
+nächste Grenze um eine Marge **m = 0.10** über- bzw. unterschreitet:
+
+- **Hochschalten** (höhere `ratio` → niedrigerer Ziel-SoC) erst ab `Grenze + 0.10`
+- **Runterschalten** erst unter `Grenze − 0.10`
+
+Das ergibt ein Totband um jede Grenze und beseitigt das Flattern an der Wurzel. Die
+Grenzwerte `[0.375, 0.875, …]` sind bewusst die **ursprünglichen effektiven Schwellen** — es
+ändert sich nur das Halteverhalten, **nicht** die Lade-Kennlinie.
+
+> **Hinweis:** Eine reine Rundung von `ratio` (z. B. auf 0.25-Schritte) ist **keine** Hysterese
+> — sie verschiebt nur den Kipppunkt, schafft aber kein Halteband. Genau das war der ursprüngliche
+> Bug. Hysterese braucht zwingend ein Gedächtnis des Vorzustands (hier das `level`-Attribut).
+
+**Debug-Trace:** Das Attribut `branch` zeigt die Live-Entscheidung, z. B.
+`ratio=0.47 plain=1 → level 1 → 90%` — mit Zusatz `(gehalten)`, wenn die Hysterese gerade eine
+Stufe gegen die Roh-`ratio` festhält.
+
+### Wie die Strategie den Ziel-SoC nutzt (mit Band H)
+
+Die Modus-Automation vergleicht den realen SoC mit `sensor.opti_target_soc` — mit einem
+zusätzlichen **Band H = 3 %** als zweiter Schutzschicht gegen Pendeln direkt an der Ziel-Kante:
+
+- **SoC < Ziel − 3** → *Akku Dynamisch* (lädt Richtung Ziel, Option 10)
+- **SoC > Ziel + 3** → *Akku nur Entladen* (genug Reserve, Option 11)
+- **innerhalb ±3 % um das Ziel** → neutrale Zone → Default *Akku Dynamisch*
+
+### Nachbauen über die zwei Repos
+
+Dieses Feature lebt in **`ha-opti-akkusteuerung`** (Strategie + abgeleitete Sensoren); die
+eigentliche Hardware-Ansteuerung in **`ha-modbus-akku-adapter`**. Zum Nachbauen genügen:
+
+1. Wechselrichter über den [Canonical-Layer](canonical-layer.md) auf `sensor.opti_*` abbilden.
+2. Eine **Solcast-Restprognose** (`opti_forecast_remaining_today_kwh`) und einen
+   **Hausverbrauchs-Sensor** (`opti_house_consumption_w`) bereitstellen.
+3. Helfer `input_number.minsoc` / `input_number.maxsoc` setzen (maxsoc = oberer Deckel; z. B.
+   95 % schont die Zellen, 100 % gibt volle Kapazität).
+4. Den Modus-Ausgang `input_select.akkusteuerung_modus` vom Adapter im anderen Repo umsetzen lassen.
+
+---
+
 ## Block-für-Block-Übersicht
 
 Die Automation besteht aus mehreren Aktionsblöcken, die **sequenziell** ausgeführt werden.
@@ -257,16 +355,16 @@ einspeisen, bei Verbrauch den Akku nutzen — je nach aktuellem Systemzustand.
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | SoC > MinSOC UND SoC < `sensor.opti_target_soc`, tagsüber |
+| Bedingung | SoC > MinSOC UND SoC < `sensor.opti_target_soc` **− 3 %**, tagsüber |
 | Preis | irrelevant |
 | Tageszeit | nach Sonnenaufgang bis Sonnenuntergang |
 | Gesetzter Modus | **Akku Dynamisch** |
 
 **Warum:** Tagsüber soll der Akku progressiv auf den intelligenten Ziel-SoC geladen werden.
-`sensor.opti_target_soc` berechnet diesen Zielwert aus der Solcast-Restprognose
-und dem geschätzten Hausverbrauch bis Sonnenuntergang. Je weniger PV noch erwartet wird,
-desto höher der Ziel-SoC. Bausteine: P10-Sicherheitsnetz (10. Perzentil der Prognose als
-konservativer Referenzwert) und Decision-Trace-Attribute für Debugging.
+Wie `sensor.opti_target_soc` diesen Zielwert herleitet (Restprognose, `ratio`-Stufen, Hysterese),
+ist im Abschnitt **[Der intelligente Ziel-SoC](#der-intelligente-ziel-soc--herzstück-der-akkuschonung)**
+erklärt. Das **−3 %-Band** (H) verhindert Modus-Pendeln direkt an der Ziel-Kante; innerhalb
+±3 % um das Ziel greift der Default (Dynamisch).
 
 ---
 
@@ -274,14 +372,15 @@ konservativer Referenzwert) und Decision-Trace-Attribute für Debugging.
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | SoC > `sensor.opti_target_soc` |
+| Bedingung | SoC > `sensor.opti_target_soc` **+ 3 %** |
 | Preis | irrelevant |
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Entladen** |
 
 **Warum:** Ist der Akku bereits über dem intelligenten Ziel-SoC, hat er genug Reserve
 für die Nacht. Weiteres Laden aus dem Netz wäre Verschwendung — stattdessen wird der
-Überschuss verbraucht bzw. eingespeist.
+Überschuss verbraucht bzw. eingespeist. Das **+3 %-Band** (H) sorgt zusammen mit der
+Ziel-SoC-Hysterese dafür, dass der Modus an der Grenze nicht flattert.
 
 ---
 
@@ -331,7 +430,8 @@ Steuer-Automation parallel aktiv lassen.
 | Baustein | Beschreibung |
 |---|---|
 | **P10-Sicherheitsnetz** | `sensor.opti_forecast_score` / `_tomorrow` verwenden das 10. Perzentil der Solcast-Prognose (`estimate10`) als konservativen Referenzwert — schützt vor Überoptimismus bei unsicheren Prognosen |
-| **Decision-Trace-Attribute** | `sensor.opti_target_soc` hängt Debugging-Attribute an (`branch`, `ratio`, `net_available_kwh`, `remaining_hours`), lesbar über HA-Entwicklerwerkzeuge |
+| **Ziel-SoC-Hysterese** | `sensor.opti_target_soc` hält die aktuelle `ratio`-Stufe im Attribut `level` (Schmitt-Trigger, Marge 0.10) → kein Flattern der Zielstufe. Siehe [Der intelligente Ziel-SoC](#der-intelligente-ziel-soc--herzstück-der-akkuschonung) |
+| **Decision-Trace-Attribute** | `sensor.opti_target_soc` hängt Debugging-Attribute an (`branch`, `level`, `ratio`, `net_available_kwh`, `remaining_hours`), lesbar über HA-Entwicklerwerkzeuge |
 | **Forecast-Score-Bänder** | `sensor.opti_charge_power_w` variiert die C-Rate in drei Bändern (score ≤ 1: aggressiv; 2–4: moderat; ≥ 5: schonend) statt starrer Prognose-Labels |
 | **`sensor.opti_price_level`** | Anbieter-agnostisches Preisniveau-Enum (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE / VERY_EXPENSIVE) auf Basis eines gleitenden Perzentils über `today`/`tomorrow`-Preislisten |
 | **`binary_sensor.opti_winter_charging_allowed`** | Fail-open Gate für Winterladeblöcke (Standard: `true`); kann mit eigenem Sommermodus-Sensor überschrieben werden |

--- a/old/README.md
+++ b/old/README.md
@@ -24,3 +24,57 @@ im Haupt-README.
 
 Der Unterordner `../old_legacy/` enthält noch ältere, ungenutzte Stände (SMA Grid Guard Code
 Ära) — nur für Archivzwecke, nutzt niemand mehr aktiv.
+
+## Konzepte (Legacy-Namen, old/templates.yaml)
+
+Diese Erklärungen gehören zu den Sensoren in `templates.yaml` (Legacy). Die aktuelle,
+kanonische Entsprechung findet sich in
+[docs/canonical-layer.md](../docs/canonical-layer.md) (Alt↔Neu-Mapping-Tabelle).
+
+### Welcher Sensor ist `sensor.betriebsstatus_sma_stp_se_10_0`?
+
+Das ist der Betriebsstatus-Sensor aus der Modbus-Konfiguration. In der mitgelieferten `configuration.yaml` heißt er `sensor.sma_stp_se_33003_betriebsstatus` (Adresse 33003). Ältere Versionen dieses Repos nutzten noch den anderen Namen – bitte in der Automation entsprechend anpassen.
+
+---
+
+### Woher kommt `sensor.akkusteuerung_dynamische_ladestaerke`?
+
+Dieser Template-Sensor ist in `templates.yaml` definiert und berechnet die optimale Ladestärke anhand von **Akku-SoC** und **Temperatur** – abgestimmt auf BYD LiFePO4-Chemie:
+
+| SoC | C-Rate | Begründung |
+|---|---|---|
+| < 30 % | 0.5C | Schnell laden bei kritisch niedrigem SoC |
+| 30–60 % | 0.3C | Optimale Langlebigkeit |
+| 60–85 % | 0.2C | Ausgewogen |
+| 85–MaxSoC | 0.1C | Schonend bei hohem SoC |
+| > MaxSoC | 0.05C | Minimal |
+| > 45 °C oder < 0 °C | reduziert/0 | Temperaturschutz |
+
+---
+
+### Was ist `sensor.akku_target_soc_intelligent`?
+
+Berechnet anhand der **verbleibenden Solcast-Prognose** und dem geschätzten **Hausverbrauch bis Sonnenuntergang**, wie weit der Akku *jetzt* geladen werden sollte. Je weniger PV-Produktion noch zu erwarten ist, desto höher der Ziel-SoC:
+
+| Verh. Restproduktion / Akkukapazität | Ziel-SoC |
+|---|---|
+| > 3× | 50 % |
+| 2–3× | 60 % |
+| 1.5–2× | 70 % |
+| 1–1.5× | 80 % |
+| 0.5–1× | 90 % |
+| < 0.5× | MaxSoC |
+
+---
+
+### Was ist der Unterschied zwischen Ladestärke, min/max Ladestärke?
+
+| Helfer | Wann aktiv | Beschreibung |
+|---|---|---|
+| `akkusteuerung_ladestaerke_soll` | Modus "Schnell Laden" | Feste Ziel-Ladestärke für den manuellen Modus |
+| _0.2C Laden_ (kein Helfer) | Modus "0.2C Laden" | Ladeleistung wird vom Hardware-Adapter automatisch aus der Batteriekapazität berechnet (0,2 × Kapazität) |
+| `akkusteuerung_min_ladestaerke` | Immer (Dynamisch-Betrieb) | Untere Grenze, die der WR nie unterschreiten soll |
+| `akkusteuerung_max_ladestaerke` | Immer (Dynamisch-Betrieb) | Obere Grenze – wird durch dynamische Ladestärke weiter begrenzt |
+| `sensor.akkusteuerung_dynamische_ladestaerke` | Immer (Dynamisch-Betrieb) | Automatisch berechneter Sollwert (SoC + Temperatur) |
+
+Empfehlung: Min auf `0`, Max auf z.B. `5000`, dann übernimmt die dynamische Berechnung die Feinsteuerung.

--- a/opti_mapping.example.yaml
+++ b/opti_mapping.example.yaml
@@ -1,0 +1,230 @@
+# =============================================================================
+# opti_mapping.example.yaml — Canonical-Mapping: Beispiel-Datei (öffentlich)
+# =============================================================================
+# Diese Datei als Vorlage kopieren nach: packages/opti_mapping.yaml
+# Dann alle DEIN_*-Platzhalter durch echte Entitäts-IDs ersetzen.
+#
+# Einheiten-Konventionen (verbindlich für Paket-2+-Komponenten):
+#   Preise:   ct/kWh  (EUR→ct wird NUR HIER ×100 normalisiert — nicht downstream)
+#   Leistung: W       (Watt, im Sensor-Namen als _w)
+#   Energie:  kWh     (im Sensor-Namen als _kwh)
+#
+# Vorzeichen-Konventionen:
+#   opti_grid_export_w    >= 0  (positiv = Einspeisung ins Netz)
+#   opti_battery_power_w  += laden  (positiv = Batterie lädt)
+#
+# Jeder Sensor hat:
+#   unique_id: opti_mapping_<name>
+#   name: "Opti …" → HA leitet daraus sensor.opti_<name> ab
+#   availability: prüft ob die Pflicht-Quelle verfügbar ist
+# =============================================================================
+
+template:
+  - sensor:
+
+      # -----------------------------------------------------------------------
+      # 1. Batterie SoC (%)
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_soc
+        name: "Opti SoC"
+        unit_of_measurement: "%"
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEIN_SOC') }}"
+        state: "{{ states('sensor.DEIN_SOC') | float(0) }}"
+
+      # -----------------------------------------------------------------------
+      # 2. Batterie-Temperatur (°C) — optional
+      # availability immer true; falls kein Sensor vorhanden, gilt 20 °C als
+      # neutraler Default (keine Abregelung wegen fehlender Temperatur).
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_battery_temp
+        name: "Opti Battery Temp"
+        unit_of_measurement: "°C"
+        state_class: measurement
+        availability: "{{ true }}"
+        state: "{{ states('sensor.DEIN_BATTERIE_TEMP') | float(20) }}"
+
+      # -----------------------------------------------------------------------
+      # 3. Batterie-Nennkapazität (kWh)
+      # Quelle liefert kWh → direkt übernehmen:
+      #   state: "{{ states('sensor.DEIN_BATTERIE_KAPAZITAET') | float(0) }}"
+      # Quelle liefert Wh → durch 1000 teilen (z.B. SMA batterie_nennkapazitaet
+      # in Wh — typisch 12800 Wh = 12,8 kWh):
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_battery_capacity_kwh
+        name: "Opti Battery Capacity kWh"
+        unit_of_measurement: "kWh"
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEIN_BATTERIE_KAPAZITAET') }}"
+        # Quelle in Wh → /1000 (SMA-Standard):
+        state: "{{ states('sensor.DEIN_BATTERIE_KAPAZITAET') | float(0) / 1000 }}"
+        # Quelle direkt in kWh (auskommentieren und obige Zeile entfernen):
+        # state: "{{ states('sensor.DEIN_BATTERIE_KAPAZITAET') | float(0) }}"
+
+      # -----------------------------------------------------------------------
+      # 4. PV-Leistung (W) — Wechselrichter AC-Ausgangsleistung
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_pv_power_w
+        name: "Opti PV Power W"
+        unit_of_measurement: "W"
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEIN_PV_POWER') }}"
+        state: "{{ states('sensor.DEIN_PV_POWER') | float(0) }}"
+
+      # -----------------------------------------------------------------------
+      # 5. PV-Erzeugung (W) — DC-Eingangsleistung / Gesamterzeugung
+      # Bei manchen Anlagen identisch mit opti_pv_power_w (gleiche Quelle möglich).
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_pv_generation_w
+        name: "Opti PV Generation W"
+        unit_of_measurement: "W"
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEIN_PV_GENERATION') }}"
+        state: "{{ states('sensor.DEIN_PV_GENERATION') | float(0) }}"
+
+      # -----------------------------------------------------------------------
+      # 6. Netz-Einspeisung (W) — IMMER >= 0 (positiv = Einspeisung ins Netz)
+      #
+      # Vorzeichen-Rezept:
+      #   Quelle positiv = Einspeisung (SMA, Fronius etc.):
+      #     state: "{{ [0, states('sensor.DEIN_GRID_EXPORT') | float(0)] | max }}"
+      #   Quelle positiv = Netzbezug (Einspeisung ist negativ):
+      #     state: "{{ [0, states('sensor.DEIN_GRID_EXPORT') | float(0) * -1] | max }}"
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_grid_export_w
+        name: "Opti Grid Export W"
+        unit_of_measurement: "W"
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEIN_GRID_EXPORT') }}"
+        # Standard: Quelle positiv = Einspeisung → auf >= 0 clippen
+        state: "{{ [0, states('sensor.DEIN_GRID_EXPORT') | float(0)] | max }}"
+        # Alternative: Quelle positiv = Netzbezug (Einspeisung negativ) → Vorzeichen drehen:
+        # state: "{{ [0, states('sensor.DEIN_GRID_EXPORT') | float(0) * -1] | max }}"
+
+      # -----------------------------------------------------------------------
+      # 7. Hausverbrauch (W)
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_house_consumption_w
+        name: "Opti House Consumption W"
+        unit_of_measurement: "W"
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEIN_HAUSVERBRAUCH') }}"
+        state: "{{ states('sensor.DEIN_HAUSVERBRAUCH') | float(0) }}"
+
+      # -----------------------------------------------------------------------
+      # 8. Aktueller Strompreis (ct/kWh)
+      # Quelle liefert EUR/kWh → ×100 = ct/kWh (Normalisierung NUR HIER)
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_price_current_ct_kwh
+        name: "Opti Price Current ct kWh"
+        unit_of_measurement: "ct/kWh"
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEIN_STROMPREIS') }}"
+        state: "{{ states('sensor.DEIN_STROMPREIS') | float(0) * 100 }}"
+
+      # -----------------------------------------------------------------------
+      # 9. Preis-Reihe (state = aktueller Preis in ct/kWh;
+      #    Attribute today/tomorrow = Listen in ct/kWh)
+      # Quelle: sensor.DEIN_PREIS_REIHE mit Attributen 'today'/'tomorrow'.
+      # Items dürfen Zahlen ODER Dicts mit Schlüssel 'total'/'price'/'value' sein.
+      # 'tomorrow' fehlt/leer → leere Liste [], kein Fehler.
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_price_series
+        name: "Opti Price Series"
+        unit_of_measurement: "ct/kWh"
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEIN_PREIS_REIHE') }}"
+        state: "{{ states('sensor.DEIN_PREIS_REIHE') | float(0) * 100 }}"
+        attributes:
+          today: >
+            {% set arr = state_attr('sensor.DEIN_PREIS_REIHE', 'today') %}
+            {% set ns = namespace(o=[]) %}
+            {% if arr is iterable and arr is not string %}
+              {% for it in arr %}
+                {% set p = it.get('total', it.get('price', it.get('value'))) if it is mapping else it %}
+                {% set p = p | float(none) %}
+                {% if p is not none %}{% set ns.o = ns.o + [p * 100] %}{% endif %}
+              {% endfor %}
+            {% endif %}
+            {{ ns.o }}
+          tomorrow: >
+            {% set arr = state_attr('sensor.DEIN_PREIS_REIHE', 'tomorrow') %}
+            {% set ns = namespace(o=[]) %}
+            {% if arr is iterable and arr is not string %}
+              {% for it in arr %}
+                {% set p = it.get('total', it.get('price', it.get('value'))) if it is mapping else it %}
+                {% set p = p | float(none) %}
+                {% if p is not none %}{% set ns.o = ns.o + [p * 100] %}{% endif %}
+              {% endfor %}
+            {% endif %}
+            {{ ns.o }}
+
+      # -----------------------------------------------------------------------
+      # 10. PV-Prognose heute (kWh)
+      # Attribut estimate10: P10-Schätzung (pessimistischer Wert für Worst-Case-Planung)
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_forecast_today_kwh
+        name: "Opti Forecast Today kWh"
+        unit_of_measurement: "kWh"
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEIN_SOLCAST_HEUTE') }}"
+        state: "{{ states('sensor.DEIN_SOLCAST_HEUTE') | float(0) }}"
+        attributes:
+          estimate10: "{{ state_attr('sensor.DEIN_SOLCAST_HEUTE', 'estimate10') | float(0) }}"
+
+      # -----------------------------------------------------------------------
+      # 11. PV-Prognose morgen (kWh)
+      # Attribut estimate10: P10-Schätzung (pessimistischer Wert für Worst-Case-Planung)
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_forecast_tomorrow_kwh
+        name: "Opti Forecast Tomorrow kWh"
+        unit_of_measurement: "kWh"
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEIN_SOLCAST_MORGEN') }}"
+        state: "{{ states('sensor.DEIN_SOLCAST_MORGEN') | float(0) }}"
+        attributes:
+          estimate10: "{{ state_attr('sensor.DEIN_SOLCAST_MORGEN', 'estimate10') | float(0) }}"
+
+      # -----------------------------------------------------------------------
+      # 12. PV-Prognose verbleibend heute (kWh) — einfacher Skalar-Alias
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_forecast_remaining_today_kwh
+        name: "Opti Forecast Remaining Today kWh"
+        unit_of_measurement: "kWh"
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEIN_SOLCAST_VERBLEIBEND') }}"
+        state: "{{ states('sensor.DEIN_SOLCAST_VERBLEIBEND') | float(0) }}"
+
+      # -----------------------------------------------------------------------
+      # 13. Batterie-Leistung (W) — += laden (positiv = Batterie lädt)
+      #
+      # AKTIVER DEFAULT: SMA (2 separate Sensoren für Laden/Entladen, beide >= 0)
+      #   battery_power = charge - discharge  →  positiv = laden
+      #   Debug-Attribut zeigt an, ob gleichzeitig geladen und entladen wird.
+      #
+      # ALTERNATIVE (Huawei / Einzel-Sensor, auskommentiert):
+      #   Manche WR liefern einen einzigen signierten Sensor.
+      #   Konvention muss +=laden sein:
+      #     Quelle positiv = laden  → direkt übernehmen
+      #     Quelle positiv = entladen → * -1 (Vorzeichen drehen)
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_battery_power_w
+        name: "Opti Battery Power W"
+        unit_of_measurement: "W"
+        state_class: measurement
+        # SMA: beide Quellen müssen verfügbar sein
+        availability: >
+          {{ has_value('sensor.DEIN_CHARGE_W') and has_value('sensor.DEIN_DISCHARGE_W') }}
+        # SMA: Netto-Ladeleistung = Laden minus Entladen (positiv = laden)
+        state: >
+          {{ states('sensor.DEIN_CHARGE_W') | float(0) - states('sensor.DEIN_DISCHARGE_W') | float(0) }}
+        attributes:
+          simultaneous_charge_discharge: >
+            {{ states('sensor.DEIN_CHARGE_W') | float(0) > 0 and
+               states('sensor.DEIN_DISCHARGE_W') | float(0) > 0 }}
+        # --- ALTERNATIVE: Huawei / Einzel-Sensor ---
+        # (diese 3 Zeilen einkommentieren und den SMA-Block oben auskommentieren)
+        # availability: "{{ has_value('sensor.DEIN_BATT_POWER') }}"
+        # state: "{{ states('sensor.DEIN_BATT_POWER') | float(0) }}"
+        # Falls Quelle positiv = entladen (Laden ist negativ) → Vorzeichen drehen:
+        # state: "{{ states('sensor.DEIN_BATT_POWER') | float(0) * -1 }}"

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -89,16 +89,17 @@ template:
           {{ (([ [tomorrow / denom_kwh, 1]|min, 0]|max) * 10)|round(0)|int }}
 
       # -----------------------------------------------------------------------
-      # 3. Ziel-SoC (%) — übersetzt aus akku_target_soc_intelligent
-      #    (SMA-Templates Z.206-305). Logik/Schwellen unverändert,
-      #    nur Quell-Entitäten getauscht. Trace-Attribute beibehalten.
+      # 3. Ziel-SoC (%) — abgeleitet aus akku_target_soc_intelligent (SMA-Templates
+      #    Z.206-305): Quell-Entitäten auf opti_*-Layer getauscht. Stufen-Kennlinie 1:1,
+      #    aber Flatter-Fix: 0.25-Quantisierung → echte Schmitt-Hysterese (siehe state).
       #    Kapazität: opti_battery_capacity_kwh ist BEREITS kWh (Quelle war Wh/1000).
       # -----------------------------------------------------------------------
       - unique_id: opti_target_soc
         name: "Opti Target SoC"
         unit_of_measurement: "%"
         state_class: measurement
-        # Ratio auf 0.25-Schritte gerundet → verhindert Flattern an Stufengrenzen (Hysterese)
+        # Ziel-SoC mit echter Schmitt-Hysterese auf den Ratio-Stufen: Attribut 'level'
+        # haelt die vorige Stufe, bis ratio die Grenze um die Marge m ueber-/unterschreitet.
         availability: >
           {{ has_value('sensor.opti_battery_capacity_kwh') and
              has_value('sensor.opti_forecast_remaining_today_kwh') }}
@@ -122,16 +123,25 @@ template:
             {% endif %}
 
             {% set net_available = [0, restproduktion - (hausverbrauch / 1000 * remaining_hours)] | max %}
-            {# Auf 0.25-Schritte runden → verhindert Flattern an Stufengrenzen #}
-            {% set ratio = (((net_available / cap_kwh) * 4) | round(0)) / 4 %}
-
-            {% if   ratio >= 3.0 %} {% set target = 50 %}
-            {% elif ratio >= 2.0 %} {% set target = 60 %}
-            {% elif ratio >= 1.5 %} {% set target = 70 %}
-            {% elif ratio >= 1.0 %} {% set target = 80 %}
-            {% elif ratio >= 0.5 %} {% set target = 90 %}
-            {% else %}              {% set target = max_soc %}
-            {% endif %}
+            {% set ratio = net_available / cap_kwh %}
+            {# Schmitt-Hysterese: vorige Stufe (Attribut 'level') halten, bis ratio die
+               naechste Grenze um die Marge m ueber-/unterschreitet. Ersetzt die alte
+               0.25-Quantisierung (= nur Kink-Verschiebung, kein Halteband).
+               bounds = die alten effektiven 0.25-Rundungsgrenzen (akkuschonende Kennlinie
+               1:1 wiederhergestellt), jetzt als Hysterese-Zentren mit Marge m. #}
+            {% set m = 0.10 %}
+            {% set bounds  = [0.375, 0.875, 1.375, 1.875, 2.875] %}
+            {% set targets = [max_soc, 90, 80, 70, 60, 50] %}
+            {% set plain = bounds | select('le', ratio) | list | count %}
+            {% set prev = this.attributes.get('level', plain) | int(plain) %}
+            {% set ns = namespace(l = prev) %}
+            {% for _ in bounds %}
+              {% if ns.l < 5 and ratio >= bounds[ns.l] + m %}{% set ns.l = ns.l + 1 %}{% endif %}
+            {% endfor %}
+            {% for _ in bounds %}
+              {% if ns.l > 0 and ratio < bounds[ns.l - 1] - m %}{% set ns.l = ns.l - 1 %}{% endif %}
+            {% endfor %}
+            {% set target = targets[ns.l] %}
 
             {{ [min_soc, [max_soc, target] | min] | max | round(0) }}
           {% endif %}
@@ -153,14 +163,53 @@ template:
                 {% set remaining_hours = 6 %}
               {% endif %}
               {% set net_available = [0, restproduktion - (hausverbrauch / 1000 * remaining_hours)] | max %}
-              {% set ratio = (((net_available / cap_kwh) * 4) | round(0)) / 4 %}
-              {% if   ratio >= 3.0 %}ratio>=3.0 → 50%
-              {% elif ratio >= 2.0 %}ratio>=2.0 → 60%
-              {% elif ratio >= 1.5 %}ratio>=1.5 → 70%
-              {% elif ratio >= 1.0 %}ratio>=1.0 → 80%
-              {% elif ratio >= 0.5 %}ratio>=0.5 → 90%
-              {% else %}ratio<0.5 → maxsoc
+              {% set ratio = net_available / cap_kwh %}
+              {% set m = 0.10 %}
+              {% set bounds  = [0.375, 0.875, 1.375, 1.875, 2.875] %}
+              {% set targets = [max_soc, 90, 80, 70, 60, 50] %}
+              {% set plain = bounds | select('le', ratio) | list | count %}
+              {% set prev = this.attributes.get('level', plain) | int(plain) %}
+              {% set ns = namespace(l = prev) %}
+              {% for _ in bounds %}
+                {% if ns.l < 5 and ratio >= bounds[ns.l] + m %}{% set ns.l = ns.l + 1 %}{% endif %}
+              {% endfor %}
+              {% for _ in bounds %}
+                {% if ns.l > 0 and ratio < bounds[ns.l - 1] - m %}{% set ns.l = ns.l - 1 %}{% endif %}
+              {% endfor %}
+              ratio={{ ratio | round(2) }} plain={{ plain }} → level {{ ns.l }} → {{ targets[ns.l] | round(0) }}%{{ ' (gehalten)' if ns.l != plain else '' }}
+            {% endif %}
+          # Hysterese-Speicher: aktuelle Stufe (0=maxsoc … 5=50%). Wird via this.attributes
+          # zurueckgelesen; state + branch berechnen dieselbe Schmitt-Logik unabhaengig.
+          level: >
+            {% set cap_kwh        = states('sensor.opti_battery_capacity_kwh') | float(12.8) %}
+            {% set restproduktion = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
+            {% set hausverbrauch  = states('sensor.opti_house_consumption_w') | float(1500) %}
+            {% set max_soc        = states('input_number.maxsoc') | float(95) %}
+            {% set netzladen      = states('input_boolean.hausakku_aus_netz_laden') %}
+            {% if netzladen == 'on' %}
+              0
+            {% else %}
+              {% set sunset_time = state_attr('sun.sun', 'next_setting') %}
+              {% if sunset_time %}
+                {% set remaining_hours = (sunset_time | as_datetime - now()).total_seconds() / 3600 %}
+                {% set remaining_hours = [0.5, [12, remaining_hours] | min] | max %}
+              {% else %}
+                {% set remaining_hours = 6 %}
               {% endif %}
+              {% set net_available = [0, restproduktion - (hausverbrauch / 1000 * remaining_hours)] | max %}
+              {% set ratio = net_available / cap_kwh %}
+              {% set m = 0.10 %}
+              {% set bounds = [0.375, 0.875, 1.375, 1.875, 2.875] %}
+              {% set plain = bounds | select('le', ratio) | list | count %}
+              {% set prev = this.attributes.get('level', plain) | int(plain) %}
+              {% set ns = namespace(l = prev) %}
+              {% for _ in bounds %}
+                {% if ns.l < 5 and ratio >= bounds[ns.l] + m %}{% set ns.l = ns.l + 1 %}{% endif %}
+              {% endfor %}
+              {% for _ in bounds %}
+                {% if ns.l > 0 and ratio < bounds[ns.l - 1] - m %}{% set ns.l = ns.l - 1 %}{% endif %}
+              {% endfor %}
+              {{ ns.l }}
             {% endif %}
           ratio: >
             {% set cap_kwh        = states('sensor.opti_battery_capacity_kwh') | float(12.8) %}
@@ -174,7 +223,7 @@ template:
               {% set remaining_hours = 6 %}
             {% endif %}
             {% set net_available = [0, restproduktion - (hausverbrauch / 1000 * remaining_hours)] | max %}
-            {{ (((net_available / cap_kwh) * 4) | round(0)) / 4 }}
+            {{ (net_available / cap_kwh) | round(3) }}
           net_available_kwh: >
             {% set restproduktion = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
             {% set hausverbrauch  = states('sensor.opti_house_consumption_w') | float(1500) %}
@@ -433,6 +482,7 @@ template:
           {% set p_e = price in ['VERY_CHEAP','CHEAP','NORMAL','EXPENSIVE'] %}
           {% set p_n = price in ['VERY_CHEAP','CHEAP','NORMAL'] %}
           {% set p_c = price in ['VERY_CHEAP','CHEAP'] %}
+          {% set H = 3 %}
           {% if soc >= 0 and soc < minsoc %}Akku nur Laden
           {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}Akku nur Laden
           {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}Akku nur Laden
@@ -442,8 +492,8 @@ template:
           {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}Akku Dynamisch
           {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}Akku Dynamisch
           {%- elif soc > 99 %}Akku Dynamisch
-          {%- elif soc > minsoc and soc < target and day %}Akku Dynamisch
-          {%- elif soc > target %}Akku nur Entladen
+          {%- elif soc > minsoc and soc < target - H and day %}Akku Dynamisch
+          {%- elif soc > target + H %}Akku nur Entladen
           {%- elif soc >= 0 %}Akku Dynamisch
           {%- else %}unbekannt{% endif %}
         attributes:
@@ -467,6 +517,7 @@ template:
             {% set p_e = price in ['VERY_CHEAP','CHEAP','NORMAL','EXPENSIVE'] %}
             {% set p_n = price in ['VERY_CHEAP','CHEAP','NORMAL'] %}
             {% set p_c = price in ['VERY_CHEAP','CHEAP'] %}
+            {% set H = 3 %}
             {% if soc >= 0 and soc < minsoc %}MinSOC-Schutz (SoC<{{minsoc}})
             {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}SOC<20 Prognose (heute+morgen schlecht)
             {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}SOC<75 Prognose (Preis bis NORMAL)
@@ -476,8 +527,8 @@ template:
             {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}70% Ueberschuss (tag)
             {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}AC Ueberschuss (tag)
             {%- elif soc > 99 %}Akku voll
-            {%- elif soc > minsoc and soc < target and day %}dyn bis Ziel (tag)
-            {%- elif soc > target %}ueber Ziel-SoC
+            {%- elif soc > minsoc and soc < target - H and day %}dyn bis Ziel (tag)
+            {%- elif soc > target + H %}ueber Ziel-SoC
             {%- elif soc >= 0 %}Default (Nacht/keine Aktion)
             {%- else %}opti_soc fehlt{% endif %}
           ist_modus: "{{ states('input_select.akkusteuerung_modus') }}"

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -83,7 +83,10 @@ template:
         availability: >
           {{ has_value('sensor.opti_forecast_tomorrow_kwh') and has_value('sensor.opti_house_consumption_w') }}
         state: >
-          {{ ((([ [states('sensor.opti_forecast_tomorrow_kwh')|float(0), state_attr('sensor.opti_forecast_tomorrow_kwh','estimate10')|float(states('sensor.opti_forecast_tomorrow_kwh')|float(0))]|min / ((states('sensor.opti_house_consumption_w')|float(400)*24/1000)), 1]|min), 0]|max) * 10)|round(0)|int }}
+          {% set verbrauch_w = [states('sensor.opti_house_consumption_w')|float(400), 1]|max %}
+          {% set denom_kwh = verbrauch_w * 24 / 1000 %}
+          {% set tomorrow = [states('sensor.opti_forecast_tomorrow_kwh')|float(0), state_attr('sensor.opti_forecast_tomorrow_kwh','estimate10')|float(states('sensor.opti_forecast_tomorrow_kwh')|float(0))]|min %}
+          {{ ((([ tomorrow / denom_kwh, 1]|min), 0]|max) * 10)|round(0)|int }}
 
       # -----------------------------------------------------------------------
       # 3. Ziel-SoC (%) — übersetzt aus akku_target_soc_intelligent
@@ -216,7 +219,7 @@ template:
           {% set temp      = states('sensor.opti_battery_temp') | float(25) %}
           {% set cap       = states('sensor.opti_battery_capacity_kwh') | float(12.8) * 1000 %}
           {% set max_helper = states('input_number.akkusteuerung_max_ladestaerke') | float(3000) %}
-          {% set score     = states('sensor.opti_forecast_score') | int(0) %}
+          {% set score     = states('sensor.opti_forecast_score') | int(10) %} {# fehlender Forecast → konservativ/schonend (Score≥5 = GENTLE) #}
 
           {% if temp >= 50 or temp <= -5 %}
             0
@@ -328,15 +331,15 @@ template:
 
       # -----------------------------------------------------------------------
       # 6. Mindestentladepreis (ct/kWh) — VERBATIM, BEWUSST KEIN float(0):
-      #    fehlende Helfer dürfen nicht zu 0 € werden (Fail-safe).
-      #    ladepreis ist EUR → *100 = ct.
+      #    fehlende Helfer dürfen nicht zu 0 ct werden (Fail-safe).
+      #    ladepreis ist ct/kWh → direkt addieren (kein ×100).
       # -----------------------------------------------------------------------
       - unique_id: opti_mindestentladepreis_ct_kwh
         name: "Opti Mindestentladepreis ct kWh"
         unit_of_measurement: ct/kWh
         availability: "{{ has_value('input_number.ladepreis') and has_value('input_number.mindestpreisdifferenz_lade_entladepreis') }}"
-        state: "{{ (states('input_number.ladepreis')|float * 100 + states('input_number.mindestpreisdifferenz_lade_entladepreis')|float)|round(2) }}"
-        attributes: { ladepreis_ct: "{{ (states('input_number.ladepreis')|float*100)|round(2) }}", differenz_ct: "{{ states('input_number.mindestpreisdifferenz_lade_entladepreis')|float|round(2) }}" }
+        state: "{{ (states('input_number.ladepreis')|float + states('input_number.mindestpreisdifferenz_lade_entladepreis')|float)|round(2) }}"
+        attributes: { ladepreis_ct: "{{ (states('input_number.ladepreis')|float)|round(2) }}", differenz_ct: "{{ states('input_number.mindestpreisdifferenz_lade_entladepreis')|float|round(2) }}" }
 
       # -----------------------------------------------------------------------
       # 7. Akku-Restlaufzeit (h) — übersetzt aus house_battery_runtime_raw

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -330,16 +330,17 @@ template:
             {{ ns.c }}
 
       # -----------------------------------------------------------------------
-      # 6. Mindestentladepreis (ct/kWh) — VERBATIM, BEWUSST KEIN float(0):
+      # 6. Mindestentladepreis (ct/kWh) — BEWUSST KEIN float(0):
       #    fehlende Helfer dürfen nicht zu 0 ct werden (Fail-safe).
-      #    ladepreis ist ct/kWh → direkt addieren (kein ×100).
+      #    ladepreis UND mindestpreisdifferenz sind in EUR/kWh (Live-Konvention,
+      #    z.B. 0.306 / 0.08) → beide ×100 nach ct. (Live-validiert: 38.6 ct.)
       # -----------------------------------------------------------------------
       - unique_id: opti_mindestentladepreis_ct_kwh
         name: "Opti Mindestentladepreis ct kWh"
         unit_of_measurement: ct/kWh
         availability: "{{ has_value('input_number.ladepreis') and has_value('input_number.mindestpreisdifferenz_lade_entladepreis') }}"
-        state: "{{ (states('input_number.ladepreis')|float + states('input_number.mindestpreisdifferenz_lade_entladepreis')|float)|round(2) }}"
-        attributes: { ladepreis_ct: "{{ (states('input_number.ladepreis')|float)|round(2) }}", differenz_ct: "{{ states('input_number.mindestpreisdifferenz_lade_entladepreis')|float|round(2) }}" }
+        state: "{{ ((states('input_number.ladepreis')|float + states('input_number.mindestpreisdifferenz_lade_entladepreis')|float) * 100)|round(2) }}"
+        attributes: { ladepreis_ct: "{{ (states('input_number.ladepreis')|float * 100)|round(2) }}", differenz_ct: "{{ (states('input_number.mindestpreisdifferenz_lade_entladepreis')|float * 100)|round(2) }}" }
 
       # -----------------------------------------------------------------------
       # 7. Akku-Restlaufzeit (h) — übersetzt aus house_battery_runtime_raw

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -16,6 +16,18 @@
 # =============================================================================
 
 template:
+  - binary_sensor:
+
+      # -----------------------------------------------------------------------
+      # 0. Wintermodus-/Winterladefreigabe (Gate) — fail-open
+      #    Default ON. Solange kein optionaler Quell-Sensor (z. B. Sommermodus-
+      #    Gate) gemappt ist, gilt true (Laden erlaubt). Wird in den Winter-/
+      #    Prognose-Ladeblöcken der Strategie-Automation als Gate genutzt.
+      # -----------------------------------------------------------------------
+      - unique_id: opti_winter_charging_allowed
+        name: "Opti Winter Charging Allowed"
+        state: "{{ true }}"
+
   - sensor:
 
       # -----------------------------------------------------------------------

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -454,9 +454,9 @@ template:
       # 8. Strategie-Vorschau (Soll-Modus, READ-ONLY) — spiegelt die Entscheidungs-
       #    kette aus automations/opti_strategie.yaml, OHNE zu steuern. Vergleich
       #    Soll (state) vs Ist (input_select.akkusteuerung_modus, Attribut ist_modus).
-      #    ANNAHME: Toggles opti_prognose_netzladen / opti_pv_ueberschuss_ladung = on
-      #    (existieren noch nicht → hier als aktiviert angenommen). Bei Änderung der
-      #    Strategie-Zweige MUSS dieser Sensor mitgespiegelt werden.
+      #    Toggles opti_prognose_netzladen / opti_pv_ueberschuss_ladung existieren live
+      #    und werden hier wie in der echten Strategie gelesen (siehe unten). Bei
+      #    Änderung der Strategie-Zweige MUSS dieser Sensor mitgespiegelt werden.
       # -----------------------------------------------------------------------
       - unique_id: opti_strategie_vorschau
         name: "Opti Strategie Vorschau"
@@ -538,4 +538,4 @@ template:
           score_morgen: "{{ states('sensor.opti_forecast_score_tomorrow') }}"
           price_level: "{{ states('sensor.opti_price_level') }}"
           tag: "{{ is_state('sun.sun','above_horizon') }}"
-          annahme: "Toggles opti_prognose_netzladen/opti_pv_ueberschuss_ladung als 'on' angenommen (existieren noch nicht)"
+          annahme: "Toggles opti_prognose_netzladen/opti_pv_ueberschuss_ladung existieren live, aktueller Zustand: prognose={{ states('input_boolean.opti_prognose_netzladen') }}, ueberschuss={{ states('input_boolean.opti_pv_ueberschuss_ladung') }}"

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -1,0 +1,386 @@
+# =============================================================================
+# opti_derived.yaml — Abgeleitete Opti-Entscheidungs-Sensoren (Paket 2)
+# =============================================================================
+# Diese Sensoren konsumieren AUSSCHLIESSLICH die Canonical-Mapping-Sensoren
+# (sensor.opti_*) aus Paket 1, die input_number-Helfer und sun.sun.
+# KEINE rohen Hardware-Refs (WR-Seriennummern, Preis-/Prognose-Rohsensoren etc.).
+#
+# Einheiten (verbindlich): Preise ct/kWh, Leistung W, Energie kWh.
+# Vorzeichen: opti_grid_export_w >= 0 (Einspeisung); opti_battery_power_w += laden.
+#
+# Übersetzte Sensoren (target_soc / charge_power / price_level / runtime) bilden
+# die Logik der SMA-Template-Quellsensoren 1:1 nach —
+# nur die Quell-Entitäten wurden gegen die opti_*-Aliase getauscht. Schwellen
+# und Stufen sind unverändert. Bewusste Ausnahme: opti_charge_power_w ersetzt die
+# Forecast-Label-Verzweigung der Quelle durch opti_forecast_score-Bänder.
+# =============================================================================
+
+template:
+  - sensor:
+
+      # -----------------------------------------------------------------------
+      # 1. Forecast Score heute (0-10) — PV-Fit-Bewertung des Resttages
+      # -----------------------------------------------------------------------
+      - unique_id: opti_forecast_score
+        name: "Opti Forecast Score"
+        state_class: measurement
+        availability: >
+          {{ has_value('sensor.opti_forecast_remaining_today_kwh')
+             and has_value('sensor.opti_forecast_today_kwh')
+             and has_value('sensor.opti_battery_capacity_kwh')
+             and has_value('sensor.opti_soc') }}
+        state: >
+          {% set median = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
+          {% set p10 = state_attr('sensor.opti_forecast_today_kwh','estimate10') | float(median) %}
+          {% set remaining = [median, p10] | min %}
+          {% set cap = states('sensor.opti_battery_capacity_kwh') | float(0) %}
+          {% set needed = cap * (1 - (states('sensor.opti_soc') | float(0))/100) %}
+          {% set sunset = state_attr('sun.sun','next_setting') %}
+          {% set h = ((sunset | as_datetime - now()).total_seconds()/3600) if sunset else 0 %}
+          {% set verbrauch = states('sensor.opti_house_consumption_w') | float(400) / 1000 * ([h,0]|max) %}
+          {% set surplus = [remaining - verbrauch, 0] | max %}
+          {% if h <= 0 %}0{% elif needed <= 0 %}10
+          {% else %}{{ (([surplus / needed, 1]|min) * 10) | round(0) | int }}{% endif %}
+        attributes:
+          remaining_kwh: "{{ [states('sensor.opti_forecast_remaining_today_kwh')|float(0), state_attr('sensor.opti_forecast_today_kwh','estimate10')|float(states('sensor.opti_forecast_remaining_today_kwh')|float(0))]|min|round(2) }}"
+          needed_full_kwh: "{{ (states('sensor.opti_battery_capacity_kwh')|float(0) * (1-(states('sensor.opti_soc')|float(0))/100))|round(2) }}"
+          hours_to_sunset: "{{ (((state_attr('sun.sun','next_setting')|as_datetime - now()).total_seconds()/3600) if state_attr('sun.sun','next_setting') else 0)|round(1) }}"
+          pv_surplus_kwh: >
+            {% set median = states('sensor.opti_forecast_remaining_today_kwh')|float(0) %}
+            {% set rem = [median, state_attr('sensor.opti_forecast_today_kwh','estimate10')|float(median)]|min %}
+            {% set sunset = state_attr('sun.sun','next_setting') %}
+            {% set h = ((sunset|as_datetime - now()).total_seconds()/3600) if sunset else 0 %}
+            {{ [rem - (states('sensor.opti_house_consumption_w')|float(400)/1000*([h,0]|max)), 0]|max|round(2) }}
+          ueberschuss_ueber_voll_kwh: >
+            {% set median = states('sensor.opti_forecast_remaining_today_kwh')|float(0) %}
+            {% set rem = [median, state_attr('sensor.opti_forecast_today_kwh','estimate10')|float(median)]|min %}
+            {% set sunset = state_attr('sun.sun','next_setting') %}
+            {% set h = ((sunset|as_datetime - now()).total_seconds()/3600) if sunset else 0 %}
+            {% set surplus = [rem - (states('sensor.opti_house_consumption_w')|float(400)/1000*([h,0]|max)),0]|max %}
+            {% set needed = states('sensor.opti_battery_capacity_kwh')|float(0)*(1-(states('sensor.opti_soc')|float(0))/100) %}
+            {{ [surplus - needed, 0]|max|round(2) }}
+          reason: >
+            {{ 'Nacht' if (state_attr('sun.sun','next_setting') is none) else ('Akku voll' if (states('sensor.opti_battery_capacity_kwh')|float(0)*(1-(states('sensor.opti_soc')|float(0))/100)) <= 0 else 'PV-Fit') }}
+
+      # -----------------------------------------------------------------------
+      # 2. Forecast Score morgen (0-10) — PV-Fit der Morgen-Prognose
+      # -----------------------------------------------------------------------
+      - unique_id: opti_forecast_score_tomorrow
+        name: "Opti Forecast Score Tomorrow"
+        state_class: measurement
+        availability: >
+          {{ has_value('sensor.opti_forecast_tomorrow_kwh') and has_value('sensor.opti_house_consumption_w') }}
+        state: >
+          {{ ((([ [states('sensor.opti_forecast_tomorrow_kwh')|float(0), state_attr('sensor.opti_forecast_tomorrow_kwh','estimate10')|float(states('sensor.opti_forecast_tomorrow_kwh')|float(0))]|min / ((states('sensor.opti_house_consumption_w')|float(400)*24/1000)), 1]|min), 0]|max) * 10)|round(0)|int }}
+
+      # -----------------------------------------------------------------------
+      # 3. Ziel-SoC (%) — übersetzt aus akku_target_soc_intelligent
+      #    (SMA-Templates Z.206-305). Logik/Schwellen unverändert,
+      #    nur Quell-Entitäten getauscht. Trace-Attribute beibehalten.
+      #    Kapazität: opti_battery_capacity_kwh ist BEREITS kWh (Quelle war Wh/1000).
+      # -----------------------------------------------------------------------
+      - unique_id: opti_target_soc
+        name: "Opti Target SoC"
+        unit_of_measurement: "%"
+        state_class: measurement
+        # Ratio auf 0.25-Schritte gerundet → verhindert Flattern an Stufengrenzen (Hysterese)
+        availability: >
+          {{ has_value('sensor.opti_battery_capacity_kwh') and
+             has_value('sensor.opti_forecast_remaining_today_kwh') }}
+        state: >
+          {% set cap_kwh        = states('sensor.opti_battery_capacity_kwh') | float(12.8) %}
+          {% set restproduktion = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
+          {% set hausverbrauch  = states('sensor.opti_house_consumption_w') | float(1500) %}
+          {% set max_soc        = states('input_number.maxsoc') | float(95) %}
+          {% set min_soc        = states('input_number.minsoc') | float(10) %}
+          {% set netzladen      = states('input_boolean.hausakku_aus_netz_laden') %}
+
+          {% if netzladen == 'on' %}
+            {{ max_soc | round(0) }}
+          {% else %}
+            {% set sunset_time = state_attr('sun.sun', 'next_setting') %}
+            {% if sunset_time %}
+              {% set remaining_hours = (sunset_time | as_datetime - now()).total_seconds() / 3600 %}
+              {% set remaining_hours = [0.5, [12, remaining_hours] | min] | max %}
+            {% else %}
+              {% set remaining_hours = 6 %}
+            {% endif %}
+
+            {% set net_available = [0, restproduktion - (hausverbrauch / 1000 * remaining_hours)] | max %}
+            {# Auf 0.25-Schritte runden → verhindert Flattern an Stufengrenzen #}
+            {% set ratio = (((net_available / cap_kwh) * 4) | round(0)) / 4 %}
+
+            {% if   ratio >= 3.0 %} {% set target = 50 %}
+            {% elif ratio >= 2.0 %} {% set target = 60 %}
+            {% elif ratio >= 1.5 %} {% set target = 70 %}
+            {% elif ratio >= 1.0 %} {% set target = 80 %}
+            {% elif ratio >= 0.5 %} {% set target = 90 %}
+            {% else %}              {% set target = max_soc %}
+            {% endif %}
+
+            {{ [min_soc, [max_soc, target] | min] | max | round(0) }}
+          {% endif %}
+        attributes:
+          branch: >
+            {% set cap_kwh        = states('sensor.opti_battery_capacity_kwh') | float(12.8) %}
+            {% set restproduktion = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
+            {% set hausverbrauch  = states('sensor.opti_house_consumption_w') | float(1500) %}
+            {% set max_soc        = states('input_number.maxsoc') | float(95) %}
+            {% set netzladen      = states('input_boolean.hausakku_aus_netz_laden') %}
+            {% if netzladen == 'on' %}
+              netzladen → maxsoc
+            {% else %}
+              {% set sunset_time = state_attr('sun.sun', 'next_setting') %}
+              {% if sunset_time %}
+                {% set remaining_hours = (sunset_time | as_datetime - now()).total_seconds() / 3600 %}
+                {% set remaining_hours = [0.5, [12, remaining_hours] | min] | max %}
+              {% else %}
+                {% set remaining_hours = 6 %}
+              {% endif %}
+              {% set net_available = [0, restproduktion - (hausverbrauch / 1000 * remaining_hours)] | max %}
+              {% set ratio = (((net_available / cap_kwh) * 4) | round(0)) / 4 %}
+              {% if   ratio >= 3.0 %}ratio>=3.0 → 50%
+              {% elif ratio >= 2.0 %}ratio>=2.0 → 60%
+              {% elif ratio >= 1.5 %}ratio>=1.5 → 70%
+              {% elif ratio >= 1.0 %}ratio>=1.0 → 80%
+              {% elif ratio >= 0.5 %}ratio>=0.5 → 90%
+              {% else %}ratio<0.5 → maxsoc
+              {% endif %}
+            {% endif %}
+          ratio: >
+            {% set cap_kwh        = states('sensor.opti_battery_capacity_kwh') | float(12.8) %}
+            {% set restproduktion = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
+            {% set hausverbrauch  = states('sensor.opti_house_consumption_w') | float(1500) %}
+            {% set sunset_time = state_attr('sun.sun', 'next_setting') %}
+            {% if sunset_time %}
+              {% set remaining_hours = (sunset_time | as_datetime - now()).total_seconds() / 3600 %}
+              {% set remaining_hours = [0.5, [12, remaining_hours] | min] | max %}
+            {% else %}
+              {% set remaining_hours = 6 %}
+            {% endif %}
+            {% set net_available = [0, restproduktion - (hausverbrauch / 1000 * remaining_hours)] | max %}
+            {{ (((net_available / cap_kwh) * 4) | round(0)) / 4 }}
+          net_available_kwh: >
+            {% set restproduktion = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
+            {% set hausverbrauch  = states('sensor.opti_house_consumption_w') | float(1500) %}
+            {% set sunset_time = state_attr('sun.sun', 'next_setting') %}
+            {% if sunset_time %}
+              {% set remaining_hours = (sunset_time | as_datetime - now()).total_seconds() / 3600 %}
+              {% set remaining_hours = [0.5, [12, remaining_hours] | min] | max %}
+            {% else %}
+              {% set remaining_hours = 6 %}
+            {% endif %}
+            {{ [0, restproduktion - (hausverbrauch / 1000 * remaining_hours)] | max | round(2) }}
+          remaining_hours: >
+            {% set sunset_time = state_attr('sun.sun', 'next_setting') %}
+            {% if sunset_time %}
+              {% set h = (sunset_time | as_datetime - now()).total_seconds() / 3600 %}
+              {{ ([0.5, [12, h] | min] | max) | round(1) }}
+            {% else %}
+              6.0
+            {% endif %}
+
+      # -----------------------------------------------------------------------
+      # 4. Dynamische Ladestärke (W) — übersetzt aus
+      #    akku_dynamische_ladestaerke_akku (SMA-Templates Z.82-136).
+      #    SoC-Taper, Temp-Schutz und Deckel UNVERÄNDERT übernommen.
+      #    BEWUSSTE ÄNDERUNG: Forecast-Label-Verzweigung der Quelle → opti_forecast_score-Bänder
+      #      score <=1 → aggressiv (vormals Kritisch/Mangelhaft)
+      #      score 2-4 → moderat   (vormals Ausreichend)
+      #      score >=5 → schonend  (vormals Gut/Optimal/Hervorragend)
+      #    Kapazität: opti_battery_capacity_kwh ist kWh → *1000 für Watt-Ausgabe
+      #      (Quelle nutzte Wh direkt: C-Rate * Wh = W).
+      # -----------------------------------------------------------------------
+      - unique_id: opti_charge_power_w
+        name: "Opti Charge Power W"
+        unit_of_measurement: W
+        state_class: measurement
+        availability: >
+          {{ has_value('sensor.opti_soc') and
+             has_value('sensor.opti_battery_temp') and
+             has_value('sensor.opti_battery_capacity_kwh') }}
+        state: >
+          {% set soc       = states('sensor.opti_soc') | float(50) %}
+          {% set temp      = states('sensor.opti_battery_temp') | float(25) %}
+          {% set cap       = states('sensor.opti_battery_capacity_kwh') | float(12.8) * 1000 %}
+          {% set max_helper = states('input_number.akkusteuerung_max_ladestaerke') | float(3000) %}
+          {% set score     = states('sensor.opti_forecast_score') | int(0) %}
+
+          {% if temp >= 50 or temp <= -5 %}
+            0
+          {% else %}
+            {# Temperaturdrosselung bei Extremen #}
+            {% if   temp >= 45 %} {% set temp_faktor = 0.5 %}
+            {% elif temp <=  0 %} {% set temp_faktor = 0.25 %}
+            {% else %}            {% set temp_faktor = 1.0 %}
+            {% endif %}
+
+            {# SOC-Stufen: prognoseabhängig verschoben (Score-Bänder) #}
+            {% if score <= 1 %}
+              {# Schlechter Tag: aggressiv laden, Grenzen hoch #}
+              {% if   soc < 40 %} {% set c = cap * 0.40 %}
+              {% elif soc < 70 %} {% set c = cap * 0.30 %}
+              {% elif soc < 90 %} {% set c = cap * 0.20 %}
+              {% elif soc < 97 %} {% set c = cap * 0.10 %}
+              {% else %}          {% set c = cap * 0.05 %}
+              {% endif %}
+            {% elif score <= 4 %}
+              {# Mittelmäßiger Tag: moderat #}
+              {% if   soc < 35 %} {% set c = cap * 0.35 %}
+              {% elif soc < 65 %} {% set c = cap * 0.25 %}
+              {% elif soc < 87 %} {% set c = cap * 0.15 %}
+              {% elif soc < 97 %} {% set c = cap * 0.08 %}
+              {% else %}          {% set c = cap * 0.05 %}
+              {% endif %}
+            {% else %}
+              {# Guter Tag: schonend, viel Zeit #}
+              {% if   soc < 30 %} {% set c = cap * 0.30 %}
+              {% elif soc < 60 %} {% set c = cap * 0.20 %}
+              {% elif soc < 85 %} {% set c = cap * 0.15 %}
+              {% elif soc < 97 %} {% set c = cap * 0.08 %}
+              {% else %}          {% set c = cap * 0.05 %}
+              {% endif %}
+            {% endif %}
+
+            {{ ([c * temp_faktor, max_helper] | min) | round(0) }}
+          {% endif %}
+
+      # -----------------------------------------------------------------------
+      # 5. Preisniveau (Enum) — übersetzt aus strompreis_niveau
+      #    (SMA-Templates Z.362-423). Perzentil-Bänder unverändert.
+      #    current → opti_price_current_ct_kwh; Reihe → opti_price_series today/tomorrow
+      #    (bereits ct/kWh-Listen). <4 Werte → NORMAL.
+      # -----------------------------------------------------------------------
+      - unique_id: opti_price_level
+        name: "Opti Price Level"
+        icon: mdi:cash-clock
+        availability: >
+          {{ has_value('sensor.opti_price_current_ct_kwh') }}
+        state: >
+          {% set current = states('sensor.opti_price_current_ct_kwh') | float(0) %}
+          {% set ns = namespace(prices=[]) %}
+          {% for key in ['today', 'tomorrow'] %}
+            {% set arr = state_attr('sensor.opti_price_series', key) %}
+            {% if arr is iterable and arr is not string %}
+              {% for it in arr %}
+                {% if it is mapping %}
+                  {% set p = it.get('total', it.get('price', it.get('value'))) %}
+                {% else %}
+                  {% set p = it %}
+                {% endif %}
+                {% set p = p | float(none) %}
+                {% if p is not none %}
+                  {% set ns.prices = ns.prices + [p] %}
+                {% endif %}
+              {% endfor %}
+            {% endif %}
+          {% endfor %}
+          {% set prices = ns.prices %}
+          {% if prices | length >= 4 %}
+            {% set below = prices | select('le', current) | list | length %}
+            {% set pct = below / (prices | length) %}
+            {% if   pct < 0.20 %}{% set level = 'VERY_CHEAP' %}
+            {% elif pct < 0.40 %}{% set level = 'CHEAP' %}
+            {% elif pct < 0.60 %}{% set level = 'NORMAL' %}
+            {% elif pct < 0.80 %}{% set level = 'EXPENSIVE' %}
+            {% else %}{% set level = 'VERY_EXPENSIVE' %}
+            {% endif %}
+            {{ level }}
+          {% else %}
+            NORMAL
+          {% endif %}
+        attributes:
+          perzentil: >
+            {% set current = states('sensor.opti_price_current_ct_kwh') | float(0) %}
+            {% set ns = namespace(prices=[]) %}
+            {% for key in ['today', 'tomorrow'] %}
+              {% set arr = state_attr('sensor.opti_price_series', key) %}
+              {% if arr is iterable and arr is not string %}
+                {% for it in arr %}
+                  {% if it is mapping %}{% set p = it.get('total', it.get('price', it.get('value'))) %}{% else %}{% set p = it %}{% endif %}
+                  {% set p = p | float(none) %}
+                  {% if p is not none %}{% set ns.prices = ns.prices + [p] %}{% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {% set prices = ns.prices %}
+            {% if prices | length >= 4 %}{{ ((prices | select('le', current) | list | length) / (prices | length) * 100) | round(1) }}{% else %}none{% endif %}
+          aktueller_preis: "{{ states('sensor.opti_price_current_ct_kwh') | float(0) }}"
+          anzahl_preise: >
+            {% set ns = namespace(c=0) %}
+            {% for key in ['today', 'tomorrow'] %}
+              {% set arr = state_attr('sensor.opti_price_series', key) %}
+              {% if arr is iterable and arr is not string %}{% set ns.c = ns.c + (arr | list | length) %}{% endif %}
+            {% endfor %}
+            {{ ns.c }}
+
+      # -----------------------------------------------------------------------
+      # 6. Mindestentladepreis (ct/kWh) — VERBATIM, BEWUSST KEIN float(0):
+      #    fehlende Helfer dürfen nicht zu 0 € werden (Fail-safe).
+      #    ladepreis ist EUR → *100 = ct.
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mindestentladepreis_ct_kwh
+        name: "Opti Mindestentladepreis"
+        unit_of_measurement: ct/kWh
+        availability: "{{ has_value('input_number.ladepreis') and has_value('input_number.mindestpreisdifferenz_lade_entladepreis') }}"
+        state: "{{ (states('input_number.ladepreis')|float * 100 + states('input_number.mindestpreisdifferenz_lade_entladepreis')|float)|round(2) }}"
+        attributes: { ladepreis_ct: "{{ (states('input_number.ladepreis')|float*100)|round(2) }}", differenz_ct: "{{ states('input_number.mindestpreisdifferenz_lade_entladepreis')|float|round(2) }}" }
+
+      # -----------------------------------------------------------------------
+      # 7. Akku-Restlaufzeit (h) — übersetzt aus house_battery_runtime_raw
+      #    (SMA-Templates Z.25-80). Logik/Schwellen unverändert, nur Quellen:
+      #      Kapazität (Wh/1000) → opti_battery_capacity_kwh (bereits kWh, kein /1000)
+      #      SoC → opti_soc; PV-Gate → opti_pv_power_w; Entladelast → opti_house_consumption_w
+      #      MinSOC/MaxSOC → input_number.minsoc / input_number.maxsoc
+      # -----------------------------------------------------------------------
+      - unique_id: opti_runtime_h
+        name: "Opti Runtime H"
+        unit_of_measurement: "hours"
+        state_class: measurement
+        availability: >
+          {{ has_value('sensor.opti_soc') and
+             has_value('sensor.opti_battery_capacity_kwh') and
+             has_value('sensor.opti_house_consumption_w') }}
+        state: >
+          {% set soc = states('sensor.opti_soc') %}
+          {% set capacity_kwh_raw = states('sensor.opti_battery_capacity_kwh') %}
+          {% set house_w = states('sensor.opti_house_consumption_w') %}
+          {% set pv_power = states('sensor.opti_pv_power_w') %}
+          {% set min_soc_helper = states('input_number.minsoc') %}
+          {% set max_soc_helper = states('input_number.maxsoc') %}
+
+          {% if soc not in ['unavailable', 'unknown', None] and
+                capacity_kwh_raw not in ['unavailable', 'unknown', None] and
+                house_w not in ['unavailable', 'unknown', None] and
+                pv_power not in ['unavailable', 'unknown', None] %}
+
+            {% set soc_value = soc|float(0) %}
+            {% set capacity_kwh = capacity_kwh_raw|float(0) %}
+            {% set pv_power_value = pv_power|float(0) %}
+
+            {% set min_soc = min_soc_helper|float(10) if min_soc_helper not in ['unavailable', 'unknown', None] else 10 %}
+            {% set max_soc = max_soc_helper|float(95) if max_soc_helper not in ['unavailable', 'unknown', None] else 95 %}
+            {% set min_soc_safe = max(0, min(100, min_soc)) %}
+            {% set max_soc_safe = max(min_soc_safe, min(100, max_soc)) %}
+
+            {% if pv_power_value < 100 %}
+              {% set discharge_power_kw = house_w|float(0) / 1000 %}
+
+              {% set current_soc_in_range = max(min_soc_safe, min(max_soc_safe, soc_value)) %}
+              {% set available_soc_percentage = (current_soc_in_range - min_soc_safe) / (max_soc_safe - min_soc_safe) * 100 if max_soc_safe > min_soc_safe else 0 %}
+              {% set available_energy_kwh = (available_soc_percentage / 100) * capacity_kwh %}
+
+              {% if discharge_power_kw > 0 and available_energy_kwh > 0 %}
+                {% set runtime_hours = available_energy_kwh / discharge_power_kw %}
+                {{ [runtime_hours, 24]|min|round(2) }}
+              {% elif discharge_power_kw == 0 %}
+                999
+              {% else %}
+                0
+              {% endif %}
+            {% else %}
+              0
+            {% endif %}
+          {% else %}
+            unavailable
+          {% endif %}

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -388,8 +388,8 @@ template:
         name: "Opti Mindestentladepreis ct kWh"
         unit_of_measurement: ct/kWh
         availability: "{{ has_value('input_number.ladepreis') and has_value('input_number.mindestpreisdifferenz_lade_entladepreis') }}"
-        state: "{{ ((states('input_number.ladepreis')|float + states('input_number.mindestpreisdifferenz_lade_entladepreis')|float) * 100)|round(2) }}"
-        attributes: { ladepreis_ct: "{{ (states('input_number.ladepreis')|float * 100)|round(2) }}", differenz_ct: "{{ (states('input_number.mindestpreisdifferenz_lade_entladepreis')|float * 100)|round(2) }}" }
+        state: "{{ ((states('input_number.ladepreis')|float(0) + states('input_number.mindestpreisdifferenz_lade_entladepreis')|float(0)) * 100)|round(2) }}"
+        attributes: { ladepreis_ct: "{{ (states('input_number.ladepreis')|float(0) * 100)|round(2) }}", differenz_ct: "{{ (states('input_number.mindestpreisdifferenz_lade_entladepreis')|float(0) * 100)|round(2) }}" }
 
       # -----------------------------------------------------------------------
       # 7. Akku-Restlaufzeit (h) — übersetzt aus house_battery_runtime_raw

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -400,3 +400,91 @@ template:
           {% else %}
             unavailable
           {% endif %}
+
+      # -----------------------------------------------------------------------
+      # 8. Strategie-Vorschau (Soll-Modus, READ-ONLY) — spiegelt die Entscheidungs-
+      #    kette aus automations/opti_strategie.yaml, OHNE zu steuern. Vergleich
+      #    Soll (state) vs Ist (input_select.akkusteuerung_modus, Attribut ist_modus).
+      #    ANNAHME: Toggles opti_prognose_netzladen / opti_pv_ueberschuss_ladung = on
+      #    (existieren noch nicht → hier als aktiviert angenommen). Bei Änderung der
+      #    Strategie-Zweige MUSS dieser Sensor mitgespiegelt werden.
+      # -----------------------------------------------------------------------
+      - unique_id: opti_strategie_vorschau
+        name: "Opti Strategie Vorschau"
+        icon: mdi:eye-check
+        availability: "{{ has_value('sensor.opti_soc') and has_value('sensor.opti_battery_capacity_kwh') }}"
+        state: >
+          {% set soc = states('sensor.opti_soc')|float(-1) %}
+          {% set s = states('sensor.opti_forecast_score')|float(-1) %}
+          {% set st = states('sensor.opti_forecast_score_tomorrow')|float(-1) %}
+          {% set price = states('sensor.opti_price_level') %}
+          {% set target = states('sensor.opti_target_soc')|float(100) %}
+          {% set minsoc = states('input_number.minsoc')|float(10) %}
+          {% set day = is_state('sun.sun','above_horizon') %}
+          {% set prog = states('input_boolean.opti_prognose_netzladen') != 'off' %}
+          {% set ueb = states('input_boolean.opti_pv_ueberschuss_ladung') != 'off' %}
+          {% set win = states('binary_sensor.opti_winter_charging_allowed') != 'off' %}
+          {% set hv_s = has_value('sensor.opti_forecast_score') %}
+          {% set hv_st = has_value('sensor.opti_forecast_score_tomorrow') %}
+          {% set grid = states('sensor.opti_grid_export_w')|float(0) %}
+          {% set pv = states('sensor.opti_pv_power_w')|float(0) %}
+          {% set g70 = states('input_number.akkusteuerung_wr_70proz_ueberschuss_grenze')|float(999999) %}
+          {% set gac = states('input_number.akkusteuerung_wr_ac_ueberschuss_grenze')|float(999999) %}
+          {% set p_e = price in ['VERY_CHEAP','CHEAP','NORMAL','EXPENSIVE'] %}
+          {% set p_n = price in ['VERY_CHEAP','CHEAP','NORMAL'] %}
+          {% set p_c = price in ['VERY_CHEAP','CHEAP'] %}
+          {% if soc >= 0 and soc < minsoc %}Akku nur Laden
+          {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}Akku nur Laden
+          {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}Akku nur Laden
+          {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}Akku nur Laden
+          {%- elif prog and hv_s and soc < 15 and s < 3 and p_e %}Akku nur Laden
+          {%- elif prog and hv_s and soc < 45 and s < 3 and p_c %}Akku nur Laden
+          {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}Akku Dynamisch
+          {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}Akku Dynamisch
+          {%- elif soc > 99 %}Akku Dynamisch
+          {%- elif soc > minsoc and soc < target and day %}Akku Dynamisch
+          {%- elif soc > target %}Akku nur Entladen
+          {%- elif soc >= 0 %}Akku Dynamisch
+          {%- else %}unbekannt{% endif %}
+        attributes:
+          grund: >
+            {% set soc = states('sensor.opti_soc')|float(-1) %}
+            {% set s = states('sensor.opti_forecast_score')|float(-1) %}
+            {% set st = states('sensor.opti_forecast_score_tomorrow')|float(-1) %}
+            {% set price = states('sensor.opti_price_level') %}
+            {% set target = states('sensor.opti_target_soc')|float(100) %}
+            {% set minsoc = states('input_number.minsoc')|float(10) %}
+            {% set day = is_state('sun.sun','above_horizon') %}
+            {% set prog = states('input_boolean.opti_prognose_netzladen') != 'off' %}
+            {% set ueb = states('input_boolean.opti_pv_ueberschuss_ladung') != 'off' %}
+            {% set win = states('binary_sensor.opti_winter_charging_allowed') != 'off' %}
+            {% set hv_s = has_value('sensor.opti_forecast_score') %}
+            {% set hv_st = has_value('sensor.opti_forecast_score_tomorrow') %}
+            {% set grid = states('sensor.opti_grid_export_w')|float(0) %}
+            {% set pv = states('sensor.opti_pv_power_w')|float(0) %}
+            {% set g70 = states('input_number.akkusteuerung_wr_70proz_ueberschuss_grenze')|float(999999) %}
+            {% set gac = states('input_number.akkusteuerung_wr_ac_ueberschuss_grenze')|float(999999) %}
+            {% set p_e = price in ['VERY_CHEAP','CHEAP','NORMAL','EXPENSIVE'] %}
+            {% set p_n = price in ['VERY_CHEAP','CHEAP','NORMAL'] %}
+            {% set p_c = price in ['VERY_CHEAP','CHEAP'] %}
+            {% if soc >= 0 and soc < minsoc %}MinSOC-Schutz (SoC<{{minsoc}})
+            {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}SOC<20 Prognose (heute+morgen schlecht)
+            {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}SOC<75 Prognose (Preis bis NORMAL)
+            {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}SOC<80 Wintermodus
+            {%- elif prog and hv_s and soc < 15 and s < 3 and p_e %}SOC<15 Notfall
+            {%- elif prog and hv_s and soc < 45 and s < 3 and p_c %}SOC<45 sehr guenstig
+            {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}70% Ueberschuss (tag)
+            {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}AC Ueberschuss (tag)
+            {%- elif soc > 99 %}Akku voll
+            {%- elif soc > minsoc and soc < target and day %}dyn bis Ziel (tag)
+            {%- elif soc > target %}ueber Ziel-SoC
+            {%- elif soc >= 0 %}Default (Nacht/keine Aktion)
+            {%- else %}opti_soc fehlt{% endif %}
+          ist_modus: "{{ states('input_select.akkusteuerung_modus') }}"
+          soc: "{{ states('sensor.opti_soc') }}"
+          ziel_soc: "{{ states('sensor.opti_target_soc') }}"
+          score_heute: "{{ states('sensor.opti_forecast_score') }}"
+          score_morgen: "{{ states('sensor.opti_forecast_score_tomorrow') }}"
+          price_level: "{{ states('sensor.opti_price_level') }}"
+          tag: "{{ is_state('sun.sun','above_horizon') }}"
+          annahme: "Toggles opti_prognose_netzladen/opti_pv_ueberschuss_ladung als 'on' angenommen (existieren noch nicht)"

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -332,7 +332,7 @@ template:
       #    ladepreis ist EUR → *100 = ct.
       # -----------------------------------------------------------------------
       - unique_id: opti_mindestentladepreis_ct_kwh
-        name: "Opti Mindestentladepreis"
+        name: "Opti Mindestentladepreis ct kWh"
         unit_of_measurement: ct/kWh
         availability: "{{ has_value('input_number.ladepreis') and has_value('input_number.mindestpreisdifferenz_lade_entladepreis') }}"
         state: "{{ (states('input_number.ladepreis')|float * 100 + states('input_number.mindestpreisdifferenz_lade_entladepreis')|float)|round(2) }}"

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -86,7 +86,7 @@ template:
           {% set verbrauch_w = [states('sensor.opti_house_consumption_w')|float(400), 1]|max %}
           {% set denom_kwh = verbrauch_w * 24 / 1000 %}
           {% set tomorrow = [states('sensor.opti_forecast_tomorrow_kwh')|float(0), state_attr('sensor.opti_forecast_tomorrow_kwh','estimate10')|float(states('sensor.opti_forecast_tomorrow_kwh')|float(0))]|min %}
-          {{ ((([ tomorrow / denom_kwh, 1]|min), 0]|max) * 10)|round(0)|int }}
+          {{ (([ [tomorrow / denom_kwh, 1]|min, 0]|max) * 10)|round(0)|int }}
 
       # -----------------------------------------------------------------------
       # 3. Ziel-SoC (%) — übersetzt aus akku_target_soc_intelligent

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -195,6 +195,19 @@ counter:
     step: 1
     icon: mdi:counter
 
+# --- Write-on-Change-Helfer für ha-modbus-akku-adapter (ab v1.2.0) ---
+# Werden vom Adapter automatisch gepflegt, nicht manuell befüllen.
+input_text:
+  akkusteuerung_modbus_letzter_schreibwert:
+    name: "Akkusteuerung Modbus Letzter Schreibwert"
+    max: 255
+
+input_datetime:
+  akkusteuerung_modbus_letzter_schreibzeitpunkt:
+    name: "Akkusteuerung Modbus Letzter Schreibzeitpunkt"
+    has_date: true
+    has_time: true
+
 # =============================================================================
 # MANUELL ÜBER DIE HA-OBERFLÄCHE ANLEGEN (nicht per YAML möglich)
 # =============================================================================

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -181,9 +181,9 @@ input_boolean:
 
   # --- Opti Canonical-Layer Gates (Paket 3) ---
   opti_prognose_netzladen:
-    name: "Opti Prognose-Netzladen erlauben"
-    # Gate für die prognosebasierten SOC-Ladeblöcke (lädt bei schlechter
-    # Prognose + günstigem Preis aus dem Netz). Default an.
+    name: "Opti Reserve-halten bei schlechter Prognose"
+    # Gate für die prognosebasierten "Akku nur Laden"-Blöcke (Entladesperre +
+    # nur PV-Überschuss bei schlechter Prognose; KEIN Netzladen). Default an.
     icon: mdi:transmission-tower
     initial: "on"
 

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -177,6 +177,20 @@ input_boolean:
     name: "Speicher Eco Netzladen"
     icon: mdi:leaf
 
+  # --- Opti Canonical-Layer Gates (Paket 3) ---
+  opti_prognose_netzladen:
+    name: "Opti Prognose-Netzladen erlauben"
+    # Gate für die prognosebasierten SOC-Ladeblöcke (lädt bei schlechter
+    # Prognose + günstigem Preis aus dem Netz). Default an.
+    icon: mdi:transmission-tower
+    initial: "on"
+
+  opti_pv_ueberschuss_ladung:
+    name: "Opti PV-Überschussladung erlauben"
+    # Gate für die PV-/AC-Überschussblöcke (Akku Dynamisch). Default an.
+    icon: mdi:solar-power
+    initial: "on"
+
 counter:
   tage_seit_akku100:
     name: "Tage seit Akku 100%"

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -135,24 +135,26 @@ input_number:
   ladepreis:
     name: "Akku Ladepreis (Referenz)"
     # Wird automatisch vom aktuellen Strompreis befüllt wenn Netzladen aktiv ist.
-    # Stellt den Preis dar, zu dem der Akku zuletzt netzgeladen wurde (ct/kWh).
+    # Stellt den Preis dar, zu dem der Akku zuletzt netzgeladen wurde (EUR/kWh).
+    # EINHEIT EUR/kWh (z.B. 0.306). opti_mindestentladepreis_ct_kwh rechnet ×100 nach ct.
     min: 0
-    max: 100
-    step: 0.01
-    unit_of_measurement: ct/kWh
+    max: 1
+    step: 0.001
+    unit_of_measurement: EUR/kWh
     mode: box
     icon: mdi:currency-eur
 
   mindestpreisdifferenz_lade_entladepreis:
     name: "Mindestpreisdifferenz Laden/Entladen"
     # Mindest-Marge zwischen Ladepreis und aktuellem Preis, ab der Entladen wirtschaftlich ist.
-    # Beispiel: Ladepreis 20 ct + Differenz 5 ct → Entladen erst ab 25 ct/kWh sinnvoll.
-    # Empfehlung: 3–8 ct/kWh (deckt Verluste + Akkuverschleiß ab)
+    # Beispiel: Ladepreis 0.20 € + Differenz 0.05 € → Entladen erst ab 0.25 €/kWh sinnvoll.
+    # Empfehlung: 0.03–0.08 EUR/kWh (deckt Verluste + Akkuverschleiß ab)
+    # EINHEIT EUR/kWh (z.B. 0.08). opti_mindestentladepreis_ct_kwh rechnet ×100 nach ct.
     min: 0
-    max: 30
-    step: 0.5
-    initial: 5
-    unit_of_measurement: ct/kWh
+    max: 0.3
+    step: 0.005
+    initial: 0.05
+    unit_of_measurement: EUR/kWh
     mode: box
     icon: mdi:cash-plus
 

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -35,14 +35,9 @@ input_number:
     mode: box
     icon: mdi:battery-arrow-up
 
-  akkusteuerung_02c_ladestaerke:
-    name: "Akkusteuerung 0.2C Ladestärke"
-    min: 100
-    max: 10000
-    step: 100
-    unit_of_measurement: W
-    mode: box
-    icon: mdi:battery-arrow-up-outline
+  # Hinweis: Für den Modus "Akku 0.2C Laden" ist kein Ladestärke-Helfer mehr nötig.
+  # Der Hardware-Adapter (ha-modbus-akku-adapter) berechnet die 0.2C-Ladeleistung
+  # automatisch aus der Batterie-Nennkapazität (0,2 × Kapazität, Register 40187).
 
   akkusteuerung_min_ladestaerke:
     name: "Akkusteuerung Min Ladestärke"

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -135,7 +135,7 @@ input_number:
   ladepreis:
     name: "Akku Ladepreis (Referenz)"
     # Wird automatisch vom aktuellen Strompreis befüllt wenn Netzladen aktiv ist.
-    # Stellt den Preis dar, zu dem der Akku zuletzt netzgeladen wurde.
+    # Stellt den Preis dar, zu dem der Akku zuletzt netzgeladen wurde (ct/kWh).
     min: 0
     max: 100
     step: 0.01

--- a/packages/sma_statistik.yaml
+++ b/packages/sma_statistik.yaml
@@ -4,51 +4,50 @@
 # Gleitende Mittelwerte für Batterielast und Hausverbrauch.
 # Diese Sensoren werden von den Template-Sensoren in sma_templates.yaml genutzt.
 #
-# ⚙️  ANPASSEN:
-#   entity_id bei jedem sensor auf deinen tatsächlichen Sensor setzen:
-#
-#   Batterielast:    Typisch sensor.sn_SERIENNUMMER_battery_power
-#                   (negativer Wert = Entladung, positiver = Ladung)
-#   Haus-Verbrauch:  Dein Gesamt-Verbrauchssensor (W)
+# Eingänge kommen vom Canonical-Layer (opti_mapping.yaml):
+#   Batterielast:    sensor.opti_battery_power_w
+#                   (positiver Wert = Laden, negativer = Entladung)
+#   Haus-Verbrauch:  sensor.opti_house_consumption_w
+# Kein manuelles Mapping hier nötig.
 # =============================================================================
 
 sensor:
   - platform: statistics
     name: "House Battery Load 30 mins"
     unique_id: house_battery_load_30_mins
-    entity_id: sensor.DEINE_BATTERIE_LAST     # ⚙️  anpassen
+    entity_id: sensor.opti_battery_power_w
     state_characteristic: mean
     max_age:
-      hours: 24
+      minutes: 30
     sampling_size: 180
     precision: 0
 
   - platform: statistics
     name: "House Stromverbrauch 30 min"
     unique_id: haus_stromverbrauch_30_min
-    entity_id: sensor.DEIN_STROMVERBRAUCH     # ⚙️  anpassen
+    entity_id: sensor.opti_house_consumption_w
     state_characteristic: mean
     max_age:
-      hours: 24
+      minutes: 30
     sampling_size: 180
     precision: 0
 
   - platform: statistics
     name: "Haus Battery Load 60 mins"
     unique_id: haus_battery_load_60_mins
-    entity_id: sensor.DEINE_BATTERIE_LAST     # ⚙️  anpassen
+    entity_id: sensor.opti_battery_power_w
     state_characteristic: mean
     max_age:
-      hours: 24
+      minutes: 60
     sampling_size: 360
     precision: 0
 
   - platform: statistics
     name: "Haus Stromverbrauch 60 min"
     unique_id: haus_stromverbrauch_60_min
-    entity_id: sensor.DEIN_STROMVERBRAUCH     # ⚙️  anpassen
+    entity_id: sensor.opti_house_consumption_w
     state_characteristic: mean
     max_age:
-      hours: 24
+      minutes: 60
     sampling_size: 360
     precision: 0


### PR DESCRIPTION
## Was

Aktualisiert die Querverweise auf den Schwester-Adapter [`ha-modbus-akku-adapter`](https://github.com/Optic00/ha-modbus-akku-adapter): Dieser berechnet die **0.2C-Ladeleistung jetzt automatisch aus der Batterie-Nennkapazität** (Register 40187) und liest den früheren Helfer `input_number.akkusteuerung_02c_ladestaerke` **nicht mehr** (Adapter-Release v1.1.0).

## Änderungen

- **`packages/sma_helpers.yaml`**: verwaisten Helfer `akkusteuerung_02c_ladestaerke` entfernt (kein Template/keine Automation im Strategie-Repo konsumiert ihn) → Erklär-Kommentar ergänzt.
- **`README.md`**: Helfer-Tabelle, Dashboard-Karte und Ladestärke-Erklär-Tabelle bereinigt; neue Zeile „0.2C Laden (kein Helfer)".

## Hinweis für bestehende Nutzer

Wer den alten `input_number.akkusteuerung_02c_ladestaerke`-Helfer angelegt hatte, kann ihn entfernen — der Adapter braucht ihn nicht mehr.

## Review

Codex read-only review: **APPROVE** · YAML valide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)