### PR TITLE
Fix: Strategie-Automation id/alias auf Live-Realität angeglichen

### DIFF
--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -1,10 +1,13 @@
-- id: "1757405050598"
-  alias: "Akku Lade- Entladesteuerung Opti 2.0"
+- id: "opti_canonical_strategie"
+  alias: "Akku Opti Strategie"
   description: >-
     Strategie auf dem Canonical-opti_*-Layer (Paket 3). Setzt ausschliesslich
     input_select.akkusteuerung_modus. Prognosebasierte SOC-Ladeblöcke
     (Score+Preis), PV-/AC-Überschussblöcke, MinSOC-Schutz und Cleanup.
     Quellen/Gates getauscht; aufgeschobene und arbitrage-basierte Zweige entfernt.
+    id/Alias sind der Live-Realität angeglichen (2026-07-01): id war zuvor eine
+    HA-generierte Zahl ohne Bedeutung, Alias hieß zuvor "Akku Lade-
+    Entladesteuerung Opti 2.0" bzw. live "Akku Opti Canonical (opti_*-Layer)".
   mode: single
   triggers:
     # Preisniveau (Enum) statt Tibber-Rohsensor

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -1,8 +1,8 @@
-# Strategie-Logik: Akku Lade- und Entladesteuerung Opti 2.0
+# Strategie-Logik: Akku Opti Strategie
 
 ## Überblick
 
-Die Automation `Akku Lade- Entladesteuerung Opti 2.0` trifft **ausschließlich Modus-Entscheidungen**.
+Die Automation `Akku Opti Strategie` trifft **ausschließlich Modus-Entscheidungen**.
 Sie schreibt einen Wert in `input_select.akkusteuerung_modus` — und nur das.
 Welche Hardware-Befehle dieser Modus am Wechselrichter/Speicher auslöst, steuert ein separater
 Hardware-Adapter (ein eigener Automatisierungszweig). Diese Trennung macht die Strategie-Logik

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -454,9 +454,9 @@ template:
       # 8. Strategie-Vorschau (Soll-Modus, READ-ONLY) — spiegelt die Entscheidungs-
       #    kette aus automations/opti_strategie.yaml, OHNE zu steuern. Vergleich
       #    Soll (state) vs Ist (input_select.akkusteuerung_modus, Attribut ist_modus).
-      #    ANNAHME: Toggles opti_prognose_netzladen / opti_pv_ueberschuss_ladung = on
-      #    (existieren noch nicht → hier als aktiviert angenommen). Bei Änderung der
-      #    Strategie-Zweige MUSS dieser Sensor mitgespiegelt werden.
+      #    Toggles opti_prognose_netzladen / opti_pv_ueberschuss_ladung existieren live
+      #    und werden hier wie in der echten Strategie gelesen (siehe unten). Bei
+      #    Änderung der Strategie-Zweige MUSS dieser Sensor mitgespiegelt werden.
       # -----------------------------------------------------------------------
       - unique_id: opti_strategie_vorschau
         name: "Opti Strategie Vorschau"
@@ -538,4 +538,4 @@ template:
           score_morgen: "{{ states('sensor.opti_forecast_score_tomorrow') }}"
           price_level: "{{ states('sensor.opti_price_level') }}"
           tag: "{{ is_state('sun.sun','above_horizon') }}"
-          annahme: "Toggles opti_prognose_netzladen/opti_pv_ueberschuss_ladung als 'on' angenommen (existieren noch nicht)"
+          annahme: "Toggles opti_prognose_netzladen/opti_pv_ueberschuss_ladung existieren live, aktueller Zustand: prognose={{ states('input_boolean.opti_prognose_netzladen') }}, ueberschuss={{ states('input_boolean.opti_pv_ueberschuss_ladung') }}"


### PR DESCRIPTION
## Summary
- Live-Automation-Alias + entity_id von `automation.akku_opti_canonical_opti_layer` auf `automation.akku_opti_strategie` / "Akku Opti Strategie" umgestellt (Entity-Registry-Rename, `id` unverändert — bewusst, um Ghost-Entity-Risiko zu vermeiden)
- Repo (`automations/opti_strategie.yaml`) auf denselben id/alias-Stand angeglichen
- Überraschung beim Recon: Toggle-Helfer (`opti_prognose_netzladen`/`opti_pv_ueberschuss_ladung`) liefen live bereits unter den Repo-Namen (als YAML-Package statt UI-Helfer) — kein Rename nötig
- Veralteten "Toggles existieren noch nicht"-Kommentar in `packages/opti_derived.yaml` korrigiert

## Test plan
- [x] Live-Rename durchgeführt, kein Ghost-Entity-Eintrag (alte entity_id sauber 404)
- [x] Dashboard-Check (Übersicht + Default): keine Referenzen auf alte entity_id
- [x] Konsistenz-Check (andere Automationen/Skripte/Packages): keine weiteren Referenzen
- [x] Automation-Traces nach Rename normal ("finished")
- [x] jinja2-Parse-Check (rekursive YAML-Struktur-Traversierung) auf alle geänderten Dateien: 0 Syntaxfehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)