### PR TITLE
Entlade-Peak-Allokation: Reserve-SoC, Peak-Leiter, Negativpreis- und Vorladeregel

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ den PV-Eigenverbrauch. Der Zielwert ergibt sich aus Solcast-Restprognose, Hausve
 Restzeit bis Sonnenuntergang, als Stufenkennlinie mit echter Hysterese (kein Flattern).
 → **[Herleitung in docs/strategie-logik.md](docs/strategie-logik.md#der-intelligente-ziel-soc--herzstück-der-akkuschonung)**
 
+**Entlade-Peak-Allokation** (`sensor.opti_peak_reserve_soc`, Peak-Leiter L1-L4)  
+Reserviert einen Teil des SoC gezielt für die kommenden teuersten Stunden, statt ihn
+undifferenziert an eine beliebige Stunde davor zu verlieren. Dazu kommen eine
+Negativpreis-Laderegel und eine spread-basierte Peak-Vorladeregel, beide mit
+selbstkorrigierender Ladefenster-Wahl.
+→ **[Details in docs/strategie-logik.md](docs/strategie-logik.md#entlade-peak-allokation-reserve-für-die-teuersten-stunden)**
+
 **Strategie** (`automations/opti_strategie.yaml`)  
 Entscheidet prognosebasiert, welcher Modus wann gilt: Lädt bei schlechter PV-Prognose aus
 dem Netz (gestaffelt nach SoC und Preisniveau), nutzt PV-Überschuss tagsüber und schützt

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -169,11 +169,12 @@
               state: "on"
             - condition: template
               value_template: >-
+                {% set stopband = 0 if is_state('input_select.akkusteuerung_modus', 'Akku Netzladen') else 3 %}
                 {{ has_value('sensor.opti_price_current_ct_kwh')
                    and has_value('sensor.opti_forecast_score')
                    and has_value('sensor.opti_soc')
                    and (states('sensor.opti_forecast_score') | float) < 3
-                   and (states('sensor.opti_soc') | float) < (states('input_number.maxsoc') | float(95))
+                   and (states('sensor.opti_soc') | float) < (states('input_number.maxsoc') | float(95) - stopband)
                    and (states('sensor.opti_price_current_ct_kwh') | float) < (states('input_number.opti_einspeiseverguetung_ct') | float(0)) }}
             - alias: "Ladefenster: kein guenstigeres Fenster vor der naechsten Spitze"
               condition: template
@@ -209,14 +210,63 @@
                 {% set avg = state_attr('sensor.opti_peak_reserve_soc', 'peak_preis_avg_ct') | float(none) %}
                 {% set spread_min = states('input_number.opti_netzlade_spread_ct') | float(10) %}
                 {% set minv = state_attr('sensor.opti_peak_reserve_soc', 'min_preis_vor_peak_ct') %}
+                {% set stopband = 0 if is_state('input_select.akkusteuerung_modus', 'Akku Netzladen') else 3 %}
                 {{ cur is not none and soc is not none and ges is not none and avg is not none
-                   and soc < ges
+                   and soc < ges - stopband
                    and (avg - cur) >= spread_min
                    and (minv is none or cur <= (minv | float(cur)) + 0.5) }}
           sequence:
             - action: input_select.select_option
               data:
                 option: "Akku Netzladen"
+              target:
+                entity_id: input_select.akkusteuerung_modus
+            - stop: "fertig"
+
+        # ---------------------------------------------------------------------
+        # Peak-Leiter L1/L2 (Entlade-Stufen der Entlade-Allokation): nur aktiv
+        # wenn das Gate an ist (= Peaks im Wiederauflade-Horizont, Reserve-
+        # Sensor gueltig). Die Entlade-Stufen der Leiter stehen VOR den alten
+        # Ladebloecken (Ben-Entscheidung 2026-07-02): Peak-Entladen schlaegt
+        # Winterladen; die Halte-Stufen L3/L4 bleiben hinter den Ladebloecken
+        # (guenstiges Laden schlaegt Halten).
+        # ---------------------------------------------------------------------
+        - alias: "Peak-Leiter L1 'nur Entladen': Preisspitze VERY_EXPENSIVE"
+          conditions:
+            - condition: state
+              entity_id: binary_sensor.opti_peak_reserve_aktiv
+              state: "on"
+            - condition: template
+              value_template: "{{ has_value('sensor.opti_soc') }}"
+            - condition: state
+              entity_id: sensor.opti_price_level
+              state: "VERY_EXPENSIVE"
+          sequence:
+            - action: input_select.select_option
+              data:
+                option: "Akku nur Entladen"
+              target:
+                entity_id: input_select.akkusteuerung_modus
+            - stop: "fertig"
+
+        - alias: "Peak-Leiter L2 'nur Entladen': EXPENSIVE, SoC ueber VE-Reserve"
+          conditions:
+            - condition: state
+              entity_id: binary_sensor.opti_peak_reserve_aktiv
+              state: "on"
+            - condition: state
+              entity_id: sensor.opti_price_level
+              state: "EXPENSIVE"
+            - condition: template
+              value_template: >-
+                {% set soc = states('sensor.opti_soc') | float(none) %}
+                {% set ve = state_attr('sensor.opti_peak_reserve_soc', 'reserve_ve_soc') | float(none) %}
+                {% set band = 5 if is_state('input_select.akkusteuerung_modus', 'Akku nur Laden') else 3 %}
+                {{ soc is not none and ve is not none and soc > ve + band }}
+          sequence:
+            - action: input_select.select_option
+              data:
+                option: "Akku nur Entladen"
               target:
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
@@ -496,53 +546,17 @@
             - stop: "fertig"
 
         # ---------------------------------------------------------------------
-        # Peak-Leiter (Entlade-Allokation): nur aktiv wenn das Gate an ist
-        # (= Peaks im Wiederauflade-Horizont, Reserve-Sensor gueltig).
-        # MUSS vor den Ziel-SoC-Optionen stehen, sonst verheizt "nur Entladen
-        # ueber Ziel-SoC" die Reserve bei NORMAL-Preis.
+        # Peak-Leiter L3/L4 (Halte-Stufen der Entlade-Allokation): nur aktiv
+        # wenn das Gate an ist (= Peaks im Wiederauflade-Horizont, Reserve-
+        # Sensor gueltig). MUSS vor den Ziel-SoC-Optionen stehen, sonst
+        # verheizt "nur Entladen ueber Ziel-SoC" die Reserve bei NORMAL-Preis.
+        # Die Entlade-Stufen der Leiter stehen VOR den alten Ladebloecken
+        # (Ben-Entscheidung 2026-07-02): Peak-Entladen schlaegt Winterladen;
+        # die Halte-Stufen L3/L4 bleiben hinter den Ladebloecken (guenstiges
+        # Laden schlaegt Halten).
         # Freigabeband asymmetrisch: aus dem Halten erst bei Reserve+5 wieder
         # freigeben, beim Entladen bis Reserve+3 runter (Modus = Gedaechtnis).
         # ---------------------------------------------------------------------
-        - alias: "Peak-Leiter L1 'nur Entladen': Preisspitze VERY_EXPENSIVE"
-          conditions:
-            - condition: state
-              entity_id: binary_sensor.opti_peak_reserve_aktiv
-              state: "on"
-            - condition: template
-              value_template: "{{ has_value('sensor.opti_soc') }}"
-            - condition: state
-              entity_id: sensor.opti_price_level
-              state: "VERY_EXPENSIVE"
-          sequence:
-            - action: input_select.select_option
-              data:
-                option: "Akku nur Entladen"
-              target:
-                entity_id: input_select.akkusteuerung_modus
-            - stop: "fertig"
-
-        - alias: "Peak-Leiter L2 'nur Entladen': EXPENSIVE, SoC ueber VE-Reserve"
-          conditions:
-            - condition: state
-              entity_id: binary_sensor.opti_peak_reserve_aktiv
-              state: "on"
-            - condition: state
-              entity_id: sensor.opti_price_level
-              state: "EXPENSIVE"
-            - condition: template
-              value_template: >-
-                {% set soc = states('sensor.opti_soc') | float(none) %}
-                {% set ve = state_attr('sensor.opti_peak_reserve_soc', 'reserve_ve_soc') | float(none) %}
-                {% set band = 5 if is_state('input_select.akkusteuerung_modus', 'Akku nur Laden') else 3 %}
-                {{ soc is not none and ve is not none and soc > ve + band }}
-          sequence:
-            - action: input_select.select_option
-              data:
-                option: "Akku nur Entladen"
-              target:
-                entity_id: input_select.akkusteuerung_modus
-            - stop: "fertig"
-
         - alias: "Peak-Leiter L3 'nur Laden' (halten): EXPENSIVE, Reserve fuer VERY_EXPENSIVE"
           conditions:
             - condition: state

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -112,6 +112,16 @@
       entity_id:
         - binary_sensor.opti_winter_charging_allowed
       id: "Winterladefreigabe geändert"
+    # Peak-Allokation: aktueller Preis (stuendlich) + Reserve-Sensor + Gate
+    - trigger: state
+      entity_id:
+        - sensor.opti_price_current_ct_kwh
+      id: "Preis geändert"
+    - trigger: state
+      entity_id:
+        - sensor.opti_peak_reserve_soc
+        - binary_sensor.opti_peak_reserve_aktiv
+      id: "Peak-Reserve geändert"
   conditions:
     - condition: state
       entity_id: input_boolean.akku_opti_automatik
@@ -146,6 +156,38 @@
               target:
                 entity_id: input_select.akkusteuerung_modus
             - stop: "MinSOC Schutz aktiv – Entladen gesperrt"
+
+        # Negativpreis-Laderegel mit Ladefenster-Wahl: Preis unter der eigenen
+        # Einspeiseverguetung (deckt negative Preise ab) + schlechte Prognose ->
+        # Netzladen lohnt immer. Fenster-Bedingung: nicht greedy laden, wenn vor
+        # der naechsten Preisspitze noch eine guenstigere Stunde kommt (Marge 0.5 ct).
+        # Fail-safe: Reserve-Sensor unavailable -> minv none -> einfacher EEG-Vergleich.
+        - alias: "Modus 'nur Laden' (Netzladen): Preis unter Einspeiseverguetung, Prognose schlecht (tag+nacht)"
+          conditions:
+            - condition: state
+              entity_id: input_boolean.opti_prognose_netzladen
+              state: "on"
+            - condition: template
+              value_template: >-
+                {{ has_value('sensor.opti_price_current_ct_kwh')
+                   and has_value('sensor.opti_forecast_score')
+                   and has_value('sensor.opti_soc')
+                   and (states('sensor.opti_forecast_score') | float) < 3
+                   and (states('sensor.opti_soc') | float) < (states('input_number.maxsoc') | float(95))
+                   and (states('sensor.opti_price_current_ct_kwh') | float) < (states('input_number.opti_einspeiseverguetung_ct') | float(0)) }}
+            - alias: "Ladefenster: kein guenstigeres Fenster vor der naechsten Spitze"
+              condition: template
+              value_template: >-
+                {% set cur = states('sensor.opti_price_current_ct_kwh') | float(0) %}
+                {% set minv = state_attr('sensor.opti_peak_reserve_soc', 'min_preis_vor_peak_ct') %}
+                {{ minv is none or cur <= (minv | float(cur)) + 0.5 }}
+          sequence:
+            - action: input_select.select_option
+              data:
+                option: "Akku nur Laden"
+              target:
+                entity_id: input_select.akkusteuerung_modus
+            - stop: "fertig"
 
         # Winter-/Prognose-Ladeblock (SOC < 20 %).
         # Quelle: heute+morgen schlecht → Score<3 (beide); Preis VERY_CHEAP..EXPENSIVE.

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -495,6 +495,107 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
 
+        # ---------------------------------------------------------------------
+        # Peak-Leiter (Entlade-Allokation): nur aktiv wenn das Gate an ist
+        # (= Peaks im Wiederauflade-Horizont, Reserve-Sensor gueltig).
+        # MUSS vor den Ziel-SoC-Optionen stehen, sonst verheizt "nur Entladen
+        # ueber Ziel-SoC" die Reserve bei NORMAL-Preis.
+        # Freigabeband asymmetrisch: aus dem Halten erst bei Reserve+5 wieder
+        # freigeben, beim Entladen bis Reserve+3 runter (Modus = Gedaechtnis).
+        # ---------------------------------------------------------------------
+        - alias: "Peak-Leiter L1 'nur Entladen': Preisspitze VERY_EXPENSIVE"
+          conditions:
+            - condition: state
+              entity_id: binary_sensor.opti_peak_reserve_aktiv
+              state: "on"
+            - condition: template
+              value_template: "{{ has_value('sensor.opti_soc') }}"
+            - condition: state
+              entity_id: sensor.opti_price_level
+              state: "VERY_EXPENSIVE"
+          sequence:
+            - action: input_select.select_option
+              data:
+                option: "Akku nur Entladen"
+              target:
+                entity_id: input_select.akkusteuerung_modus
+            - stop: "fertig"
+
+        - alias: "Peak-Leiter L2 'nur Entladen': EXPENSIVE, SoC ueber VE-Reserve"
+          conditions:
+            - condition: state
+              entity_id: binary_sensor.opti_peak_reserve_aktiv
+              state: "on"
+            - condition: state
+              entity_id: sensor.opti_price_level
+              state: "EXPENSIVE"
+            - condition: template
+              value_template: >-
+                {% set soc = states('sensor.opti_soc') | float(none) %}
+                {% set ve = state_attr('sensor.opti_peak_reserve_soc', 'reserve_ve_soc') | float(none) %}
+                {% set band = 5 if is_state('input_select.akkusteuerung_modus', 'Akku nur Laden') else 3 %}
+                {{ soc is not none and ve is not none and soc > ve + band }}
+          sequence:
+            - action: input_select.select_option
+              data:
+                option: "Akku nur Entladen"
+              target:
+                entity_id: input_select.akkusteuerung_modus
+            - stop: "fertig"
+
+        - alias: "Peak-Leiter L3 'nur Laden' (halten): EXPENSIVE, Reserve fuer VERY_EXPENSIVE"
+          conditions:
+            - condition: state
+              entity_id: binary_sensor.opti_peak_reserve_aktiv
+              state: "on"
+            - condition: state
+              entity_id: sensor.opti_price_level
+              state: "EXPENSIVE"
+            - condition: template
+              value_template: >-
+                {% set soc = states('sensor.opti_soc') | float(none) %}
+                {% set ve = state_attr('sensor.opti_peak_reserve_soc', 'reserve_ve_soc') | float(none) %}
+                {% set band = 5 if is_state('input_select.akkusteuerung_modus', 'Akku nur Laden') else 3 %}
+                {{ soc is not none and ve is not none and soc <= ve + band }}
+          sequence:
+            - action: input_select.select_option
+              data:
+                option: "Akku nur Laden"
+              target:
+                entity_id: input_select.akkusteuerung_modus
+            - stop: "fertig"
+
+        - alias: "Peak-Leiter L4 'nur Laden' (halten): Preis normal/billig, Reserve fuer Peaks"
+          conditions:
+            - condition: state
+              entity_id: binary_sensor.opti_peak_reserve_aktiv
+              state: "on"
+            - alias: "Preisniveau NORMAL oder billiger"
+              condition: or
+              conditions:
+                - condition: state
+                  entity_id: sensor.opti_price_level
+                  state: "VERY_CHEAP"
+                - condition: state
+                  entity_id: sensor.opti_price_level
+                  state: "CHEAP"
+                - condition: state
+                  entity_id: sensor.opti_price_level
+                  state: "NORMAL"
+            - condition: template
+              value_template: >-
+                {% set soc = states('sensor.opti_soc') | float(none) %}
+                {% set ges = states('sensor.opti_peak_reserve_soc') | float(none) %}
+                {% set band = 5 if is_state('input_select.akkusteuerung_modus', 'Akku nur Laden') else 3 %}
+                {{ soc is not none and ges is not none and soc <= ges + band }}
+          sequence:
+            - action: input_select.select_option
+              data:
+                option: "Akku nur Laden"
+              target:
+                entity_id: input_select.akkusteuerung_modus
+            - stop: "fertig"
+
         # Modus-Set-Zweig: dynamisch laden zwischen MinSoC und Ziel-SoC (nur tagsüber).
         - alias: "Modus 'Dynamisch': SOC zwischen MinSoC und Ziel-SoC (nur tagsüber)"
           conditions:

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -189,6 +189,38 @@
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
 
+        # Peak-Vorladeregel (spread-basiert): kommende Spitzen sind deutlich teurer
+        # als jetzt -> gezielt bis reserve_gesamt_soc nachladen (nicht bis maxsoc).
+        # Stoppt selbsttaetig, sobald SoC die Reserve erreicht (Bedingung entfaellt).
+        # Ladefenster-Wahl wie bei der Negativpreis-Regel (selbstkorrigierend).
+        - alias: "Modus 'nur Laden' (Peak-Vorladen): Spread zur kommenden Spitze gross genug (tag+nacht)"
+          conditions:
+            - condition: state
+              entity_id: input_boolean.opti_prognose_netzladen
+              state: "on"
+            - condition: state
+              entity_id: binary_sensor.opti_peak_reserve_aktiv
+              state: "on"
+            - condition: template
+              value_template: >-
+                {% set cur = states('sensor.opti_price_current_ct_kwh') | float(none) %}
+                {% set soc = states('sensor.opti_soc') | float(none) %}
+                {% set ges = states('sensor.opti_peak_reserve_soc') | float(none) %}
+                {% set avg = state_attr('sensor.opti_peak_reserve_soc', 'peak_preis_avg_ct') | float(none) %}
+                {% set spread_min = states('input_number.opti_netzlade_spread_ct') | float(10) %}
+                {% set minv = state_attr('sensor.opti_peak_reserve_soc', 'min_preis_vor_peak_ct') %}
+                {{ cur is not none and soc is not none and ges is not none and avg is not none
+                   and soc < ges
+                   and (avg - cur) >= spread_min
+                   and (minv is none or cur <= (minv | float(cur)) + 0.5) }}
+          sequence:
+            - action: input_select.select_option
+              data:
+                option: "Akku nur Laden"
+              target:
+                entity_id: input_select.akkusteuerung_modus
+            - stop: "fertig"
+
         # Winter-/Prognose-Ladeblock (SOC < 20 %).
         # Quelle: heute+morgen schlecht → Score<3 (beide); Preis VERY_CHEAP..EXPENSIVE.
         # Gates: opti_prognose_netzladen on + opti_winter_charging_allowed on.

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -162,7 +162,7 @@
         # Netzladen lohnt immer. Fenster-Bedingung: nicht greedy laden, wenn vor
         # der naechsten Preisspitze noch eine guenstigere Stunde kommt (Marge 0.5 ct).
         # Fail-safe: Reserve-Sensor unavailable -> minv none -> einfacher EEG-Vergleich.
-        - alias: "Modus 'nur Laden' (Netzladen): Preis unter Einspeiseverguetung, Prognose schlecht (tag+nacht)"
+        - alias: "Modus 'Netzladen': Preis unter Einspeiseverguetung, Prognose schlecht (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
@@ -184,7 +184,7 @@
           sequence:
             - action: input_select.select_option
               data:
-                option: "Akku nur Laden"
+                option: "Akku Netzladen"
               target:
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"
@@ -193,7 +193,7 @@
         # als jetzt -> gezielt bis reserve_gesamt_soc nachladen (nicht bis maxsoc).
         # Stoppt selbsttaetig, sobald SoC die Reserve erreicht (Bedingung entfaellt).
         # Ladefenster-Wahl wie bei der Negativpreis-Regel (selbstkorrigierend).
-        - alias: "Modus 'nur Laden' (Peak-Vorladen): Spread zur kommenden Spitze gross genug (tag+nacht)"
+        - alias: "Modus 'Netzladen' (Peak-Vorladen): Spread zur kommenden Spitze gross genug (tag+nacht)"
           conditions:
             - condition: state
               entity_id: input_boolean.opti_prognose_netzladen
@@ -216,7 +216,7 @@
           sequence:
             - action: input_select.select_option
               data:
-                option: "Akku nur Laden"
+                option: "Akku Netzladen"
               target:
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -227,7 +227,7 @@ des betreffenden Sensors testen — häufig ist der Quell-Sensor noch falsch ben
 | `sensor.opti_forecast_score_tomorrow` | PV-Fit morgen (0–10) |
 | `sensor.opti_target_soc` | Ziel-SoC (%) basierend auf Restprognose und Hausverbrauch |
 | `sensor.opti_charge_power_w` | Dynamische Ladestärke (W) nach SoC-Stufe und Forecast-Score |
-| `sensor.opti_price_level` | Preisniveau-Enum (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE / VERY_EXPENSIVE) |
+| `sensor.opti_price_level` | Preisniveau-Enum (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE / VERY_EXPENSIVE); Midrank-Perzentil (Gleichstände zählen halb) - flache Preistage (viele identische Werte) landen dadurch bei NORMAL statt fälschlich bei VERY_EXPENSIVE |
 | `sensor.opti_mindestentladepreis_ct_kwh` | Mindestentladepreis = Ladepreis + Preisdifferenz (ct/kWh) |
 | `sensor.opti_runtime_h` | Geschätzte Akku-Restlaufzeit (Stunden) |
 | `binary_sensor.opti_winter_charging_allowed` | Saisonales Lade-Gate (Standard: `true`, fail-open) |
@@ -256,7 +256,7 @@ du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
 | **Tagsüber unter Ziel-SoC** | SoC < `opti_target_soc` **− 3 %**, nach Sonnenaufgang | **Akku Dynamisch** | Option „Dynamisch laden wenn SOC < ZielSoC"; das ±3 %-Band verhindert Modus-Pendeln direkt an der Ziel-Kante — siehe [strategie-logik.md](strategie-logik.md#der-intelligente-ziel-soc--herzstück-der-akkuschonung) |
 | **Entladen über Ziel-SoC** | SoC > `opti_target_soc` **+ 3 %** | **Akku nur Entladen** | Option „Nur Entladen wenn SOC > DynZielSoC" |
 | **MinSOC-Schutz** | SoC < `input_number.minsoc` | **Akku nur Laden** | Höchste Priorität, überstimmt alle anderen Blöcke |
-| **Preis-morgen fehlt** | `opti_price_series`-Attribut `tomorrow` leer / < 4 Gesamtwerte | Preisniveau bleibt **NORMAL** | Fail-safe: `< 4 Preise gesamt → NORMAL` |
+| **Preis-morgen fehlt** | `opti_price_series`-Attribut `tomorrow` leer / < 4 Gesamtwerte | Preisniveau bleibt **NORMAL** | Fail-safe: `< 4 Preise gesamt → NORMAL`. `sensor.opti_peak_reserve_soc` wird bei < 4 Preisen `unavailable` (Peak-Leiter L1-L4 komplett inaktiv) - bewusst anders als der NORMAL-Fallback des Preisniveaus, siehe [strategie-logik.md](strategie-logik.md#fail-safes-und-bekannte-grenzen) |
 | **Forecast fehlt** | `opti_forecast_remaining_today_kwh` → `unavailable` | Prognose-Blöcke inaktiv; MinSOC-Schutz und Cleanup laufen weiter | Default → **Akku Dynamisch** (nur wenn `opti_soc` + `opti_battery_capacity_kwh` verfügbar) |
 | **Voller Akku** | SoC > 99 % | **Akku Dynamisch**; Lade-Booster (Legacy) wird deaktiviert | Option „Bei vollem Akku auf Dynamisch" + Cleanup-Block |
 

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -103,6 +103,8 @@ state: "{{ states('sensor.awattar_current_price') | float(0) * 100 }}"
 > **Hinweis:** Falls die Quelle bereits ct/kWh liefert, `* 100` weglassen und
 > den Availability-Check entsprechend anpassen.
 
+> **Stundenraster-Kontrakt:** `today`/`tomorrow` müssen Stundenlisten sein (max. 25 Einträge je Liste) — die Peak-Reserve (`sensor.opti_peak_reserve_soc`) ordnet Stunden über den Listenindex zu und deaktiviert sich bei 15-Minuten-Listen oder anderen Rastern über 25 Einträgen automatisch (`gueltig: false`).
+
 ---
 
 ## Solcast-Anbindung
@@ -231,6 +233,8 @@ des betreffenden Sensors testen — häufig ist der Quell-Sensor noch falsch ben
 | `sensor.opti_mindestentladepreis_ct_kwh` | Mindestentladepreis = Ladepreis + Preisdifferenz (ct/kWh) |
 | `sensor.opti_runtime_h` | Geschätzte Akku-Restlaufzeit (Stunden) |
 | `binary_sensor.opti_winter_charging_allowed` | Saisonales Lade-Gate (Standard: `true`, fail-open) |
+| `sensor.opti_peak_reserve_soc` | Reserve-SoC für kommende Preisspitzen (trigger-basiert, 36h-Horizont) |
+| `binary_sensor.opti_peak_reserve_aktiv` | Gate: Peaks im Wiederauflade-Horizont vorhanden |
 
 > **Warnung — `opti_winter_charging_allowed`:** Dieses Gate ist **fail-open** (`{{ true }}`).
 > Solange kein realer Saisonal-Sensor gemappt ist, ist es immer `on`.

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -253,7 +253,7 @@ Steht **vor** den alten SOC-gestuften Ladeblöcken (Option 2 in der Übersicht u
 | Ladefenster | keine günstigere Stunde vor der nächsten Preisspitze in Sicht (siehe unten) |
 | Gate | `input_boolean.opti_prognose_netzladen` = on |
 | Ziel-SoC | maxsoc |
-| Gesetzter Modus | Akku nur Laden |
+| Gesetzter Modus | Akku Netzladen (braucht `ha-modbus-akku-adapter` >= v1.5.0) |
 
 ### Peak-Vorladeregel
 
@@ -265,7 +265,7 @@ Direkt danach (Option 3): lädt gezielt bis zur Gesamt-Reserve nach, wenn sich d
 | Ladefenster | wie Negativpreis-Regel |
 | Gate | `input_boolean.opti_prognose_netzladen` = on |
 | Ziel-SoC | `reserve_gesamt_soc` (**nicht** maxsoc) |
-| Gesetzter Modus | Akku nur Laden |
+| Gesetzter Modus | Akku Netzladen (braucht `ha-modbus-akku-adapter` >= v1.5.0) |
 | Selbst-Stop | Bedingung entfällt automatisch, sobald SoC die Reserve erreicht - kein extra Abschalt-Trigger nötig |
 
 Der Spread-Schwellwert (Default 10 ct) ist bewusst so hoch gesetzt, dass er die Round-Trip-Verluste des Akkus (Lade- + Entladewirkungsgrad) deckt.
@@ -343,12 +343,17 @@ Diese Option steht bewusst ganz oben und kann von keinem anderen Block überstim
 | Preis | unter Einspeisevergütung (Default 0 ct, faktisch nur negative Preise) |
 | Tageszeit | jederzeit |
 | Zusatz | Ladefenster-Wahl (keine günstigere Stunde vor der nächsten Spitze in Sicht) |
-| Gesetzter Modus | **Akku nur Laden** (bis maxsoc) |
+| Gesetzter Modus | **Akku Netzladen** (bis maxsoc; braucht `ha-modbus-akku-adapter` >= v1.5.0) |
 
 **Warum:** Ist der Netzstrom günstiger als die eigene Einspeisevergütung, lohnt sich Laden aus
 dem Netz fast immer, unabhängig vom sonstigen SoC-Niveau.
 Details zur Reserve-Logik, der Ladefenster-Wahl und den Fail-safes stehen im Abschnitt
 **[Entlade-Peak-Allokation](#entlade-peak-allokation-reserve-für-die-teuersten-stunden)**.
+
+**Warum ein eigener Modus:** „Akku nur Laden" ist im Live-Setup eine reine Entladesperre
+(`min_ladestaerke = 0`, kein Netzbezug) — damit wäre diese Regel wirkungslos. „Akku Netzladen"
+setzt am Wechselrichter `BatChaMinW = opti_charge_power_w` (dynamisch, SMA-Register 2289) und
+erzwingt so tatsächliches Laden aus dem Netz.
 
 ---
 
@@ -360,7 +365,7 @@ Details zur Reserve-Logik, der Ladefenster-Wahl und den Fail-safes stehen im Abs
 | Preis | irrelevant (Spread-Vergleich statt Preisniveau) |
 | Tageszeit | jederzeit |
 | Zusatz | Ladefenster-Wahl wie Option 2; stoppt selbsttätig bei Erreichen der Reserve |
-| Gesetzter Modus | **Akku nur Laden** (bis `reserve_gesamt_soc`, nicht maxsoc) |
+| Gesetzter Modus | **Akku Netzladen** (bis `reserve_gesamt_soc`, nicht maxsoc; braucht `ha-modbus-akku-adapter` >= v1.5.0) |
 
 **Warum:** Ist eine kommende Preisspitze absehbar deutlich teurer als der aktuelle Preis,
 lohnt sich gezieltes Vorladen bis zur Reserve, auch ohne dass der Preis gerade negativ ist.
@@ -615,9 +620,10 @@ putzt den Zustand automatisch auf — er läuft immer (kein Toggle-Gate).
 
 | Modus | Typische Situation |
 |---|---|
-| **Akku nur Laden** | SoC unter MinSOC (Notfall); schlechte Prognose + günstiger Strom; Wintermodus aktiv; Akku fast leer bei Schlechtwetter |
+| **Akku nur Laden** | SoC unter MinSOC (Notfall); schlechte Prognose + günstiger Strom; Wintermodus aktiv; Akku fast leer bei Schlechtwetter; Peak-Leiter L3/L4 (halten) |
+| **Akku Netzladen** | Negativpreis-Laderegel oder Peak-Vorladeregel aktiv — erzwungenes dynamisches Netzladen (BatChaMinW = `opti_charge_power_w`); braucht `ha-modbus-akku-adapter` >= v1.5.0 |
 | **Akku Dynamisch** | PV-Überschuss tagsüber; Akku zwischen MinSOC und Ziel-SoC; voller Akku; kein klarer Lade-/Entladegrund (Default) |
-| **Akku nur Entladen** | SoC über intelligentem Ziel-SoC (`sensor.opti_target_soc`) — Akku hat genug Reserve für die Nacht |
+| **Akku nur Entladen** | SoC über intelligentem Ziel-SoC (`sensor.opti_target_soc`); Peak-Leiter L1/L2 (entladen) |
 
 **Modus-Contract (Single-Writer-Regel):**
 Die Strategie-Automation schreibt primär `input_select.akkusteuerung_modus`. Im

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -22,6 +22,9 @@ Zentrales Entitäts-Modell (Canonical-`opti_*`-Layer):
 - `input_boolean.opti_prognose_netzladen` — Gate für prognosebasiertes Netzladen
 - `input_boolean.opti_pv_ueberschuss_ladung` — Gate für PV-Überschuss-Laden
 - `binary_sensor.opti_winter_charging_allowed` — Winterladefreigabe (Standard: `true`)
+- `sensor.opti_peak_reserve_soc` - berechneter Reserve-SoC für kommende Preisspitzen (36h-Horizont)
+- `binary_sensor.opti_peak_reserve_aktiv` - Gate: Peaks im Wiederauflade-Horizont vorhanden
+- `input_number.opti_peak_verbrauch_kw` / `opti_einspeiseverguetung_ct` / `opti_netzlade_spread_ct` - Konfiguration der Peak-Allokation
 - `input_select.akkusteuerung_modus` — Ziel-Ausgang dieser Automation
 
 ---
@@ -165,8 +168,8 @@ Stufe gegen die Roh-`ratio` festhält.
 Die Modus-Automation vergleicht den realen SoC mit `sensor.opti_target_soc` — mit einem
 zusätzlichen **Band H = 3 %** als zweiter Schutzschicht gegen Pendeln direkt an der Ziel-Kante:
 
-- **SoC < Ziel − 3** → *Akku Dynamisch* (lädt Richtung Ziel, Option 10)
-- **SoC > Ziel + 3** → *Akku nur Entladen* (genug Reserve, Option 11)
+- **SoC < Ziel − 3** → *Akku Dynamisch* (lädt Richtung Ziel, Option 16)
+- **SoC > Ziel + 3** → *Akku nur Entladen* (genug Reserve, Option 17)
 - **innerhalb ±3 % um das Ziel** → neutrale Zone → Default *Akku Dynamisch*
 
 ### Nachbauen über die zwei Repos
@@ -183,10 +186,119 @@ eigentliche Hardware-Ansteuerung in **`ha-modbus-akku-adapter`**. Zum Nachbauen 
 
 ---
 
+## Entlade-Peak-Allokation: Reserve für die teuersten Stunden
+
+### Das Problem
+
+Ein Winterakku, der nach dem intelligenten Ziel-SoC geladen wird, reicht oft nicht bis zum nächsten Morgen.
+Bisher entlädt die Strategie undifferenziert: sobald der Modus „Akku Dynamisch" oder „Akku nur Entladen" steht, fließt die gespeicherte Energie in der Reihenfolge ab, in der der Hausverbrauch sie abruft - unabhängig davon, ob gerade eine günstige oder eine sehr teure Stunde läuft.
+Die Entlade-Peak-Allokation löst das, indem sie einen Teil des SoC gezielt für die **kommenden teuersten Stunden** reserviert, statt ihn an eine x-beliebige NORMAL-Stunde davor zu verlieren.
+
+### Wie die Reserve berechnet wird
+
+Der trigger-basierte Block „Entlade-Peak-Allokation" in `packages/opti_derived.yaml` rechnet alle 15 Minuten (und bei relevanten State-Changes) eine gemeinsame `peak`-Variable, aus der zwei Entitäten abgeleitet werden: `sensor.opti_peak_reserve_soc` und `binary_sensor.opti_peak_reserve_aktiv`.
+
+**Wiederauflade-Horizont.**
+Die Reserve muss nur bis zum nächsten Zeitpunkt reichen, an dem der Akku voraussichtlich wieder auflädt.
+Das Fenster beginnt an der nächsten vollen Stunde und endet:
+
+- **leer**, wenn es gerade Tag ist (Sonne über dem Horizont) und der heutige Forecast-Score gut ist (> 2) - dann füllt die PV den Akku ohnehin gleich wieder auf, eine Reserve ist überflüssig.
+- sonst am **nächsten Sonnenaufgang + 3 h**, wenn der Score des Tages, an dem dieser Sonnenaufgang liegt, gut ist (> 2) - heute oder morgen, je nachdem, ob der nächste Sonnenaufgang schon heute war oder erst morgen kommt.
+- sonst **maximal 36 h** ab jetzt (kein guter Score in Sicht, oder Score fehlt).
+
+Wichtig: Ist der nächste Sonnenaufgang erst **morgen** (Score von morgen entscheidet), zählt die **heutige** Abendspitze trotzdem mit - sie liegt ja vor diesem Wiederaufladepunkt.
+Ein sonniger Tag von morgen schließt die heutige Abendspitze also nicht aus dem Horizont aus, er verkürzt ihn nur ab dem morgigen Sonnenaufgang + 3 h.
+
+**Klassifikation.**
+Jede Stunde im Horizont wird mit demselben **Midrank-Perzentil** wie `sensor.opti_price_level` eingestuft (gleiche Grenzen: ≥ 80 % → VERY_EXPENSIVE, ≥ 60 % → EXPENSIVE) - ein konsistentes Preisniveau-Konzept für die ganze Strategie.
+
+**Formel.**
+Für jede VERY_EXPENSIVE- bzw. VERY_EXPENSIVE+EXPENSIVE-Stunde im Horizont:
+
+```
+reserve_kwh = anzahl_stunden * opti_peak_verbrauch_kw / eta      (eta = 0.9 Entladewirkungsgrad)
+reserve_soc = min(minsoc + reserve_kwh / kapazität_kwh * 100, maxsoc)
+```
+
+`reserve_ve_soc` deckt nur die VERY_EXPENSIVE-Stunden, `reserve_gesamt_soc` (der State von `sensor.opti_peak_reserve_soc`) zusätzlich die EXPENSIVE-Stunden.
+Beide werden bei `maxsoc` gekappt - ein kleiner Akku kann nie mehr reservieren, als er fasst.
+
+### Die Leiter: L1-L4
+
+Ist `binary_sensor.opti_peak_reserve_aktiv` an (Reserve-Sensor gültig **und** mindestens eine Peak-Stunde im Horizont), steuert eine vierstufige „Leiter" die Entlade-Freigabe.
+Sie steht in der Optionsliste **vor** den normalen Ziel-SoC-Optionen, sonst würde „nur Entladen über Ziel-SoC" die Reserve bei NORMAL-Preis vorzeitig verheizen.
+
+| Stufe | Preisniveau | Zusatzbedingung | Modus |
+|---|---|---|---|
+| **L1** | VERY_EXPENSIVE | - | Akku nur Entladen |
+| **L2** | EXPENSIVE | SoC > `reserve_ve_soc` + Band | Akku nur Entladen |
+| **L3** | EXPENSIVE | SoC ≤ `reserve_ve_soc` + Band | Akku nur Laden (halten) |
+| **L4** | NORMAL oder billiger | SoC ≤ `reserve_gesamt_soc` + Band | Akku nur Laden (halten) |
+
+Ist keine Stufe einschlägig (z. B. NORMAL-Preis mit ausreichend SoC über der Reserve), fällt die Prüfung durch zu den normalen Ziel-SoC-Optionen.
+
+**Asymmetrisches Freigabeband.**
+Damit der Modus nicht direkt an der Reserve-Kante flattert, ist das Band abhängig vom *aktuellen* Modus - der Modus dient als Gedächtnis des Vorzustands:
+
+- **+5 %**, wenn der aktuelle Modus „Akku nur Laden" ist (aus dem Halten heraus erst bei deutlichem Überschuss wieder freigeben)
+- **+3 %**, wenn der aktuelle Modus etwas anderes ist (beim Entladen genügt ein kleineres Band, um nicht sofort wieder zu halten)
+
+### Negativpreis-Laderegel
+
+Steht **vor** den alten SOC-gestuften Ladeblöcken (Option 2 in der Übersicht unten) und lädt gezielt bis `maxsoc`, wenn Netzstrom günstiger ist als die eigene Einspeisung:
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | Preis < `input_number.opti_einspeiseverguetung_ct` (Default 0 ct, Regel greift dann nur bei negativen Preisen), `opti_forecast_score` < 3, SoC < maxsoc |
+| Ladefenster | keine günstigere Stunde vor der nächsten Preisspitze in Sicht (siehe unten) |
+| Gate | `input_boolean.opti_prognose_netzladen` = on |
+| Ziel-SoC | maxsoc |
+| Gesetzter Modus | Akku nur Laden |
+
+### Peak-Vorladeregel
+
+Direkt danach (Option 3): lädt gezielt bis zur Gesamt-Reserve nach, wenn sich das wirtschaftlich lohnt, auch ohne negative Preise.
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | `binary_sensor.opti_peak_reserve_aktiv` = on, SoC < `reserve_gesamt_soc`, (`peak_preis_avg_ct` minus aktueller Preis) ≥ `input_number.opti_netzlade_spread_ct` (Default 10 ct) |
+| Ladefenster | wie Negativpreis-Regel |
+| Gate | `input_boolean.opti_prognose_netzladen` = on |
+| Ziel-SoC | `reserve_gesamt_soc` (**nicht** maxsoc) |
+| Gesetzter Modus | Akku nur Laden |
+| Selbst-Stop | Bedingung entfällt automatisch, sobald SoC die Reserve erreicht - kein extra Abschalt-Trigger nötig |
+
+Der Spread-Schwellwert (Default 10 ct) ist bewusst so hoch gesetzt, dass er die Round-Trip-Verluste des Akkus (Lade- + Entladewirkungsgrad) deckt.
+Vorladen soll sich nach Verlusten noch lohnen, nicht nur brutto.
+
+### Ladefenster-Wahl
+
+Beide Laderegeln oben laden nicht einfach sofort los, sobald ihre Preisbedingung erfüllt ist.
+Sie prüfen zusätzlich `min_preis_vor_peak_ct` (Attribut von `sensor.opti_peak_reserve_soc`): den günstigsten Preis, der **vor** der nächsten Preisspitze noch kommt.
+Ist der aktuelle Preis mehr als **0.5 ct** teurer als dieses Minimum, wird gewartet, weil eine noch günstigere Stunde absehbar ist.
+
+Das ist **selbstkorrigierend**: `min_preis_vor_peak_ct` wird bei jeder Neuberechnung aus den aktuellen Preislisten ermittelt.
+Trifft die erwartete günstigere Stunde nicht ein (z. B. weil sich der Markt seit der letzten Preisaktualisierung geändert hat), wird der neue, jetzt aktuelle Minimalpreis zum Maßstab.
+Die Regel wartet also nicht ewig auf einen Wert, der nicht mehr existiert.
+
+### Fail-safes und bekannte Grenzen
+
+- **< 4 Preise gesamt** (`today` + `tomorrow`): `sensor.opti_peak_reserve_soc` wird `unavailable`, `binary_sensor.opti_peak_reserve_aktiv` fällt auf `off` - die komplette Leiter (L1-L4) ist inaktiv.
+  Das ist **bewusst anders** als der NORMAL-Fallback von `sensor.opti_price_level` bei derselben Datenlage: eine Reserve von 0 % sähe wie „keine Peaks in Sicht" aus und würde die Leiter fälschlich freigeben, statt sie einfach abzuschalten.
+- **DST-Limitation:** Die Preislisten liefern keine Zeitstempel, die Stundenzuordnung erfolgt über den Listenindex ab Mitternacht.
+  An Tagen mit Zeitumstellung kann diese Zuordnung um eine Stunde verrutschen - akzeptiertes, bekanntes Verhalten.
+
+### Wechselwirkung mit den alten Ladeblöcken
+
+Die bestehenden SOC-gestuften Ladeblöcke (Optionen 4-8 in der Übersicht unten, siehe [Winter-/Prognose-Ladelogik](#winter-prognose-ladelogik--intent)) bleiben unverändert vor der Peak-Allokation stehen und kennen die Ladefenster-Wahl **nicht** - sie laden sofort, sobald ihre eigenen SoC-/Preisbedingungen erfüllt sind.
+Das ist bewusst so belassen: Fällt die Peak-Allokation aus (z. B. wegen zu weniger Preise) oder ist ihre Reserve zu knapp bemessen, sorgen die alten Blöcke weiterhin als **Sicherheitsnetz** dafür, dass bei schlechter Prognose überhaupt geladen wird, unabhängig davon, ob gerade das optimale Fenster ist.
+
+---
+
 ## Block-für-Block-Übersicht
 
 Die Automation besteht aus mehreren Aktionsblöcken, die **sequenziell** ausgeführt werden.
-Der wichtigste ist „Zwischen Speicherszenarien wählen" mit 11 Optionen und einem Default-Pfad.
+Der wichtigste ist „Zwischen Speicherszenarien wählen" mit 17 Optionen und einem Default-Pfad.
 
 ---
 
@@ -201,7 +313,7 @@ spätere Automatisierungen, die einen Voll-Zyklus erzwingen können.
 
 ---
 
-### Aktionsblock 2 — „Zwischen Speicherszenarien wählen" (12 Optionen + Default)
+### Aktionsblock 2 — „Zwischen Speicherszenarien wählen" (17 Optionen + Default)
 
 Dies ist das Herzstück. Die Optionen werden **der Reihe nach** geprüft;
 die erste, deren Bedingungen alle erfüllt sind, wird ausgeführt und die weitere Prüfung
@@ -223,7 +335,40 @@ Diese Option steht bewusst ganz oben und kann von keinem anderen Block überstim
 
 ---
 
-#### Option 2 — Laden wenn heute + morgen schlecht, SoC < 20 % (Tag und Nacht)
+#### Option 2 - Negativpreis-Laden (Tag und Nacht)
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | Preis < `input_number.opti_einspeiseverguetung_ct`, `opti_forecast_score` < 3, SoC < maxsoc |
+| Preis | unter Einspeisevergütung (Default 0 ct, faktisch nur negative Preise) |
+| Tageszeit | jederzeit |
+| Zusatz | Ladefenster-Wahl (keine günstigere Stunde vor der nächsten Spitze in Sicht) |
+| Gesetzter Modus | **Akku nur Laden** (bis maxsoc) |
+
+**Warum:** Ist der Netzstrom günstiger als die eigene Einspeisevergütung, lohnt sich Laden aus
+dem Netz fast immer, unabhängig vom sonstigen SoC-Niveau.
+Details zur Reserve-Logik, der Ladefenster-Wahl und den Fail-safes stehen im Abschnitt
+**[Entlade-Peak-Allokation](#entlade-peak-allokation-reserve-für-die-teuersten-stunden)**.
+
+---
+
+#### Option 3 - Peak-Vorladen (Tag und Nacht)
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | `binary_sensor.opti_peak_reserve_aktiv` = on, SoC < `reserve_gesamt_soc`, Spread zur kommenden Spitze ≥ `opti_netzlade_spread_ct` |
+| Preis | irrelevant (Spread-Vergleich statt Preisniveau) |
+| Tageszeit | jederzeit |
+| Zusatz | Ladefenster-Wahl wie Option 2; stoppt selbsttätig bei Erreichen der Reserve |
+| Gesetzter Modus | **Akku nur Laden** (bis `reserve_gesamt_soc`, nicht maxsoc) |
+
+**Warum:** Ist eine kommende Preisspitze absehbar deutlich teurer als der aktuelle Preis,
+lohnt sich gezieltes Vorladen bis zur Reserve, auch ohne dass der Preis gerade negativ ist.
+Details siehe **[Entlade-Peak-Allokation](#entlade-peak-allokation-reserve-für-die-teuersten-stunden)**.
+
+---
+
+#### Option 4 — Laden wenn heute + morgen schlecht, SoC < 20 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -239,7 +384,7 @@ noch besser als kein Puffer. Diese Ausnahmeregelung gilt nur für diese kritisch
 
 ---
 
-#### Option 3 — Laden wenn heute + morgen schlecht, SoC < 75 % (Tag und Nacht)
+#### Option 5 — Laden wenn heute + morgen schlecht, SoC < 75 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -251,12 +396,12 @@ noch besser als kein Puffer. Diese Ausnahmeregelung gilt nur für diese kritisch
 **Warum (Nuance):** Bei moderatem SoC (20–75 %) und zwei schlechten Prognosetagen wird
 bis NORMAL-Preis nachgeladen. Der Grenze zu EXPENSIVE bleibt verschlossen, weil der Akku
 noch nicht kritisch leer ist — es lohnt sich, auf günstigere Stunden zu warten.
-Dieser Block bildet zusammen mit Option 2 eine bewusste Abstufung: je leerer der Akku,
+Dieser Block bildet zusammen mit Option 4 eine bewusste Abstufung: je leerer der Akku,
 desto teureren Strom darf die Automatik akzeptieren.
 
 ---
 
-#### Option 4 — Laden wenn heute + morgen schlecht, Wintermodus, SoC < 80 % (Tag und Nacht)
+#### Option 6 — Laden wenn heute + morgen schlecht, Wintermodus, SoC < 80 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -274,7 +419,7 @@ Sommermodus-Schalter überschrieben werden, wenn ein saisonales Gate gewünscht 
 
 ---
 
-#### Option 5 — Laden wenn heute schlecht, SoC < 15 % (Tag und Nacht)
+#### Option 7 — Laden wenn heute schlecht, SoC < 15 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -283,13 +428,13 @@ Sommermodus-Schalter überschrieben werden, wenn ein saisonales Gate gewünscht 
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Laden** |
 
-**Warum:** Ähnlich wie Option 2, aber unabhängig von der Morgen-Prognose. Wenn der Akku
+**Warum:** Ähnlich wie Option 4, aber unabhängig von der Morgen-Prognose. Wenn der Akku
 fast leer ist (< 15 %) und die heutige Bewertung schlecht ist, wird notgeladen — ohne
 Rücksicht auf morgen. Kurzfrist-Schutz.
 
 ---
 
-#### Option 6 — Laden wenn heute schlecht, SoC < 45 %, Strom sehr günstig (Tag und Nacht)
+#### Option 8 — Laden wenn heute schlecht, SoC < 45 %, Strom sehr günstig (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -305,7 +450,7 @@ Stunden rechtfertigen das Netzladen bei diesem SoC-Niveau.
 
 ---
 
-#### Option 7 — Bei 70%-Überschuss laden (nur tagsüber)
+#### Option 9 — Bei 70%-Überschuss laden (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -321,7 +466,7 @@ richtige Ladeleistung zu wählen.
 
 ---
 
-#### Option 8 — Bei AC-Überschuss laden (nur tagsüber)
+#### Option 10 — Bei AC-Überschuss laden (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -331,12 +476,12 @@ richtige Ladeleistung zu wählen.
 | Gesetzter Modus | **Akku Dynamisch** |
 | Gate | `input_boolean.opti_pv_ueberschuss_ladung` muss `on` sein |
 
-**Warum:** Ähnlich wie Option 7, aber die Messgröße ist die WR-AC-Ausgangsleistung statt
+**Warum:** Ähnlich wie Option 9, aber die Messgröße ist die WR-AC-Ausgangsleistung statt
 der Netzeinspeisung. Nutzt verfügbare PV-Energie aktiv, bevor sie verschwendet wird.
 
 ---
 
-#### Option 9 — Bei vollem Akku auf Dynamisch schalten
+#### Option 11 — Bei vollem Akku auf Dynamisch schalten
 
 | Eigenschaft | Wert |
 |---|---|
@@ -351,7 +496,66 @@ einspeisen, bei Verbrauch den Akku nutzen — je nach aktuellem Systemzustand.
 
 ---
 
-#### Option 10 — Dynamisch laden wenn SoC zwischen MinSOC und Ziel-SoC (nur tagsüber)
+#### Option 12 - Peak-Leiter L1: Entladen bei VERY_EXPENSIVE (Tag und Nacht)
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | `binary_sensor.opti_peak_reserve_aktiv` = on |
+| Preis | VERY_EXPENSIVE |
+| Tageszeit | jederzeit |
+| Gesetzter Modus | **Akku nur Entladen** |
+
+**Warum:** Die teuerste Preisklasse darf immer aus dem Akku bedient werden, dafür ist die
+Reserve ja da. Details zur Leiter (L1-L4) und zum Freigabeband stehen im Abschnitt
+**[Entlade-Peak-Allokation](#entlade-peak-allokation-reserve-für-die-teuersten-stunden)**.
+
+---
+
+#### Option 13 - Peak-Leiter L2: Entladen bei EXPENSIVE über VE-Reserve (Tag und Nacht)
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | `binary_sensor.opti_peak_reserve_aktiv` = on, SoC > `reserve_ve_soc` + Freigabeband |
+| Preis | EXPENSIVE |
+| Tageszeit | jederzeit |
+| Gesetzter Modus | **Akku nur Entladen** |
+
+**Warum:** Bei EXPENSIVE darf entladen werden, solange noch genug SoC über der
+VERY_EXPENSIVE-Reserve liegt (Freigabeband +5 %/+3 %, siehe Hauptabschnitt).
+
+---
+
+#### Option 14 - Peak-Leiter L3: Halten bei EXPENSIVE unter VE-Reserve (Tag und Nacht)
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | `binary_sensor.opti_peak_reserve_aktiv` = on, SoC ≤ `reserve_ve_soc` + Freigabeband |
+| Preis | EXPENSIVE |
+| Tageszeit | jederzeit |
+| Gesetzter Modus | **Akku nur Laden** (Entladesperre, hält die VE-Reserve) |
+
+**Warum:** Reicht der SoC nicht mehr deutlich über der VERY_EXPENSIVE-Reserve, wird das
+Entladen gesperrt, damit die kommende VERY_EXPENSIVE-Stunde nicht leerläuft.
+
+---
+
+#### Option 15 - Peak-Leiter L4: Halten bei NORMAL oder billiger unter Gesamt-Reserve (Tag und Nacht)
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | `binary_sensor.opti_peak_reserve_aktiv` = on, SoC ≤ `reserve_gesamt_soc` + Freigabeband |
+| Preis | VERY_CHEAP / CHEAP / NORMAL |
+| Tageszeit | jederzeit |
+| Gesetzter Modus | **Akku nur Laden** (Entladesperre, hält die Gesamt-Reserve) |
+
+**Warum:** Auch bei günstigem Preis wird nicht in die für Peaks reservierte Energie
+entladen, solange der SoC die Gesamt-Reserve noch nicht deutlich übersteigt.
+Trifft keine der vier Leiter-Stufen zu, fällt die Prüfung durch zu den normalen
+Ziel-SoC-Optionen (Option 16/17).
+
+---
+
+#### Option 16 — Dynamisch laden wenn SoC zwischen MinSOC und Ziel-SoC (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -368,7 +572,7 @@ erklärt. Das **−3 %-Band** (H) verhindert Modus-Pendeln direkt an der Ziel-Ka
 
 ---
 
-#### Option 11 — Nur Entladen wenn SoC über Ziel-SoC
+#### Option 17 — Nur Entladen wenn SoC über Ziel-SoC
 
 | Eigenschaft | Wert |
 |---|---|
@@ -386,7 +590,7 @@ Ziel-SoC-Hysterese dafür, dass der Modus an der Grenze nicht flattert.
 
 #### Default — Akku Dynamisch
 
-Trifft keine der 11 Optionen zu (z. B. nachts ohne Ladegrund, Preis zu hoch),
+Trifft keine der 17 Optionen zu (z. B. nachts ohne Ladegrund, Preis zu hoch),
 wird der Modus auf **Akku Dynamisch** gesetzt. Der Adapter entscheidet dann
 situationsabhängig, ob leicht geladen oder entladen wird — ein sicherer Mittelweg.
 
@@ -434,4 +638,6 @@ Steuer-Automation parallel aktiv lassen.
 | **Decision-Trace-Attribute** | `sensor.opti_target_soc` hängt Debugging-Attribute an (`branch`, `level`, `ratio`, `net_available_kwh`, `remaining_hours`), lesbar über HA-Entwicklerwerkzeuge |
 | **Forecast-Score-Bänder** | `sensor.opti_charge_power_w` variiert die C-Rate in drei Bändern (score ≤ 1: aggressiv; 2–4: moderat; ≥ 5: schonend) statt starrer Prognose-Labels |
 | **`sensor.opti_price_level`** | Anbieter-agnostisches Preisniveau-Enum (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE / VERY_EXPENSIVE) auf Basis eines gleitenden Perzentils über `today`/`tomorrow`-Preislisten |
+| **Midrank-Perzentil** | `sensor.opti_price_level` zählt Preis-Gleichstände seit dem Fix nur noch halb (statt sie wie ein `select('le')` komplett auf die teure Seite zu zählen) - flache Preistage landen dadurch bei NORMAL statt fälschlich bei VERY_EXPENSIVE. Dieselbe Klassifikation nutzt auch `sensor.opti_peak_reserve_soc` |
+| **`sensor.opti_peak_reserve_soc`** | Reserve-SoC für kommende Preisspitzen im Wiederauflade-Horizont (36h); steuert die Peak-Leiter L1-L4. Siehe [Entlade-Peak-Allokation](#entlade-peak-allokation-reserve-für-die-teuersten-stunden) |
 | **`binary_sensor.opti_winter_charging_allowed`** | Fail-open Gate für Winterladeblöcke (Standard: `true`); kann mit eigenem Sommermodus-Sensor überschrieben werden |

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -290,7 +290,7 @@ Die Regel wartet also nicht ewig auf einen Wert, der nicht mehr existiert.
 
 ### Wechselwirkung mit den alten Ladeblöcken
 
-Die bestehenden SOC-gestuften Ladeblöcke (Optionen 4-8 in der Übersicht unten, siehe [Winter-/Prognose-Ladelogik](#winter-prognose-ladelogik--intent)) bleiben unverändert vor der Peak-Allokation stehen und kennen die Ladefenster-Wahl **nicht** - sie laden sofort, sobald ihre eigenen SoC-/Preisbedingungen erfüllt sind.
+Die bestehenden SOC-gestuften Ladeblöcke (Optionen 6-10 in der Übersicht unten, siehe [Winter-/Prognose-Ladelogik](#winter-prognose-ladelogik--intent)) stehen weiterhin **hinter** der Negativpreis-/Vorladeregel und **hinter** den Entlade-Stufen der Leiter (L1/L2), aber **vor** deren Halte-Stufen (L3/L4) - Peak-Entladen schlägt Winterladen, günstiges Laden schlägt Halten (Ben-Entscheidung 2026-07-02). Sie kennen die Ladefenster-Wahl **nicht** - sie laden sofort, sobald ihre eigenen SoC-/Preisbedingungen erfüllt sind.
 Das ist bewusst so belassen: Fällt die Peak-Allokation aus (z. B. wegen zu weniger Preise) oder ist ihre Reserve zu knapp bemessen, sorgen die alten Blöcke weiterhin als **Sicherheitsnetz** dafür, dass bei schlechter Prognose überhaupt geladen wird, unabhängig davon, ob gerade das optimale Fenster ist.
 
 ---
@@ -373,7 +373,41 @@ Details siehe **[Entlade-Peak-Allokation](#entlade-peak-allokation-reserve-für-
 
 ---
 
-#### Option 4 — Laden wenn heute + morgen schlecht, SoC < 20 % (Tag und Nacht)
+#### Option 4 - Peak-Leiter L1: Entladen bei VERY_EXPENSIVE (Tag und Nacht)
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | `binary_sensor.opti_peak_reserve_aktiv` = on |
+| Preis | VERY_EXPENSIVE |
+| Tageszeit | jederzeit |
+| Gesetzter Modus | **Akku nur Entladen** |
+
+**Warum:** Die teuerste Preisklasse darf immer aus dem Akku bedient werden, dafür ist die
+Reserve ja da. Details zur Leiter (L1-L4) und zum Freigabeband stehen im Abschnitt
+**[Entlade-Peak-Allokation](#entlade-peak-allokation-reserve-für-die-teuersten-stunden)**.
+
+**Warum vor den alten Ladeblöcken (Ben-Entscheidung 2026-07-02):** L1/L2 stehen jetzt direkt
+nach der Peak-Vorladeregel und damit vor den alten SOC-gestuften Ladeblöcken (Option 6-10):
+Peak-Entladen schlägt Winterladen. Die Halte-Stufen L3/L4 (Option 14/15) bleiben hinter den
+Ladeblöcken stehen — günstiges Laden schlägt Halten.
+
+---
+
+#### Option 5 - Peak-Leiter L2: Entladen bei EXPENSIVE über VE-Reserve (Tag und Nacht)
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | `binary_sensor.opti_peak_reserve_aktiv` = on, SoC > `reserve_ve_soc` + Freigabeband |
+| Preis | EXPENSIVE |
+| Tageszeit | jederzeit |
+| Gesetzter Modus | **Akku nur Entladen** |
+
+**Warum:** Bei EXPENSIVE darf entladen werden, solange noch genug SoC über der
+VERY_EXPENSIVE-Reserve liegt (Freigabeband +5 %/+3 %, siehe Hauptabschnitt).
+
+---
+
+#### Option 6 — Laden wenn heute + morgen schlecht, SoC < 20 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -389,7 +423,7 @@ noch besser als kein Puffer. Diese Ausnahmeregelung gilt nur für diese kritisch
 
 ---
 
-#### Option 5 — Laden wenn heute + morgen schlecht, SoC < 75 % (Tag und Nacht)
+#### Option 7 — Laden wenn heute + morgen schlecht, SoC < 75 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -401,12 +435,12 @@ noch besser als kein Puffer. Diese Ausnahmeregelung gilt nur für diese kritisch
 **Warum (Nuance):** Bei moderatem SoC (20–75 %) und zwei schlechten Prognosetagen wird
 bis NORMAL-Preis nachgeladen. Der Grenze zu EXPENSIVE bleibt verschlossen, weil der Akku
 noch nicht kritisch leer ist — es lohnt sich, auf günstigere Stunden zu warten.
-Dieser Block bildet zusammen mit Option 4 eine bewusste Abstufung: je leerer der Akku,
+Dieser Block bildet zusammen mit Option 6 eine bewusste Abstufung: je leerer der Akku,
 desto teureren Strom darf die Automatik akzeptieren.
 
 ---
 
-#### Option 6 — Laden wenn heute + morgen schlecht, Wintermodus, SoC < 80 % (Tag und Nacht)
+#### Option 8 — Laden wenn heute + morgen schlecht, Wintermodus, SoC < 80 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -424,7 +458,7 @@ Sommermodus-Schalter überschrieben werden, wenn ein saisonales Gate gewünscht 
 
 ---
 
-#### Option 7 — Laden wenn heute schlecht, SoC < 15 % (Tag und Nacht)
+#### Option 9 — Laden wenn heute schlecht, SoC < 15 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -433,13 +467,13 @@ Sommermodus-Schalter überschrieben werden, wenn ein saisonales Gate gewünscht 
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Laden** |
 
-**Warum:** Ähnlich wie Option 4, aber unabhängig von der Morgen-Prognose. Wenn der Akku
+**Warum:** Ähnlich wie Option 6, aber unabhängig von der Morgen-Prognose. Wenn der Akku
 fast leer ist (< 15 %) und die heutige Bewertung schlecht ist, wird notgeladen — ohne
 Rücksicht auf morgen. Kurzfrist-Schutz.
 
 ---
 
-#### Option 8 — Laden wenn heute schlecht, SoC < 45 %, Strom sehr günstig (Tag und Nacht)
+#### Option 10 — Laden wenn heute schlecht, SoC < 45 %, Strom sehr günstig (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -455,7 +489,7 @@ Stunden rechtfertigen das Netzladen bei diesem SoC-Niveau.
 
 ---
 
-#### Option 9 — Bei 70%-Überschuss laden (nur tagsüber)
+#### Option 11 — Bei 70%-Überschuss laden (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -471,7 +505,7 @@ richtige Ladeleistung zu wählen.
 
 ---
 
-#### Option 10 — Bei AC-Überschuss laden (nur tagsüber)
+#### Option 12 — Bei AC-Überschuss laden (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -481,12 +515,12 @@ richtige Ladeleistung zu wählen.
 | Gesetzter Modus | **Akku Dynamisch** |
 | Gate | `input_boolean.opti_pv_ueberschuss_ladung` muss `on` sein |
 
-**Warum:** Ähnlich wie Option 9, aber die Messgröße ist die WR-AC-Ausgangsleistung statt
+**Warum:** Ähnlich wie Option 11, aber die Messgröße ist die WR-AC-Ausgangsleistung statt
 der Netzeinspeisung. Nutzt verfügbare PV-Energie aktiv, bevor sie verschwendet wird.
 
 ---
 
-#### Option 11 — Bei vollem Akku auf Dynamisch schalten
+#### Option 13 — Bei vollem Akku auf Dynamisch schalten
 
 | Eigenschaft | Wert |
 |---|---|
@@ -498,35 +532,6 @@ der Netzeinspeisung. Nutzt verfügbare PV-Energie aktiv, bevor sie verschwendet 
 **Warum:** Ein voller Akku soll nicht weiter geladen werden, aber auch nicht zwingend
 aktiv entladen. „Dynamisch" erlaubt dem Adapter zu entscheiden: bei PV-Überschuss
 einspeisen, bei Verbrauch den Akku nutzen — je nach aktuellem Systemzustand.
-
----
-
-#### Option 12 - Peak-Leiter L1: Entladen bei VERY_EXPENSIVE (Tag und Nacht)
-
-| Eigenschaft | Wert |
-|---|---|
-| Bedingung | `binary_sensor.opti_peak_reserve_aktiv` = on |
-| Preis | VERY_EXPENSIVE |
-| Tageszeit | jederzeit |
-| Gesetzter Modus | **Akku nur Entladen** |
-
-**Warum:** Die teuerste Preisklasse darf immer aus dem Akku bedient werden, dafür ist die
-Reserve ja da. Details zur Leiter (L1-L4) und zum Freigabeband stehen im Abschnitt
-**[Entlade-Peak-Allokation](#entlade-peak-allokation-reserve-für-die-teuersten-stunden)**.
-
----
-
-#### Option 13 - Peak-Leiter L2: Entladen bei EXPENSIVE über VE-Reserve (Tag und Nacht)
-
-| Eigenschaft | Wert |
-|---|---|
-| Bedingung | `binary_sensor.opti_peak_reserve_aktiv` = on, SoC > `reserve_ve_soc` + Freigabeband |
-| Preis | EXPENSIVE |
-| Tageszeit | jederzeit |
-| Gesetzter Modus | **Akku nur Entladen** |
-
-**Warum:** Bei EXPENSIVE darf entladen werden, solange noch genug SoC über der
-VERY_EXPENSIVE-Reserve liegt (Freigabeband +5 %/+3 %, siehe Hauptabschnitt).
 
 ---
 

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -498,10 +498,13 @@ template:
           {% set minv = minv_raw|float(none) if minv_raw is not none else none %}
           {% set avg = state_attr('sensor.opti_peak_reserve_soc','peak_preis_avg_ct')|float(none) %}
           {% set band = 5 if states('input_select.akkusteuerung_modus') == 'Akku nur Laden' else 3 %}
+          {% set stopband = 0 if states('input_select.akkusteuerung_modus') == 'Akku Netzladen' else 3 %}
           {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
           {% if soc >= 0 and soc < minsoc %}Akku nur Laden
-          {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) and cur < eeg and fenster %}Akku Netzladen
-          {%- elif prog and aktiv and soc >= 0 and soc < ges_res and avg is not none and (avg - cur) >= spread and fenster %}Akku Netzladen
+          {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) - stopband and cur < eeg and fenster %}Akku Netzladen
+          {%- elif prog and aktiv and soc >= 0 and soc < ges_res - stopband and avg is not none and (avg - cur) >= spread and fenster %}Akku Netzladen
+          {%- elif aktiv and soc >= 0 and price == 'VERY_EXPENSIVE' %}Akku nur Entladen
+          {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and soc > ve_res + band %}Akku nur Entladen
           {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}Akku nur Laden
           {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}Akku nur Laden
           {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}Akku nur Laden
@@ -510,8 +513,6 @@ template:
           {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}Akku Dynamisch
           {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}Akku Dynamisch
           {%- elif soc > 99 %}Akku Dynamisch
-          {%- elif aktiv and soc >= 0 and price == 'VERY_EXPENSIVE' %}Akku nur Entladen
-          {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and soc > ve_res + band %}Akku nur Entladen
           {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' %}Akku nur Laden
           {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Akku nur Laden
           {%- elif soc > minsoc and soc < target - H and day %}Akku Dynamisch
@@ -551,10 +552,13 @@ template:
             {% set minv = minv_raw|float(none) if minv_raw is not none else none %}
             {% set avg = state_attr('sensor.opti_peak_reserve_soc','peak_preis_avg_ct')|float(none) %}
             {% set band = 5 if states('input_select.akkusteuerung_modus') == 'Akku nur Laden' else 3 %}
+            {% set stopband = 0 if states('input_select.akkusteuerung_modus') == 'Akku Netzladen' else 3 %}
             {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
             {% if soc >= 0 and soc < minsoc %}MinSOC-Schutz (SoC<{{minsoc}})
-            {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) and cur < eeg and fenster %}Negativpreis-Laden ({{cur}}ct < EEG {{eeg}}ct)
-            {%- elif prog and aktiv and soc >= 0 and soc < ges_res and avg is not none and (avg - cur) >= spread and fenster %}Peak-Vorladen (Spread {{(avg - cur)|round(1)}}ct, bis {{ges_res}}%)
+            {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) - stopband and cur < eeg and fenster %}Negativpreis-Laden ({{cur}}ct < EEG {{eeg}}ct)
+            {%- elif prog and aktiv and soc >= 0 and soc < ges_res - stopband and avg is not none and (avg - cur) >= spread and fenster %}Peak-Vorladen (Spread {{(avg - cur)|round(1)}}ct, bis {{ges_res}}%)
+            {%- elif aktiv and soc >= 0 and price == 'VERY_EXPENSIVE' %}Peak-Leiter L1 (VE entladen)
+            {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and soc > ve_res + band %}Peak-Leiter L2 (EXP entladen, ueber VE-Reserve {{ve_res}}%)
             {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}SOC<20 Prognose (heute+morgen schlecht)
             {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}SOC<75 Prognose (Preis bis NORMAL)
             {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}SOC<80 Wintermodus
@@ -563,8 +567,6 @@ template:
             {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}70% Ueberschuss (tag)
             {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}AC Ueberschuss (tag)
             {%- elif soc > 99 %}Akku voll
-            {%- elif aktiv and soc >= 0 and price == 'VERY_EXPENSIVE' %}Peak-Leiter L1 (VE entladen)
-            {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and soc > ve_res + band %}Peak-Leiter L2 (EXP entladen, ueber VE-Reserve {{ve_res}}%)
             {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' %}Peak-Leiter L3 (halten fuer VE, Reserve {{ve_res}}%)
             {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Peak-Leiter L4 (halten fuer Peaks, Reserve {{ges_res}}%)
             {%- elif soc > minsoc and soc < target - H and day %}dyn bis Ziel (tag)
@@ -603,6 +605,7 @@ template:
           - sensor.opti_price_series
           - sensor.opti_forecast_score
           - sensor.opti_forecast_score_tomorrow
+          - sensor.opti_battery_capacity_kwh
           - input_number.opti_peak_verbrauch_kw
           - input_number.minsoc
           - input_number.maxsoc
@@ -613,12 +616,15 @@ template:
         {% set min_soc = states('input_number.minsoc') | float(10) %}
         {% set max_soc = states('input_number.maxsoc') | float(95) %}
         {% set eta = 0.9 %}
-        {# 1. Preisbasis + Zukunftsstunden einsammeln (Stundenindex -> Zeitpunkt) #}
-        {% set ns = namespace(prices=[], future=[]) %}
+        {# 1. Preisbasis + Zukunftsstunden einsammeln (Stundenindex -> Zeitpunkt).
+           Raster-Guard: Listen > 25 Eintraege (15-min-Raster o.ae.) -> ungueltig;
+           die Stundenzuordnung via Index setzt Stundenraster voraus. #}
+        {% set ns = namespace(prices=[], future=[], raster_ok=true) %}
         {% set heute = today_at('00:00') %}
         {% for key in ['today', 'tomorrow'] %}
           {% set arr = state_attr('sensor.opti_price_series', key) %}
           {% if arr is iterable and arr is not string %}
+            {% if arr | length > 25 %}{% set ns.raster_ok = false %}{% endif %}
             {% set base = heute if key == 'today' else heute + timedelta(days=1) %}
             {% for it in arr %}
               {% if it is mapping %}{% set p = it.get('total', it.get('price', it.get('value'))) %}{% else %}{% set p = it %}{% endif %}
@@ -630,7 +636,7 @@ template:
             {% endfor %}
           {% endif %}
         {% endfor %}
-        {% set n = ns.prices | length %}
+        {% set n = ns.prices | length if ns.raster_ok else 0 %}
         {# 2. Wiederauflade-Horizont: bis naechster Sonnenaufgang + 3 h mit gutem
            Tages-Score (> 2), sonst 36 h. Tagsueber + guter Heute-Score -> leer. #}
         {% set s_heute = states('sensor.opti_forecast_score') | float(-1) %}
@@ -652,8 +658,11 @@ template:
             {% set horizont_ende = horizont_max %}
           {% endif %}
         {% endif %}
-        {# 3. Zukunftsstunden im Horizont klassifizieren (Midrank-Perzentil) #}
-        {% set start = now().replace(minute=0, second=0, microsecond=0) + timedelta(hours=1) %}
+        {# 3. Zukunftsstunden im Horizont klassifizieren (Midrank-Perzentil).
+           Fenster ab der aktuellen vollen Stunde: die laufende Peak-Stunde
+           zaehlt mit, damit das Gate waehrend der Spitze nicht abfaellt
+           (laufende Stunde konservativ voll gerechnet). #}
+        {% set start = now().replace(minute=0, second=0, microsecond=0) %}
         {% set f = namespace(ve=0, exp=0, minpre=none, summe=0.0, anz=0, peak_gesehen=false) %}
         {% if n >= 4 %}
           {% for eintrag in ns.future %}

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -501,6 +501,7 @@ template:
           {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
           {% if soc >= 0 and soc < minsoc %}Akku nur Laden
           {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) and cur < eeg and fenster %}Akku nur Laden
+          {%- elif prog and aktiv and soc >= 0 and soc < ges_res and avg is not none and (avg - cur) >= spread and fenster %}Akku nur Laden
           {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}Akku nur Laden
           {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}Akku nur Laden
           {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}Akku nur Laden
@@ -549,6 +550,7 @@ template:
             {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
             {% if soc >= 0 and soc < minsoc %}MinSOC-Schutz (SoC<{{minsoc}})
             {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) and cur < eeg and fenster %}Negativpreis-Laden ({{cur}}ct < EEG {{eeg}}ct)
+            {%- elif prog and aktiv and soc >= 0 and soc < ges_res and avg is not none and (avg - cur) >= spread and fenster %}Peak-Vorladen (Spread {{(avg - cur)|round(1)}}ct, bis {{ges_res}}%)
             {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}SOC<20 Prognose (heute+morgen schlecht)
             {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}SOC<75 Prognose (Preis bis NORMAL)
             {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}SOC<80 Wintermodus

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -510,6 +510,10 @@ template:
           {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}Akku Dynamisch
           {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}Akku Dynamisch
           {%- elif soc > 99 %}Akku Dynamisch
+          {%- elif aktiv and soc >= 0 and price == 'VERY_EXPENSIVE' %}Akku nur Entladen
+          {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and soc > ve_res + band %}Akku nur Entladen
+          {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' %}Akku nur Laden
+          {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Akku nur Laden
           {%- elif soc > minsoc and soc < target - H and day %}Akku Dynamisch
           {%- elif soc > target + H %}Akku nur Entladen
           {%- elif soc >= 0 %}Akku Dynamisch
@@ -559,6 +563,10 @@ template:
             {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}70% Ueberschuss (tag)
             {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}AC Ueberschuss (tag)
             {%- elif soc > 99 %}Akku voll
+            {%- elif aktiv and soc >= 0 and price == 'VERY_EXPENSIVE' %}Peak-Leiter L1 (VE entladen)
+            {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and soc > ve_res + band %}Peak-Leiter L2 (EXP entladen, ueber VE-Reserve {{ve_res}}%)
+            {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' %}Peak-Leiter L3 (halten fuer VE, Reserve {{ve_res}}%)
+            {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Peak-Leiter L4 (halten fuer Peaks, Reserve {{ges_res}}%)
             {%- elif soc > minsoc and soc < target - H and day %}dyn bis Ziel (tag)
             {%- elif soc > target + H %}ueber Ziel-SoC
             {%- elif soc >= 0 %}Default (Nacht/keine Aktion)

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -500,8 +500,8 @@ template:
           {% set band = 5 if states('input_select.akkusteuerung_modus') == 'Akku nur Laden' else 3 %}
           {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
           {% if soc >= 0 and soc < minsoc %}Akku nur Laden
-          {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) and cur < eeg and fenster %}Akku nur Laden
-          {%- elif prog and aktiv and soc >= 0 and soc < ges_res and avg is not none and (avg - cur) >= spread and fenster %}Akku nur Laden
+          {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) and cur < eeg and fenster %}Akku Netzladen
+          {%- elif prog and aktiv and soc >= 0 and soc < ges_res and avg is not none and (avg - cur) >= spread and fenster %}Akku Netzladen
           {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}Akku nur Laden
           {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}Akku nur Laden
           {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}Akku nur Laden

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -502,7 +502,7 @@ template:
           {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
           {% if soc >= 0 and soc < minsoc %}Akku nur Laden
           {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) - stopband and cur < eeg and fenster %}Akku Netzladen
-          {%- elif prog and aktiv and soc >= 0 and soc < ges_res - stopband and avg is not none and (avg - cur) >= spread and fenster %}Akku Netzladen
+          {%- elif prog and aktiv and hv_cur and soc >= 0 and soc < ges_res - stopband and avg is not none and (avg - cur) >= spread and fenster %}Akku Netzladen
           {%- elif aktiv and soc >= 0 and price == 'VERY_EXPENSIVE' %}Akku nur Entladen
           {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and soc > ve_res + band %}Akku nur Entladen
           {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}Akku nur Laden
@@ -556,7 +556,7 @@ template:
             {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
             {% if soc >= 0 and soc < minsoc %}MinSOC-Schutz (SoC<{{minsoc}})
             {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) - stopband and cur < eeg and fenster %}Negativpreis-Laden ({{cur}}ct < EEG {{eeg}}ct)
-            {%- elif prog and aktiv and soc >= 0 and soc < ges_res - stopband and avg is not none and (avg - cur) >= spread and fenster %}Peak-Vorladen (Spread {{(avg - cur)|round(1)}}ct, bis {{ges_res}}%)
+            {%- elif prog and aktiv and hv_cur and soc >= 0 and soc < ges_res - stopband and avg is not none and (avg - cur) >= spread and fenster %}Peak-Vorladen (Spread {{(avg - cur)|round(1)}}ct, bis {{ges_res}}%)
             {%- elif aktiv and soc >= 0 and price == 'VERY_EXPENSIVE' %}Peak-Leiter L1 (VE entladen)
             {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and soc > ve_res + band %}Peak-Leiter L2 (EXP entladen, ueber VE-Reserve {{ve_res}}%)
             {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}SOC<20 Prognose (heute+morgen schlecht)

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -460,6 +460,7 @@ template:
       #    Toggles opti_prognose_netzladen / opti_pv_ueberschuss_ladung existieren live
       #    und werden hier wie in der echten Strategie gelesen (siehe unten). Bei
       #    Änderung der Strategie-Zweige MUSS dieser Sensor mitgespiegelt werden.
+      #    Peak-Allokations-Zweige (Negativpreis/Vorladen/Leiter) sind mitgespiegelt.
       # -----------------------------------------------------------------------
       - unique_id: opti_strategie_vorschau
         name: "Opti Strategie Vorschau"
@@ -486,7 +487,20 @@ template:
           {% set p_n = price in ['VERY_CHEAP','CHEAP','NORMAL'] %}
           {% set p_c = price in ['VERY_CHEAP','CHEAP'] %}
           {% set H = 3 %}
+          {% set cur = states('sensor.opti_price_current_ct_kwh')|float(0) %}
+          {% set hv_cur = has_value('sensor.opti_price_current_ct_kwh') %}
+          {% set eeg = states('input_number.opti_einspeiseverguetung_ct')|float(0) %}
+          {% set spread = states('input_number.opti_netzlade_spread_ct')|float(10) %}
+          {% set aktiv = is_state('binary_sensor.opti_peak_reserve_aktiv','on') %}
+          {% set ges_res = states('sensor.opti_peak_reserve_soc')|float(101) %}
+          {% set ve_res = state_attr('sensor.opti_peak_reserve_soc','reserve_ve_soc')|float(101) %}
+          {% set minv_raw = state_attr('sensor.opti_peak_reserve_soc','min_preis_vor_peak_ct') %}
+          {% set minv = minv_raw|float(none) if minv_raw is not none else none %}
+          {% set avg = state_attr('sensor.opti_peak_reserve_soc','peak_preis_avg_ct')|float(none) %}
+          {% set band = 5 if states('input_select.akkusteuerung_modus') == 'Akku nur Laden' else 3 %}
+          {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
           {% if soc >= 0 and soc < minsoc %}Akku nur Laden
+          {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) and cur < eeg and fenster %}Akku nur Laden
           {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}Akku nur Laden
           {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}Akku nur Laden
           {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}Akku nur Laden
@@ -521,7 +535,20 @@ template:
             {% set p_n = price in ['VERY_CHEAP','CHEAP','NORMAL'] %}
             {% set p_c = price in ['VERY_CHEAP','CHEAP'] %}
             {% set H = 3 %}
+            {% set cur = states('sensor.opti_price_current_ct_kwh')|float(0) %}
+            {% set hv_cur = has_value('sensor.opti_price_current_ct_kwh') %}
+            {% set eeg = states('input_number.opti_einspeiseverguetung_ct')|float(0) %}
+            {% set spread = states('input_number.opti_netzlade_spread_ct')|float(10) %}
+            {% set aktiv = is_state('binary_sensor.opti_peak_reserve_aktiv','on') %}
+            {% set ges_res = states('sensor.opti_peak_reserve_soc')|float(101) %}
+            {% set ve_res = state_attr('sensor.opti_peak_reserve_soc','reserve_ve_soc')|float(101) %}
+            {% set minv_raw = state_attr('sensor.opti_peak_reserve_soc','min_preis_vor_peak_ct') %}
+            {% set minv = minv_raw|float(none) if minv_raw is not none else none %}
+            {% set avg = state_attr('sensor.opti_peak_reserve_soc','peak_preis_avg_ct')|float(none) %}
+            {% set band = 5 if states('input_select.akkusteuerung_modus') == 'Akku nur Laden' else 3 %}
+            {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
             {% if soc >= 0 and soc < minsoc %}MinSOC-Schutz (SoC<{{minsoc}})
+            {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) and cur < eeg and fenster %}Negativpreis-Laden ({{cur}}ct < EEG {{eeg}}ct)
             {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}SOC<20 Prognose (heute+morgen schlecht)
             {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}SOC<75 Prognose (Preis bis NORMAL)
             {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}SOC<80 Wintermodus

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -311,7 +311,7 @@ template:
 
       # -----------------------------------------------------------------------
       # 5. Preisniveau (Enum) — übersetzt aus strompreis_niveau
-      #    (SMA-Templates Z.362-423). Perzentil-Bänder unverändert.
+      #    (SMA-Templates Z.362-423). Perzentil-Bänder unverändert, aber Midrank-Zählung (Gleichstände halb) statt select('le') - Fix für flache Preistage.
       #    current → opti_price_current_ct_kwh; Reihe → opti_price_series today/tomorrow
       #    (bereits ct/kWh-Listen). <4 Werte → NORMAL.
       # -----------------------------------------------------------------------
@@ -341,8 +341,11 @@ template:
           {% endfor %}
           {% set prices = ns.prices %}
           {% if prices | length >= 4 %}
-            {% set below = prices | select('le', current) | list | length %}
-            {% set pct = below / (prices | length) %}
+            {# Midrank-Perzentil: Gleichstaende zaehlen halb. Fix fuer den Tie-Bug
+               (select('le') machte bei flachen Preisen alles zu VERY_EXPENSIVE). #}
+            {% set kleiner = prices | select('lt', current) | list | length %}
+            {% set gleich  = prices | select('eq', current) | list | length %}
+            {% set pct = (kleiner + 0.5 * gleich) / (prices | length) %}
             {% if   pct < 0.20 %}{% set level = 'VERY_CHEAP' %}
             {% elif pct < 0.40 %}{% set level = 'CHEAP' %}
             {% elif pct < 0.60 %}{% set level = 'NORMAL' %}
@@ -368,7 +371,7 @@ template:
               {% endif %}
             {% endfor %}
             {% set prices = ns.prices %}
-            {% if prices | length >= 4 %}{{ ((prices | select('le', current) | list | length) / (prices | length) * 100) | round(1) }}{% else %}none{% endif %}
+            {% if prices | length >= 4 %}{{ (((prices | select('lt', current) | list | length) + 0.5 * (prices | select('eq', current) | list | length)) / (prices | length) * 100) | round(1) }}{% else %}none{% endif %}
           aktueller_preis: "{{ states('sensor.opti_price_current_ct_kwh') | float(0) }}"
           anzahl_preise: >
             {% set ns = namespace(c=0) %}

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -542,3 +542,141 @@ template:
           price_level: "{{ states('sensor.opti_price_level') }}"
           tag: "{{ is_state('sun.sun','above_horizon') }}"
           annahme: "Toggles opti_prognose_netzladen/opti_pv_ueberschuss_ladung existieren live, aktueller Zustand: prognose={{ states('input_boolean.opti_prognose_netzladen') }}, ueberschuss={{ states('input_boolean.opti_pv_ueberschuss_ladung') }}"
+
+  # ---------------------------------------------------------------------------
+  # 9. Entlade-Peak-Allokation: Reserve-SoC + Aktiv-Gate (trigger-basiert).
+  #    Rechnet aus opti_price_series (today/tomorrow) die Reserve fuer kommende
+  #    teure Stunden im Wiederauflade-Horizont. Trigger-basiert, damit der
+  #    Rechenkern EINMAL in 'variables' steht (kein 7x dupliziertes Template);
+  #    Bonus: RestoreEntity ueber HA-Neustarts. Braucht HA >= 2024.10.
+  #    Klassifikation: Midrank-Perzentil, identische Grenzen wie opti_price_level.
+  #    Fail-safe: < 4 Preise -> Sensor unavailable (BEWUSST anders als der
+  #    NORMAL-Fallback von opti_price_level: Reserve 0 saehe aus wie "keine
+  #    Peaks" und wuerde die Leiter falsch scharf schalten).
+  #    Bekannte Grenze: Preislisten ohne Zeitstempel, Stundenzuordnung per Index
+  #    (DST-Tage koennen 1 h verrutschen - akzeptiert).
+  # ---------------------------------------------------------------------------
+  - triggers:
+      - trigger: homeassistant
+        event: start
+      - trigger: time_pattern
+        minutes: "/15"
+      - trigger: state
+        entity_id:
+          - sensor.opti_price_series
+          - sensor.opti_forecast_score
+          - sensor.opti_forecast_score_tomorrow
+          - input_number.opti_peak_verbrauch_kw
+          - input_number.minsoc
+          - input_number.maxsoc
+    variables:
+      peak: >
+        {% set cap_kwh = states('sensor.opti_battery_capacity_kwh') | float(0) %}
+        {% set verbrauch_kw = states('input_number.opti_peak_verbrauch_kw') | float(0.8) %}
+        {% set min_soc = states('input_number.minsoc') | float(10) %}
+        {% set max_soc = states('input_number.maxsoc') | float(95) %}
+        {% set eta = 0.9 %}
+        {# 1. Preisbasis + Zukunftsstunden einsammeln (Stundenindex -> Zeitpunkt) #}
+        {% set ns = namespace(prices=[], future=[]) %}
+        {% set heute = today_at('00:00') %}
+        {% for key in ['today', 'tomorrow'] %}
+          {% set arr = state_attr('sensor.opti_price_series', key) %}
+          {% if arr is iterable and arr is not string %}
+            {% set base = heute if key == 'today' else heute + timedelta(days=1) %}
+            {% for it in arr %}
+              {% if it is mapping %}{% set p = it.get('total', it.get('price', it.get('value'))) %}{% else %}{% set p = it %}{% endif %}
+              {% set p = p | float(none) %}
+              {% if p is not none %}
+                {% set ns.prices = ns.prices + [p] %}
+                {% set ns.future = ns.future + [[base + timedelta(hours=loop.index0), p]] %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+        {% set n = ns.prices | length %}
+        {# 2. Wiederauflade-Horizont: bis naechster Sonnenaufgang + 3 h mit gutem
+           Tages-Score (> 2), sonst 36 h. Tagsueber + guter Heute-Score -> leer. #}
+        {% set s_heute = states('sensor.opti_forecast_score') | float(-1) %}
+        {% set s_morgen = states('sensor.opti_forecast_score_tomorrow') | float(-1) %}
+        {% set horizont_max = now() + timedelta(hours=36) %}
+        {% if is_state('sun.sun', 'above_horizon') and s_heute > 2 %}
+          {% set horizont_ende = now() %}
+        {% else %}
+          {% set rising = state_attr('sun.sun', 'next_rising') %}
+          {% set rise = (rising | as_datetime | as_local) if rising else none %}
+          {% if rise is not none %}
+            {% set rise_score = s_heute if rise.date() == now().date() else s_morgen %}
+            {% if rise_score > 2 %}
+              {% set horizont_ende = [rise + timedelta(hours=3), horizont_max] | min %}
+            {% else %}
+              {% set horizont_ende = horizont_max %}
+            {% endif %}
+          {% else %}
+            {% set horizont_ende = horizont_max %}
+          {% endif %}
+        {% endif %}
+        {# 3. Zukunftsstunden im Horizont klassifizieren (Midrank-Perzentil) #}
+        {% set start = now().replace(minute=0, second=0, microsecond=0) + timedelta(hours=1) %}
+        {% set f = namespace(ve=0, exp=0, minpre=none, summe=0.0, anz=0, peak_gesehen=false) %}
+        {% if n >= 4 %}
+          {% for eintrag in ns.future %}
+            {% set t = eintrag[0] %}
+            {% set p = eintrag[1] %}
+            {% if t >= start and t < horizont_ende %}
+              {% set kleiner = ns.prices | select('lt', p) | list | length %}
+              {% set gleich  = ns.prices | select('eq', p) | list | length %}
+              {% set pct = (kleiner + 0.5 * gleich) / n %}
+              {% if pct >= 0.80 %}
+                {% set f.ve = f.ve + 1 %}{% set f.summe = f.summe + p %}{% set f.anz = f.anz + 1 %}{% set f.peak_gesehen = true %}
+              {% elif pct >= 0.60 %}
+                {% set f.exp = f.exp + 1 %}{% set f.summe = f.summe + p %}{% set f.anz = f.anz + 1 %}{% set f.peak_gesehen = true %}
+              {% elif not f.peak_gesehen %}
+                {% set f.minpre = p if f.minpre is none else ([f.minpre, p] | min) %}
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        {# 4. Reserve in kWh und SoC (mit Entladeverlusten), Kappung bei maxsoc #}
+        {% set ve_kwh = f.ve * verbrauch_kw / eta %}
+        {% set ges_kwh = (f.ve + f.exp) * verbrauch_kw / eta %}
+        {% if cap_kwh > 0 %}
+          {% set ve_soc = [min_soc + ve_kwh / cap_kwh * 100, max_soc] | min %}
+          {% set ges_soc = [min_soc + ges_kwh / cap_kwh * 100, max_soc] | min %}
+        {% else %}
+          {% set ve_soc = max_soc %}
+          {% set ges_soc = max_soc %}
+        {% endif %}
+        {{ {'gueltig': n >= 4,
+            've_soc': ve_soc | round(1),
+            'ges_soc': ges_soc | round(1),
+            've_stunden': f.ve,
+            'exp_stunden': f.exp,
+            'benoetigt_kwh': ges_kwh | round(2),
+            'min_preis_vor_peak_ct': (f.minpre | round(2)) if f.minpre is not none else none,
+            'peak_preis_avg_ct': ((f.summe / f.anz) | round(2)) if f.anz > 0 else none,
+            'horizont_ende': horizont_ende.isoformat(),
+            'branch': 've=' ~ f.ve ~ ' exp=' ~ f.exp ~ ' n=' ~ n ~ ' ende=' ~ horizont_ende.strftime('%d.%m %H:%M')} }}
+    sensor:
+      - unique_id: opti_peak_reserve_soc
+        name: "Opti Peak Reserve SoC"
+        unit_of_measurement: "%"
+        state_class: measurement
+        icon: mdi:battery-lock
+        availability: "{{ peak.gueltig and has_value('sensor.opti_battery_capacity_kwh') }}"
+        state: "{{ peak.ges_soc }}"
+        attributes:
+          reserve_ve_soc: "{{ peak.ve_soc }}"
+          peak_stunden_ve: "{{ peak.ve_stunden }}"
+          peak_stunden_exp: "{{ peak.exp_stunden }}"
+          benoetigt_kwh: "{{ peak.benoetigt_kwh }}"
+          min_preis_vor_peak_ct: "{{ peak.min_preis_vor_peak_ct }}"
+          peak_preis_avg_ct: "{{ peak.peak_preis_avg_ct }}"
+          horizont_ende: "{{ peak.horizont_ende }}"
+          branch: "{{ peak.branch }}"
+    binary_sensor:
+      - unique_id: opti_peak_reserve_aktiv
+        name: "Opti Peak Reserve Aktiv"
+        icon: mdi:shield-lock
+        state: >
+          {{ peak.gueltig and has_value('sensor.opti_battery_capacity_kwh')
+             and peak.benoetigt_kwh > 0 }}

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -18,6 +18,7 @@ input_select:
       - "Akku schnell Entladen"
       - "Akku Pause"
       - "Akku nur Laden"
+      - "Akku Netzladen" # Erzwungenes dynamisches Netzladen (BatChaMinW = opti_charge_power_w); braucht ha-modbus-akku-adapter >= v1.5.0
       - "Akku nur Entladen"
       - "Akku Dynamisch"
       - "Akku 0.2C Laden"

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -153,6 +153,45 @@ input_number:
     mode: box
     icon: mdi:cash-plus
 
+  # --- Entlade-Peak-Allokation (Reserve fuer teure Stunden) ---
+  opti_peak_verbrauch_kw:
+    name: "Opti Peak-Verbrauch"
+    # Erwarteter Hausverbrauch waehrend Peak-Stunden (kW). Geht in die
+    # Reserve-Rechnung von sensor.opti_peak_reserve_soc ein.
+    min: 0.1
+    max: 5
+    step: 0.1
+    initial: 0.8
+    unit_of_measurement: kW
+    mode: box
+    icon: mdi:home-lightning-bolt
+
+  opti_einspeiseverguetung_ct:
+    name: "Opti Einspeiseverguetung"
+    # Eigene Einspeiseverguetung in ct/kWh. Preis darunter -> Netzladen lohnt immer
+    # (Negativpreis-Laderegel). Default 0 = Regel greift nur bei negativen Preisen,
+    # bis der echte EEG-Satz eingetragen ist.
+    min: 0
+    max: 30
+    step: 0.1
+    initial: 0
+    unit_of_measurement: ct/kWh
+    mode: box
+    icon: mdi:solar-power-variant
+
+  opti_netzlade_spread_ct:
+    name: "Opti Netzlade-Spread"
+    # Wirtschaftliche Mindest-Differenz zwischen Peak-Durchschnittspreis und
+    # aktuellem Ladepreis (ct/kWh), ab der Peak-Vorladen aus dem Netz lohnt.
+    # Deckt Round-Trip-Verluste des Akkus ab.
+    min: 0
+    max: 100
+    step: 0.5
+    initial: 10
+    unit_of_measurement: ct/kWh
+    mode: box
+    icon: mdi:swap-vertical-bold
+
 input_boolean:
   akku_opti_automatik:
     name: "Akku Opti-Automatik"

--- a/tests/ha_harness.py
+++ b/tests/ha_harness.py
@@ -1,0 +1,125 @@
+"""Fake-HA-Jinja-Umgebung: rendert die echten Templates aus den YAML-Dateien
+mit synthetischen States. Nachbau nur der hier benutzten HA-Funktionen/Filter."""
+from __future__ import annotations
+
+import datetime as dt
+import pathlib
+from zoneinfo import ZoneInfo
+
+import jinja2
+import yaml
+from jinja2.nativetypes import NativeEnvironment
+
+TZ = ZoneInfo("Europe/Berlin")
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+class FakeHass:
+    def __init__(self, states=None, attrs=None, now=None):
+        self.states_map = dict(states or {})
+        self.attrs_map = {k: dict(v) for k, v in (attrs or {}).items()}
+        self.now_value = now or dt.datetime(2026, 1, 15, 18, 30, tzinfo=TZ)
+
+    def states(self, entity_id):
+        return self.states_map.get(entity_id, "unknown")
+
+    def state_attr(self, entity_id, attr):
+        return self.attrs_map.get(entity_id, {}).get(attr)
+
+    def has_value(self, entity_id):
+        return self.states_map.get(entity_id) not in (None, "unknown", "unavailable")
+
+    def is_state(self, entity_id, value):
+        return self.states_map.get(entity_id) == value
+
+    def now(self):
+        return self.now_value
+
+    def today_at(self, timestr="00:00"):
+        parts = timestr.split(":")
+        return self.now_value.replace(
+            hour=int(parts[0]), minute=int(parts[1]) if len(parts) > 1 else 0,
+            second=0, microsecond=0)
+
+
+def _float(value, default=0.0):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int(value, default=0):
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_datetime(value, default=None):
+    if isinstance(value, dt.datetime):
+        return value
+    try:
+        return dt.datetime.fromisoformat(str(value))
+    except ValueError:
+        return default
+
+
+def _as_local(value):
+    return value.astimezone(TZ) if isinstance(value, dt.datetime) else value
+
+
+def _setup(env, hass):
+    env.globals.update(
+        states=hass.states, state_attr=hass.state_attr, has_value=hass.has_value,
+        is_state=hass.is_state, now=hass.now, today_at=hass.today_at,
+        timedelta=dt.timedelta, min=min, max=max,
+    )
+    env.filters.update({
+        "float": _float, "int": _int,
+        "as_datetime": _as_datetime, "as_local": _as_local,
+        "round": lambda v, n=0: round(float(v), n),
+    })
+    return env
+
+
+def render(hass, template_str):
+    env = _setup(jinja2.Environment(), hass)
+    return env.from_string(template_str).render().strip()
+
+
+def render_native(hass, template_str):
+    env = _setup(NativeEnvironment(), hass)
+    return env.from_string(template_str).render()
+
+
+def load_yaml(path):
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def find_template_entity(cfg, kind, unique_id):
+    """Sucht in einer Package-Datei (Schlüssel 'template') den Sensor/Binary-Sensor."""
+    for block in cfg["template"]:
+        for entity in block.get(kind, []):
+            if entity.get("unique_id") == unique_id:
+                return entity
+    raise KeyError(f"{kind}/{unique_id} nicht gefunden")
+
+
+def find_trigger_block_variables(cfg, var_name):
+    """Liefert das variables-Template eines trigger-basierten template-Blocks."""
+    for block in cfg["template"]:
+        if "triggers" in block and var_name in block.get("variables", {}):
+            return block["variables"][var_name]
+    raise KeyError(f"variables/{var_name} nicht gefunden")
+
+
+def find_automation_condition(cfg, option_alias):
+    """Liefert die conditions-Liste einer choose-Option aus opti_strategie.yaml."""
+    automation = cfg[0]
+    for action in automation["actions"]:
+        for option in action.get("choose", []) or []:
+            if option.get("alias") == option_alias:
+                return option["conditions"]
+    raise KeyError(f"Option '{option_alias}' nicht gefunden")

--- a/tests/ha_harness.py
+++ b/tests/ha_harness.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import datetime as dt
 import pathlib
+from ast import literal_eval
 from zoneinfo import ZoneInfo
 
 import jinja2
 import yaml
-from jinja2.nativetypes import NativeEnvironment
 
 TZ = ZoneInfo("Europe/Berlin")
 REPO = pathlib.Path(__file__).resolve().parent.parent
@@ -89,8 +89,14 @@ def render(hass, template_str):
 
 
 def render_native(hass, template_str):
-    env = _setup(NativeEnvironment(), hass)
-    return env.from_string(template_str).render()
+    """Nachbau von HAs Template.async_render(parse_result=True): render zu String,
+    stripped (echtes HA macht render_result.strip()), dann literal_eval-Versuch."""
+    env = _setup(jinja2.Environment(), hass)
+    render_result = env.from_string(template_str).render().strip()
+    try:
+        return literal_eval(render_result)
+    except (ValueError, TypeError, SyntaxError, MemoryError):
+        return render_result
 
 
 def load_yaml(path):

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,27 @@
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "tools"))
+
+from backtest import simulate_day  # noqa: E402
+
+FLACH_50 = [50.0] * 24
+SPITZE_ABEND = [50.0] * 19 + [200.0, 200.0, 200.0, 50.0, 50.0]
+
+
+def test_neu_billiger_bei_abendspitze():
+    kwargs = dict(load_kw=0.9, pv_kwh_per_hour=[0.0] * 24,
+                  start_soc=15.0, cap_kwh=12.8)
+    alt = simulate_day(SPITZE_ABEND, FLACH_50, neu=False, **kwargs)
+    neu = simulate_day(SPITZE_ABEND, FLACH_50, neu=True, **kwargs)
+    # Neu laedt tagsueber bei 50 ct vor und entlaedt in der 200-ct-Spitze.
+    assert neu["cost_eur"] < alt["cost_eur"]
+    assert any(m == "Akku nur Entladen" for m in neu["modus_verlauf"][19:22])
+
+
+def test_flacher_tag_kein_unterschied():
+    kwargs = dict(load_kw=0.9, pv_kwh_per_hour=[0.0] * 24,
+                  start_soc=50.0, cap_kwh=12.8)
+    alt = simulate_day(FLACH_50, FLACH_50, neu=False, **kwargs)
+    neu = simulate_day(FLACH_50, FLACH_50, neu=True, **kwargs)
+    assert abs(neu["cost_eur"] - alt["cost_eur"]) < 0.01

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,32 @@
+import datetime as dt
+
+from .ha_harness import REPO, TZ, FakeHass, load_yaml, render, render_native
+
+
+def test_render_basic_state():
+    hass = FakeHass(states={"sensor.x": "42.5"})
+    assert render(hass, "{{ states('sensor.x') | float(0) + 1 }}") == "43.5"
+
+
+def test_has_value_and_defaults():
+    hass = FakeHass(states={"sensor.a": "unavailable"})
+    assert render(hass, "{{ has_value('sensor.a') }}") == "False"
+    assert render(hass, "{{ states('sensor.fehlt') | float(-1) }}") == "-1"
+
+
+def test_native_returns_dict():
+    hass = FakeHass()
+    result = render_native(hass, "{{ {'a': 1, 'b': none} }}")
+    assert result == {"a": 1, "b": None}
+
+
+def test_time_functions():
+    now = dt.datetime(2026, 1, 15, 18, 30, tzinfo=TZ)
+    hass = FakeHass(now=now)
+    out = render(hass, "{{ (today_at('00:00') + timedelta(hours=26)).isoformat() }}")
+    assert out == "2026-01-16T02:00:00+01:00"
+
+
+def test_load_repo_yaml():
+    cfg = load_yaml(REPO / "packages" / "opti_derived.yaml")
+    assert "template" in cfg

--- a/tests/test_peak_reserve.py
+++ b/tests/test_peak_reserve.py
@@ -107,3 +107,23 @@ def test_exp_stunden_gehen_in_gesamt_nicht_ve():
     assert peak["ve_stunden"] > 0
     assert peak["exp_stunden"] > 0
     assert peak["ges_soc"] >= peak["ve_soc"]
+
+
+def test_viertelstunden_raster_ungueltig():
+    # 96 Werte (15-min-Raster statt Stunden-Raster): Stundenzuordnung per Index
+    # waere falsch -> gesamte Preisbasis wird verworfen.
+    today = [50.0] * 96
+    peak = _peak(_hass(today, [50.0] * 24))
+    assert peak["gueltig"] is False
+
+
+def test_laufende_peak_stunde_zaehlt():
+    # now = 20:30, mitten in der 19-22-Uhr-Spitze. Das Fenster beginnt jetzt an
+    # der AKTUELLEN vollen Stunde (20:00), nicht erst ab 21:00 - die laufende
+    # Peak-Stunde (20 Uhr) zaehlt mit, damit das Gate waehrend der Spitze nicht
+    # abfaellt.
+    mitten_spitze = dt.datetime(2026, 1, 15, 20, 30, tzinfo=TZ)
+    today = [50.0] * 19 + [200.0, 200.0, 200.0, 50.0, 50.0]
+    peak = _peak(_hass(today, [50.0] * 24, now=mitten_spitze))
+    assert peak["ve_stunden"] == 2  # Stunden 20 + 21
+    assert peak["benoetigt_kwh"] > 0

--- a/tests/test_peak_reserve.py
+++ b/tests/test_peak_reserve.py
@@ -1,0 +1,109 @@
+import datetime as dt
+
+from .ha_harness import (REPO, TZ, FakeHass, find_template_entity,
+                         find_trigger_block_variables, load_yaml, render_native)
+
+WINTER_ABEND = dt.datetime(2026, 1, 15, 17, 30, tzinfo=TZ)  # nach Sonnenuntergang
+
+
+def _hass(today, tomorrow, *, now=WINTER_ABEND, score_heute="1", score_morgen="1",
+          cap="12.8", verbrauch="0.9", minsoc="10", maxsoc="95",
+          sun_state="below_horizon", next_rising="2026-01-16T08:15:00+01:00"):
+    return FakeHass(
+        now=now,
+        states={
+            "sensor.opti_battery_capacity_kwh": cap,
+            "sensor.opti_forecast_score": score_heute,
+            "sensor.opti_forecast_score_tomorrow": score_morgen,
+            "input_number.opti_peak_verbrauch_kw": verbrauch,
+            "input_number.minsoc": minsoc,
+            "input_number.maxsoc": maxsoc,
+            "sun.sun": sun_state,
+        },
+        attrs={
+            "sensor.opti_price_series": {"today": today, "tomorrow": tomorrow},
+            "sun.sun": {"next_rising": next_rising},
+        },
+    )
+
+
+def _peak(hass):
+    cfg = load_yaml(REPO / "packages" / "opti_derived.yaml")
+    template = find_trigger_block_variables(cfg, "peak")
+    return render_native(hass, template)
+
+
+def test_abendspitze_heute_zaehlt():
+    # 19-22 Uhr heute 200 ct, sonst 50 ct; morgen flach 50. Score morgen schlecht -> 36h-Fenster.
+    today = [50.0] * 19 + [200.0, 200.0, 200.0, 50.0, 50.0]
+    peak = _peak(_hass(today, [50.0] * 24))
+    assert peak["ve_stunden"] == 3
+    assert peak["exp_stunden"] == 0
+    # 3 h * 0.9 kW / 0.9 eta = 3.0 kWh -> 10 + 3.0/12.8*100 = 33.4 %
+    assert abs(peak["ges_soc"] - 33.4) < 0.2
+    assert abs(peak["ve_soc"] - 33.4) < 0.2
+    assert peak["benoetigt_kwh"] == 3.0
+    assert peak["min_preis_vor_peak_ct"] == 50.0
+    assert peak["peak_preis_avg_ct"] == 200.0
+
+
+def test_abendspitze_trotz_sonne_morgen_im_horizont():
+    # Morgen sonnig (Score 8): Horizont endet morgen 08:15+3h. Spitze 20-22 Uhr HEUTE zaehlt.
+    today = [50.0] * 20 + [200.0, 200.0, 50.0, 50.0]
+    peak = _peak(_hass(today, [50.0] * 24, score_morgen="8"))
+    assert peak["ve_stunden"] == 2
+    # Morgen-Spitzen wuerden NICHT mehr zaehlen (nach 11:15): Gegenprobe.
+    tomorrow_mit_spitze = [50.0] * 18 + [200.0] * 3 + [50.0] * 3
+    peak2 = _peak(_hass([50.0] * 24, tomorrow_mit_spitze, score_morgen="8"))
+    assert peak2["ve_stunden"] == 0
+
+
+def test_morgen_schlecht_spitze_morgen_zaehlt():
+    tomorrow = [50.0] * 18 + [200.0] * 3 + [50.0] * 3
+    peak = _peak(_hass([50.0] * 24, tomorrow, score_morgen="1"))
+    assert peak["ve_stunden"] == 3
+
+
+def test_tomorrow_fehlt_nur_heute_rest():
+    today = [50.0] * 19 + [200.0, 200.0, 200.0, 50.0, 50.0]
+    peak = _peak(_hass(today, []))
+    assert peak["gueltig"] is True
+    assert peak["ve_stunden"] == 3
+
+
+def test_kappung_bei_maxsoc():
+    # Kleiner Akku (2 kWh): 3 VE-Stunden brauchen 3 kWh -> Kappung bei maxsoc.
+    today = [50.0] * 19 + [200.0, 200.0, 200.0, 50.0, 50.0]
+    peak = _peak(_hass(today, [50.0] * 24, cap="2.0"))
+    assert peak["ges_soc"] == 95.0
+
+
+def test_weniger_als_4_preise_ungueltig():
+    peak = _peak(_hass([50.0, 60.0], []))
+    assert peak["gueltig"] is False
+
+
+def test_sommer_tag_guter_score_horizont_leer():
+    mittag = dt.datetime(2026, 6, 20, 12, 0, tzinfo=TZ)
+    today = [20.0] * 18 + [80.0, 80.0, 80.0, 20.0, 20.0, 20.0]
+    peak = _peak(_hass(today, [20.0] * 24, now=mittag, score_heute="9",
+                       sun_state="above_horizon"))
+    assert peak["ve_stunden"] == 0
+    assert peak["benoetigt_kwh"] == 0.0
+
+
+def test_min_preis_vor_peak_nur_bis_erster_spitze():
+    # Dip (30 ct) VOR der Spitze zaehlt, Dip (10 ct) NACH der Spitze nicht.
+    today = [50.0] * 18 + [30.0, 200.0, 200.0, 10.0, 50.0, 50.0]
+    peak = _peak(_hass(today, [50.0] * 24))
+    assert peak["min_preis_vor_peak_ct"] == 30.0
+
+
+def test_exp_stunden_gehen_in_gesamt_nicht_ve():
+    # Preisprofil mit klarer EXP-Schicht (70-79 Perzentil) und VE-Schicht.
+    today = [20.0 + i for i in range(24)]           # 20..43 aufsteigend
+    tomorrow = [20.0 + i for i in range(24)]
+    peak = _peak(_hass(today, tomorrow))
+    assert peak["ve_stunden"] > 0
+    assert peak["exp_stunden"] > 0
+    assert peak["ges_soc"] >= peak["ve_soc"]

--- a/tests/test_price_level.py
+++ b/tests/test_price_level.py
@@ -1,0 +1,42 @@
+from .ha_harness import REPO, FakeHass, find_template_entity, load_yaml, render
+
+
+def _hass(current, today, tomorrow=None):
+    return FakeHass(
+        states={"sensor.opti_price_current_ct_kwh": str(current)},
+        attrs={"sensor.opti_price_series": {"today": today, "tomorrow": tomorrow or []}},
+    )
+
+
+def _level(hass):
+    cfg = load_yaml(REPO / "packages" / "opti_derived.yaml")
+    entity = find_template_entity(cfg, "sensor", "opti_price_level")
+    return render(hass, entity["state"])
+
+
+def test_flache_preise_sind_normal():
+    # Tie-Bug: mit select('le') war pct=1.0 -> VERY_EXPENSIVE. Midrank: pct=0.5 -> NORMAL.
+    assert _level(_hass(30.0, [30.0] * 24)) == "NORMAL"
+
+
+def test_plateau_mit_spitze_bleibt_normal():
+    # Bens Szenario: 21x 50 ct flach, 3x 200 ct Spitze. Plateau-Stunde ist NORMAL.
+    today = [50.0] * 19 + [200.0, 200.0, 200.0, 50.0, 50.0]
+    assert _level(_hass(50.0, today)) == "NORMAL"
+
+
+def test_spitze_ist_very_expensive():
+    today = [50.0] * 19 + [200.0, 200.0, 200.0, 50.0, 50.0]
+    assert _level(_hass(200.0, today)) == "VERY_EXPENSIVE"
+
+
+def test_unterscheidbare_preise_wie_bisher():
+    # Streng monotone Preise: Midrank == altes Verhalten minus halbem Selbst-Tie.
+    today = [float(10 + i) for i in range(24)]  # 10..33
+    assert _level(_hass(10.0, today)) == "VERY_CHEAP"
+    assert _level(_hass(33.0, today)) == "VERY_EXPENSIVE"
+    assert _level(_hass(21.0, today)) == "NORMAL"
+
+
+def test_weniger_als_4_preise_normal():
+    assert _level(_hass(99.0, [99.0, 99.0])) == "NORMAL"

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -57,7 +57,7 @@ def reserve_attrs(ve=30.0, min_vor=None, avg=None):
 def test_negativpreis_laedt():
     # Preis 3 ct < EEG 8 ct, Prognose schlecht, kein guenstigeres Fenster bekannt.
     assert vorschau(**{"sensor.opti_price_current_ct_kwh": "3",
-                       "sensor.opti_forecast_score": "1"}) == "Akku nur Laden"
+                       "sensor.opti_forecast_score": "1"}) == "Akku Netzladen"
     assert "Negativpreis" in grund(**{"sensor.opti_price_current_ct_kwh": "3",
                                       "sensor.opti_forecast_score": "1"})
 
@@ -67,7 +67,7 @@ def test_negativpreis_wartet_auf_guenstigeres_fenster():
                       "sensor.opti_forecast_score": "1",
                       "sensor.opti_peak_reserve_soc": "35",
                       "_attrs": reserve_attrs(min_vor=-2.0, avg=40.0)})
-    assert out != "Akku nur Laden"  # -2 ct kommt noch -> warten
+    assert out != "Akku Netzladen"  # -2 ct kommt noch -> warten
 
 
 def test_negativpreis_marge_gleiche_preise():
@@ -75,12 +75,12 @@ def test_negativpreis_marge_gleiche_preise():
     assert vorschau(**{"sensor.opti_price_current_ct_kwh": "3",
                        "sensor.opti_forecast_score": "1",
                        "sensor.opti_peak_reserve_soc": "35",
-                       "_attrs": reserve_attrs(min_vor=2.6, avg=40.0)}) == "Akku nur Laden"
+                       "_attrs": reserve_attrs(min_vor=2.6, avg=40.0)}) == "Akku Netzladen"
 
 
 def test_negativpreis_nicht_bei_guter_prognose():
     assert vorschau(**{"sensor.opti_price_current_ct_kwh": "3",
-                       "sensor.opti_forecast_score": "7"}) != "Akku nur Laden"
+                       "sensor.opti_forecast_score": "7"}) != "Akku Netzladen"
 
 
 def test_negativpreis_nicht_ueber_eeg():
@@ -95,7 +95,7 @@ def test_negativpreis_nicht_ueber_eeg():
 def test_negativpreis_gate_aus():
     assert vorschau(**{"sensor.opti_price_current_ct_kwh": "3",
                        "sensor.opti_forecast_score": "1",
-                       "input_boolean.opti_prognose_netzladen": "off"}) != "Akku nur Laden"
+                       "input_boolean.opti_prognose_netzladen": "off"}) != "Akku Netzladen"
 
 
 def test_minsoc_schutz_hat_vorrang():
@@ -118,7 +118,7 @@ VORLADEN = {
 def test_vorladen_bei_grossem_spread():
     # Peak avg 200 ct - aktuell 50 ct = 150 >= 10 -> laden bis Reserve.
     out = vorschau(**VORLADEN, _attrs=reserve_attrs(ve=25.0, min_vor=50.0, avg=200.0))
-    assert out == "Akku nur Laden"
+    assert out == "Akku Netzladen"
     assert "Peak-Vorladen" in grund(**VORLADEN,
                                     _attrs=reserve_attrs(ve=25.0, min_vor=50.0, avg=200.0))
 

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -152,3 +152,86 @@ def test_vorladen_nicht_ohne_netzladen_schalter():
     out = grund(**{**VORLADEN, "input_boolean.opti_prognose_netzladen": "off"},
                 _attrs=reserve_attrs(ve=25.0, min_vor=50.0, avg=200.0))
     assert "Peak-Vorladen" not in out
+
+
+# --- Task 6: Peak-Leiter ---
+
+LEITER = {
+    "sensor.opti_forecast_score": "1",
+    "sensor.opti_forecast_score_tomorrow": "1",
+    "sensor.opti_peak_reserve_soc": "45",
+    "binary_sensor.opti_peak_reserve_aktiv": "on",
+    "sensor.opti_price_current_ct_kwh": "50",
+    # alte Ladebloecke ruhigstellen: SoC hoch genug, dass keiner greift
+    "sensor.opti_soc": "85",
+}
+LEITER_ATTRS = reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0)
+
+
+def test_l1_very_expensive_entlaedt():
+    out = vorschau(**{**LEITER, "sensor.opti_price_level": "VERY_EXPENSIVE"},
+                   _attrs=LEITER_ATTRS)
+    assert out == "Akku nur Entladen"
+
+
+def test_l2_expensive_ueber_ve_reserve_entlaedt():
+    # soc 85 > ve_res 30 + 3 -> entladen.
+    out = vorschau(**{**LEITER, "sensor.opti_price_level": "EXPENSIVE"},
+                   _attrs=LEITER_ATTRS)
+    assert out == "Akku nur Entladen"
+
+
+def test_l3_expensive_unter_ve_reserve_haelt():
+    # prognose_netzladen off, sonst greift der alte SOC<80-Winterblock VOR der
+    # Leiter (gleicher Modus, aber falscher Zweig) - grund pinnt den Zweig fest.
+    fall = {**LEITER, "sensor.opti_price_level": "EXPENSIVE",
+            "sensor.opti_soc": "31",
+            "input_boolean.opti_prognose_netzladen": "off"}
+    assert vorschau(**fall, _attrs=LEITER_ATTRS) == "Akku nur Laden"
+    assert "Peak-Leiter L3" in grund(**fall, _attrs=LEITER_ATTRS)
+
+
+def test_freigabeband_asymmetrisch():
+    # prognose_netzladen off (siehe test_l3). soc 34, ve_res 30:
+    # beim Entladen (Band 3) -> 34 > 33 -> weiter entladen.
+    fall = {**LEITER, "sensor.opti_price_level": "EXPENSIVE",
+            "sensor.opti_soc": "34",
+            "input_boolean.opti_prognose_netzladen": "off"}
+    out = vorschau(**{**fall, "input_select.akkusteuerung_modus": "Akku nur Entladen"},
+                   _attrs=LEITER_ATTRS)
+    assert out == "Akku nur Entladen"
+    # gleicher SoC, aber gerade am Halten (Band 5) -> 34 <= 35 -> halten bleibt.
+    out = vorschau(**{**fall, "input_select.akkusteuerung_modus": "Akku nur Laden"},
+                   _attrs=LEITER_ATTRS)
+    assert out == "Akku nur Laden"
+
+
+def test_l4_normal_unter_gesamtreserve_haelt():
+    # ges_res 45, soc 40 <= 45+3 -> halten. (SoC 40 statt 85, alte Bloecke:
+    # Preis NORMAL + score 1 + soc < 75 wuerde alten Block treffen -> Toggle aus.)
+    out = vorschau(**{**LEITER, "sensor.opti_price_level": "NORMAL",
+                      "sensor.opti_soc": "40",
+                      "input_boolean.opti_prognose_netzladen": "off"},
+                   _attrs=LEITER_ATTRS)
+    assert out == "Akku nur Laden"
+    assert "Peak-Leiter L4" in grund(**{**LEITER, "sensor.opti_price_level": "NORMAL",
+                                        "sensor.opti_soc": "40",
+                                        "input_boolean.opti_prognose_netzladen": "off"},
+                                     _attrs=LEITER_ATTRS)
+
+
+def test_l4_normal_mit_genug_reserve_normalbetrieb():
+    # soc 85 > 45+3 -> keine Leiter-Option, Ziel-SoC-Logik uebernimmt (85 > 60+3).
+    out = vorschau(**{**LEITER, "sensor.opti_price_level": "NORMAL"},
+                   _attrs=LEITER_ATTRS)
+    assert out == "Akku nur Entladen"
+    assert "ueber Ziel-SoC" in grund(**{**LEITER, "sensor.opti_price_level": "NORMAL"},
+                                     _attrs=LEITER_ATTRS)
+
+
+def test_leiter_inaktiv_ohne_gate():
+    out = grund(**{**LEITER, "sensor.opti_price_level": "EXPENSIVE",
+                   "sensor.opti_soc": "31",
+                   "binary_sensor.opti_peak_reserve_aktiv": "off"},
+                _attrs=LEITER_ATTRS)
+    assert "Peak-Leiter" not in out

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -1,0 +1,103 @@
+from .ha_harness import REPO, FakeHass, find_template_entity, load_yaml, render
+
+BASIS = {
+    "sensor.opti_soc": "40",
+    "sensor.opti_battery_capacity_kwh": "12.8",
+    "sensor.opti_forecast_score": "5",
+    "sensor.opti_forecast_score_tomorrow": "5",
+    "sensor.opti_price_level": "NORMAL",
+    "sensor.opti_target_soc": "60",
+    "sensor.opti_price_current_ct_kwh": "30",
+    "sensor.opti_grid_export_w": "0",
+    "sensor.opti_pv_power_w": "0",
+    "sensor.opti_peak_reserve_soc": "unavailable",
+    "binary_sensor.opti_peak_reserve_aktiv": "off",
+    "binary_sensor.opti_winter_charging_allowed": "on",
+    "input_number.minsoc": "10",
+    "input_number.maxsoc": "95",
+    "input_number.opti_einspeiseverguetung_ct": "8",
+    "input_number.opti_netzlade_spread_ct": "10",
+    "input_number.akkusteuerung_wr_70proz_ueberschuss_grenze": "500",
+    "input_number.akkusteuerung_wr_ac_ueberschuss_grenze": "4500",
+    "input_boolean.opti_prognose_netzladen": "on",
+    "input_boolean.opti_pv_ueberschuss_ladung": "on",
+    "input_select.akkusteuerung_modus": "Akku Dynamisch",
+    "sun.sun": "below_horizon",
+}
+
+
+def _render_vorschau(part, overrides):
+    overrides = dict(overrides)
+    attrs = overrides.pop("_attrs", None) or {}
+    states = dict(BASIS)
+    states.update(overrides)
+    hass = FakeHass(states=states, attrs=attrs)
+    cfg = load_yaml(REPO / "packages" / "opti_derived.yaml")
+    entity = find_template_entity(cfg, "sensor", "opti_strategie_vorschau")
+    template = entity["state"] if part == "state" else entity["attributes"]["grund"]
+    return render(hass, template)
+
+
+def vorschau(**overrides):
+    return _render_vorschau("state", overrides)
+
+
+def grund(**overrides):
+    return _render_vorschau("grund", overrides)
+
+
+def reserve_attrs(ve=30.0, min_vor=None, avg=None):
+    return {"sensor.opti_peak_reserve_soc": {
+        "reserve_ve_soc": ve, "min_preis_vor_peak_ct": min_vor,
+        "peak_preis_avg_ct": avg}}
+
+
+# --- Task 4: Negativpreis-Laderegel ---
+
+def test_negativpreis_laedt():
+    # Preis 3 ct < EEG 8 ct, Prognose schlecht, kein guenstigeres Fenster bekannt.
+    assert vorschau(**{"sensor.opti_price_current_ct_kwh": "3",
+                       "sensor.opti_forecast_score": "1"}) == "Akku nur Laden"
+    assert "Negativpreis" in grund(**{"sensor.opti_price_current_ct_kwh": "3",
+                                      "sensor.opti_forecast_score": "1"})
+
+
+def test_negativpreis_wartet_auf_guenstigeres_fenster():
+    out = vorschau(**{"sensor.opti_price_current_ct_kwh": "3",
+                      "sensor.opti_forecast_score": "1",
+                      "sensor.opti_peak_reserve_soc": "35",
+                      "_attrs": reserve_attrs(min_vor=-2.0, avg=40.0)})
+    assert out != "Akku nur Laden"  # -2 ct kommt noch -> warten
+
+
+def test_negativpreis_marge_gleiche_preise():
+    # min_vor = 2.6, aktuell 3.0 -> innerhalb 0.5-ct-Marge -> laden.
+    assert vorschau(**{"sensor.opti_price_current_ct_kwh": "3",
+                       "sensor.opti_forecast_score": "1",
+                       "sensor.opti_peak_reserve_soc": "35",
+                       "_attrs": reserve_attrs(min_vor=2.6, avg=40.0)}) == "Akku nur Laden"
+
+
+def test_negativpreis_nicht_bei_guter_prognose():
+    assert vorschau(**{"sensor.opti_price_current_ct_kwh": "3",
+                       "sensor.opti_forecast_score": "7"}) != "Akku nur Laden"
+
+
+def test_negativpreis_nicht_ueber_eeg():
+    # 12 ct > EEG 8 ct: der ALTE SOC<45-Block darf greifen, aber nicht die
+    # Negativpreis-Regel - deshalb wird das grund-Attribut geprueft.
+    g = grund(**{"sensor.opti_price_current_ct_kwh": "12",
+                 "sensor.opti_forecast_score": "1",
+                 "sensor.opti_price_level": "VERY_CHEAP"})
+    assert "Negativpreis" not in g
+
+
+def test_negativpreis_gate_aus():
+    assert vorschau(**{"sensor.opti_price_current_ct_kwh": "3",
+                       "sensor.opti_forecast_score": "1",
+                       "input_boolean.opti_prognose_netzladen": "off"}) != "Akku nur Laden"
+
+
+def test_minsoc_schutz_hat_vorrang():
+    assert vorschau(**{"sensor.opti_soc": "5",
+                       "sensor.opti_price_current_ct_kwh": "3"}) == "Akku nur Laden"

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -101,3 +101,54 @@ def test_negativpreis_gate_aus():
 def test_minsoc_schutz_hat_vorrang():
     assert vorschau(**{"sensor.opti_soc": "5",
                        "sensor.opti_price_current_ct_kwh": "3"}) == "Akku nur Laden"
+
+
+# --- Task 5: Peak-Vorladeregel ---
+
+VORLADEN = {
+    "sensor.opti_price_current_ct_kwh": "50",
+    "sensor.opti_forecast_score": "1",
+    "sensor.opti_forecast_score_tomorrow": "1",
+    "sensor.opti_peak_reserve_soc": "35",
+    "binary_sensor.opti_peak_reserve_aktiv": "on",
+    "sensor.opti_soc": "15",
+}
+
+
+def test_vorladen_bei_grossem_spread():
+    # Peak avg 200 ct - aktuell 50 ct = 150 >= 10 -> laden bis Reserve.
+    out = vorschau(**VORLADEN, _attrs=reserve_attrs(ve=25.0, min_vor=50.0, avg=200.0))
+    assert out == "Akku nur Laden"
+    assert "Peak-Vorladen" in grund(**VORLADEN,
+                                    _attrs=reserve_attrs(ve=25.0, min_vor=50.0, avg=200.0))
+
+
+def test_vorladen_stoppt_bei_reserve():
+    out = grund(**{**VORLADEN, "sensor.opti_soc": "36"},
+                _attrs=reserve_attrs(ve=25.0, min_vor=50.0, avg=200.0))
+    assert "Peak-Vorladen" not in out
+
+
+def test_vorladen_nicht_bei_kleinem_spread():
+    # Peak avg 32 ct - aktuell 25 ct = 7 < 10 -> nicht vorladen.
+    out = grund(**{**VORLADEN, "sensor.opti_price_current_ct_kwh": "25"},
+                _attrs=reserve_attrs(ve=25.0, min_vor=25.0, avg=32.0))
+    assert "Peak-Vorladen" not in out
+
+
+def test_vorladen_wartet_auf_guenstigstes_fenster():
+    # Dip auf 45 ct kommt noch vor der Spitze -> jetzt (50 ct) nicht laden.
+    out = grund(**VORLADEN, _attrs=reserve_attrs(ve=25.0, min_vor=45.0, avg=200.0))
+    assert "Peak-Vorladen" not in out
+
+
+def test_vorladen_nicht_ohne_gate():
+    out = grund(**{**VORLADEN, "binary_sensor.opti_peak_reserve_aktiv": "off"},
+                _attrs=reserve_attrs(ve=25.0, min_vor=50.0, avg=200.0))
+    assert "Peak-Vorladen" not in out
+
+
+def test_vorladen_nicht_ohne_netzladen_schalter():
+    out = grund(**{**VORLADEN, "input_boolean.opti_prognose_netzladen": "off"},
+                _attrs=reserve_attrs(ve=25.0, min_vor=50.0, avg=200.0))
+    assert "Peak-Vorladen" not in out

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -182,8 +182,10 @@ def test_l2_expensive_ueber_ve_reserve_entlaedt():
 
 
 def test_l3_expensive_unter_ve_reserve_haelt():
-    # prognose_netzladen off, sonst greift der alte SOC<80-Winterblock VOR der
-    # Leiter (gleicher Modus, aber falscher Zweig) - grund pinnt den Zweig fest.
+    # L3/L4 stehen weiterhin HINTER den alten Ladebloecken (nur L1/L2 wurden
+    # vor sie gezogen, Ben-Entscheidung 2026-07-02). Bei soc 31 wuerde ohne
+    # prognose_netzladen=off der alte SOC<80-Winterblock VOR L3 greifen
+    # (gleicher Modus, aber falscher Zweig) - grund pinnt den Zweig fest.
     fall = {**LEITER, "sensor.opti_price_level": "EXPENSIVE",
             "sensor.opti_soc": "31",
             "input_boolean.opti_prognose_netzladen": "off"}
@@ -191,12 +193,26 @@ def test_l3_expensive_unter_ve_reserve_haelt():
     assert "Peak-Leiter L3" in grund(**fall, _attrs=LEITER_ATTRS)
 
 
-def test_freigabeband_asymmetrisch():
-    # prognose_netzladen off (siehe test_l3). soc 34, ve_res 30:
-    # beim Entladen (Band 3) -> 34 > 33 -> weiter entladen.
+def test_l2_schlaegt_alten_winterblock():
+    # L2 steht jetzt VOR dem alten SOC<80-Winterblock: bei EXPENSIVE-Preis und
+    # soc 55 > ve_res 30 + 3 gewinnt die Leiter, obwohl der alte Block (prog on,
+    # winter on, soc<80, beide Scores <3, p_e) ebenfalls zutreffen wuerde.
     fall = {**LEITER, "sensor.opti_price_level": "EXPENSIVE",
-            "sensor.opti_soc": "34",
-            "input_boolean.opti_prognose_netzladen": "off"}
+            "sensor.opti_soc": "55",
+            "sensor.opti_peak_reserve_soc": "45"}
+    out = vorschau(**fall, _attrs=reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0))
+    assert out == "Akku nur Entladen"
+    assert "Peak-Leiter L2" in grund(**fall, _attrs=reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0))
+
+
+def test_freigabeband_asymmetrisch():
+    # L2 steht jetzt vor den alten Ladebloecken, daher gewinnt die Leiter auch
+    # bei prog=on (kein Workaround mehr noetig). ges_res auf 34 gesetzt (statt
+    # LEITER-Default 45), sonst wuerde die noch frueher stehende Peak-Vorlade-
+    # regel greifen (soc 34 < ges_res waere sonst erfuellt und prog-gated).
+    # soc 34, ve_res 30: beim Entladen (Band 3) -> 34 > 33 -> weiter entladen.
+    fall = {**LEITER, "sensor.opti_price_level": "EXPENSIVE",
+            "sensor.opti_soc": "34", "sensor.opti_peak_reserve_soc": "34"}
     out = vorschau(**{**fall, "input_select.akkusteuerung_modus": "Akku nur Entladen"},
                    _attrs=LEITER_ATTRS)
     assert out == "Akku nur Entladen"

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -154,6 +154,28 @@ def test_vorladen_nicht_ohne_netzladen_schalter():
     assert "Peak-Vorladen" not in out
 
 
+def test_vorladen_nicht_ohne_preis():
+    # M1: hv_cur-Guard - fehlt der aktuelle Preis, darf Peak-Vorladen nicht greifen
+    # (cur faellt sonst per float(0) auf 0 zurueck und wuerde den Spread verfaelschen).
+    out = grund(**{**VORLADEN, "sensor.opti_price_current_ct_kwh": "unavailable"},
+                _attrs=reserve_attrs(ve=25.0, min_vor=50.0, avg=200.0))
+    assert "Peak-Vorladen" not in out
+
+
+def test_vorladen_haelt_bis_reserve_im_lademodus():
+    # Stop-Kanten-Band (I2): im Modus 'Akku Netzladen' ist stopband 0, sonst 3.
+    # soc 34, ges_res 35: im Lademodus laedt es weiter (34 < 35 - 0), im
+    # Dynamisch-Modus nicht mehr (34 >= 35 - 3 = 32).
+    fall = {**VORLADEN, "sensor.opti_soc": "34"}
+    attrs = reserve_attrs(ve=25.0, min_vor=50.0, avg=200.0)
+    out_lademodus = grund(**{**fall, "input_select.akkusteuerung_modus": "Akku Netzladen"},
+                          _attrs=attrs)
+    assert "Peak-Vorladen" in out_lademodus
+    out_dynamisch = grund(**{**fall, "input_select.akkusteuerung_modus": "Akku Dynamisch"},
+                          _attrs=attrs)
+    assert "Peak-Vorladen" not in out_dynamisch
+
+
 # --- Task 6: Peak-Leiter ---
 
 LEITER = {

--- a/tools/backtest.py
+++ b/tools/backtest.py
@@ -1,0 +1,171 @@
+"""Stunden-Backtest der Opti-Strategie: faehrt die ECHTEN Jinja-Templates
+(Reserve-Sensor + Strategie-Vorschau) gegen Preis-/Lastprofile und simuliert
+den SoC-Verlauf. Vergleich alt (neue Regeln stillgelegt) vs. neu.
+
+Modus-Wirkung im Simulator (vereinfachtes Adapter-Modell):
+  Akku nur Laden     -> Entladen gesperrt; laedt aus Netz nur wenn eine der
+                        beiden Netzladeregeln aktiv war (Grund-Text), sonst idle.
+  Akku nur Entladen  -> deckt Hauslast aus dem Akku (bis minsoc).
+  Akku Dynamisch     -> deckt Hauslast aus dem Akku (bis minsoc), laedt PV ein.
+Verluste: Laden und Entladen je mit eta=0.95 (Round-Trip ~0.9).
+"""
+from __future__ import annotations
+
+import datetime as dt
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from tests.ha_harness import (REPO, TZ, FakeHass, find_template_entity,
+                              find_trigger_block_variables, load_yaml,
+                              render, render_native)
+
+ETA = 0.95
+LADE_KW = 2.5  # angenommene Netz-Ladeleistung im Simulator
+
+_derived = load_yaml(REPO / "packages" / "opti_derived.yaml")
+_vorschau = find_template_entity(_derived, "sensor", "opti_strategie_vorschau")
+_peak_template = find_trigger_block_variables(_derived, "peak")
+
+
+def _states(hour_price, soc, load_kw, neu, cap_kwh, peak):
+    minv = peak["min_preis_vor_peak_ct"] if peak else None
+    avg = peak["peak_preis_avg_ct"] if peak else None
+    aktiv = bool(peak and peak["gueltig"] and peak["benoetigt_kwh"] > 0)
+    return FakeHass(
+        states={
+            "sensor.opti_soc": str(round(soc, 2)),
+            "sensor.opti_battery_capacity_kwh": str(cap_kwh),
+            "sensor.opti_forecast_score": "1",
+            "sensor.opti_forecast_score_tomorrow": "1",
+            "sensor.opti_price_level": "unknown",  # wird unten gesetzt
+            "sensor.opti_target_soc": "95",
+            "sensor.opti_price_current_ct_kwh": str(hour_price),
+            "sensor.opti_grid_export_w": "0",
+            "sensor.opti_pv_power_w": "0",
+            "sensor.opti_peak_reserve_soc":
+                str(peak["ges_soc"]) if aktiv else "unavailable",
+            "binary_sensor.opti_peak_reserve_aktiv": "on" if (neu and aktiv) else "off",
+            "binary_sensor.opti_winter_charging_allowed": "on",
+            "input_number.minsoc": "10",
+            "input_number.maxsoc": "95",
+            "input_number.opti_peak_verbrauch_kw": str(load_kw),
+            "input_number.opti_einspeiseverguetung_ct": "8" if neu else "0",
+            "input_number.opti_netzlade_spread_ct": "10" if neu else "999",
+            "input_number.akkusteuerung_wr_70proz_ueberschuss_grenze": "500",
+            "input_number.akkusteuerung_wr_ac_ueberschuss_grenze": "4500",
+            "input_boolean.opti_prognose_netzladen": "on",
+            "input_boolean.opti_pv_ueberschuss_ladung": "on",
+            "input_select.akkusteuerung_modus": "Akku Dynamisch",
+            "sun.sun": "below_horizon",
+        },
+        attrs={"sensor.opti_peak_reserve_soc": {
+            "reserve_ve_soc": peak["ve_soc"] if peak else None,
+            "min_preis_vor_peak_ct": minv,
+            "peak_preis_avg_ct": avg}},
+    )
+
+
+def _price_level(prices, current):
+    kleiner = len([p for p in prices if p < current])
+    gleich = len([p for p in prices if p == current])
+    pct = (kleiner + 0.5 * gleich) / len(prices)
+    if pct < 0.20:
+        return "VERY_CHEAP"
+    if pct < 0.40:
+        return "CHEAP"
+    if pct < 0.60:
+        return "NORMAL"
+    if pct < 0.80:
+        return "EXPENSIVE"
+    return "VERY_EXPENSIVE"
+
+
+def simulate_day(prices_today, prices_tomorrow, *, load_kw, pv_kwh_per_hour,
+                 start_soc, cap_kwh, neu, modus_start="Akku Dynamisch"):
+    soc = start_soc
+    modus = modus_start
+    cost = 0.0
+    soc_verlauf, modus_verlauf = [], []
+    alle_preise = list(prices_today) + list(prices_tomorrow)
+    for hour in range(24):
+        preis = prices_today[hour]
+        now = dt.datetime(2026, 1, 15, hour, 30, tzinfo=TZ)
+        # 1. Reserve-Sensor mit echtem Template rechnen
+        peak_hass = FakeHass(
+            now=now,
+            states={
+                "sensor.opti_battery_capacity_kwh": str(cap_kwh),
+                "sensor.opti_forecast_score": "1",
+                "sensor.opti_forecast_score_tomorrow": "1",
+                "input_number.opti_peak_verbrauch_kw": str(load_kw),
+                "input_number.minsoc": "10",
+                "input_number.maxsoc": "95",
+                "sun.sun": "below_horizon",
+            },
+            attrs={
+                "sensor.opti_price_series":
+                    {"today": prices_today, "tomorrow": prices_tomorrow},
+                "sun.sun": {"next_rising": "2026-01-16T08:15:00+01:00"},
+            })
+        peak = render_native(peak_hass, _peak_template)
+        # 2. Strategie-Entscheidung mit echtem Vorschau-Template
+        hass = _states(preis, soc, load_kw, neu, cap_kwh, peak)
+        hass.now_value = now
+        hass.states_map["sensor.opti_price_level"] = _price_level(alle_preise, preis)
+        hass.states_map["input_select.akkusteuerung_modus"] = modus
+        modus = render(hass, _vorschau["state"])
+        grund = render(hass, _vorschau["attributes"]["grund"])
+        # 3. Energiefluss der Stunde
+        pv = pv_kwh_per_hour[hour]
+        last = load_kw
+        if modus == "Akku nur Entladen" or modus == "Akku Dynamisch":
+            entnehmbar = max(0.0, (soc - 10) / 100 * cap_kwh) * ETA
+            aus_akku = min(last, entnehmbar)
+            soc -= aus_akku / ETA / cap_kwh * 100
+            cost += (last - aus_akku) * preis / 100
+        else:  # Akku nur Laden: Entladen gesperrt, Haus aus dem Netz
+            cost += last * preis / 100
+            if "Negativpreis" in grund or "Peak-Vorladen" in grund:
+                lade = min(LADE_KW, (95 - soc) / 100 * cap_kwh / ETA)
+                soc += lade * ETA / cap_kwh * 100
+                cost += lade * preis / 100
+        if pv > 0 and soc < 95:
+            soc = min(95.0, soc + pv * ETA / cap_kwh * 100)
+        soc = max(0.0, min(100.0, soc))
+        soc_verlauf.append(round(soc, 1))
+        modus_verlauf.append(modus)
+    return {"cost_eur": round(cost, 2), "soc_verlauf": soc_verlauf,
+            "modus_verlauf": modus_verlauf}
+
+
+SZENARIEN = {
+    "Abendspitze (Bens 2-EUR-Szenario)": {
+        "prices_today": [50.0] * 19 + [200.0, 200.0, 200.0, 50.0, 50.0],
+        "prices_tomorrow": [50.0] * 24, "start_soc": 15.0},
+    "Flacher Wintertag": {
+        "prices_today": [32.0] * 24, "prices_tomorrow": [32.0] * 24,
+        "start_soc": 50.0},
+    "Typischer Tibber-Wintertag (Morgen- + Abendpeak)": {
+        "prices_today": [28, 26, 25, 25, 26, 30, 38, 45, 42, 35, 32, 30,
+                         29, 29, 30, 33, 38, 44, 48, 46, 40, 34, 30, 28],
+        "prices_tomorrow": [28, 26, 25, 25, 26, 30, 38, 45, 42, 35, 32, 30,
+                            29, 29, 30, 33, 38, 44, 48, 46, 40, 34, 30, 28],
+        "start_soc": 35.0},
+}
+
+
+def main():
+    for name, sz in SZENARIEN.items():
+        kwargs = dict(load_kw=0.9, pv_kwh_per_hour=[0.0] * 24, cap_kwh=12.8, **sz)
+        alt = simulate_day(neu=False, **kwargs)
+        neu = simulate_day(neu=True, **kwargs)
+        delta = alt["cost_eur"] - neu["cost_eur"]
+        print(f"{name}\n  alt: {alt['cost_eur']:6.2f} EUR   "
+              f"neu: {neu['cost_eur']:6.2f} EUR   Ersparnis: {delta:+.2f} EUR")
+        print(f"  Modi neu: {neu['modus_verlauf']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/backtest.py
+++ b/tools/backtest.py
@@ -3,8 +3,10 @@
 den SoC-Verlauf. Vergleich alt (neue Regeln stillgelegt) vs. neu.
 
 Modus-Wirkung im Simulator (vereinfachtes Adapter-Modell):
-  Akku nur Laden     -> Entladen gesperrt; laedt aus Netz nur wenn eine der
-                        beiden Netzladeregeln aktiv war (Grund-Text), sonst idle.
+  Akku nur Laden     -> reine Entladesperre (kein Netzbezug); Haus laeuft aus
+                        dem Netz, Akku bleibt idle.
+  Akku Netzladen     -> erzwungenes Netzladen (beide Laderegeln setzen diesen
+                        Modus); laedt aus dem Netz bis 95% SoC.
   Akku nur Entladen  -> deckt Hauslast aus dem Akku (bis minsoc).
   Akku Dynamisch     -> deckt Hauslast aus dem Akku (bis minsoc), laedt PV ein.
 Verluste: Laden und Entladen je mit eta=0.95 (Round-Trip ~0.9).
@@ -125,12 +127,13 @@ def simulate_day(prices_today, prices_tomorrow, *, load_kw, pv_kwh_per_hour,
             aus_akku = min(last, entnehmbar)
             soc -= aus_akku / ETA / cap_kwh * 100
             cost += (last - aus_akku) * preis / 100
-        else:  # Akku nur Laden: Entladen gesperrt, Haus aus dem Netz
+        elif modus == "Akku Netzladen":  # erzwungenes dynamisches Netzladen
             cost += last * preis / 100
-            if "Negativpreis" in grund or "Peak-Vorladen" in grund:
-                lade = min(LADE_KW, (95 - soc) / 100 * cap_kwh / ETA)
-                soc += lade * ETA / cap_kwh * 100
-                cost += lade * preis / 100
+            lade = min(LADE_KW, (95 - soc) / 100 * cap_kwh / ETA)
+            soc += lade * ETA / cap_kwh * 100
+            cost += lade * preis / 100
+        else:  # Akku nur Laden: reine Entladesperre (idle), Haus aus dem Netz
+            cost += last * preis / 100
         if pv > 0 and soc < 95:
             soc = min(95.0, soc + pv * ETA / cap_kwh * 100)
         soc = max(0.0, min(100.0, soc))


### PR DESCRIPTION
## Was

- Neuer trigger-basierter Sensor `sensor.opti_peak_reserve_soc` + Gate `binary_sensor.opti_peak_reserve_aktiv`: Reserve fuer kommende teure Stunden im Wiederauflade-Horizont (ab aktueller Stunde, max. 36h, Ende = naechster Sonnenaufgang + 3h mit gutem Tages-Score).
- Peak-Leiter L1-L4 in der Strategie: Entladen pro Preislevel nur ueber der berechneten Reserve, asymmetrisches Freigabeband (+5/+3, Modus als Gedaechtnis). L1/L2 (Entlade-Stufen) stehen vor den alten Winterladebloecken, L3/L4 (Halten) dahinter.
- Negativpreis-Laderegel (Preis < Einspeiseverguetung) und spread-basierte Peak-Vorladeregel, beide mit Ladefenster-Wahl (0.5-ct-Marge) und Stop-Kanten-Band. Beide setzen den NEUEN Modus **"Akku Netzladen"** (dynamisches Netzladen via BatChaMinW = `opti_charge_power_w`) - braucht `ha-modbus-akku-adapter` >= v1.5.0 (Branch `feat/modus-netzladen`, wird nach Live-Regressionstest gepusht). Ohne Adapter-Update sind die zwei Laderegeln wirkungslos (Modus faellt auf nichts zurueck), die Leiter funktioniert unabhaengig davon.
- Voraussetzungs-Fix: Midrank-Perzentil in `opti_price_level` (Tie-Bug: flache Preistage wurden komplett VERY_EXPENSIVE klassifiziert; aendert bewusst auch Live-Verhalten).
- Raster-Guard (Preislisten > 25 Eintraege deaktivieren die Reserve), Fail-safes (< 4 Preise -> Leiter inaktiv).
- Neu: Test-Harness `tests/` (Fake-HA-Jinja, rendert die echten Templates) + Stunden-Backtest `tools/backtest.py`.
- 3 neue Konfigurations-Helfer (`opti_peak_verbrauch_kw`, `opti_einspeiseverguetung_ct`, `opti_netzlade_spread_ct`), Doku in strategie-logik.md / canonical-layer.md / README.

## Verifikation

- pytest-Suite 46/46 gruen (Harness, Preislevel, Reserve, Vorschau-Kette, Backtest).
- Jinja2-Parse-Check: 138 Templates, 0 Fehler. YAML parst. Privacy-Scan sauber.
- Backtest: Abendspitzen-Szenario (2 EUR/kWh, 19-22 Uhr) spart 2.93 EUR/Tag; flacher Tag identisch; Tibber-Tags-Szenario -0.91 EUR ist ein bestaetigtes Terminal-SoC-Bilanzierungs-Artefakt (Tag endet mit 65% statt 10% SoC, restwertbereinigt positiv).
- Zwei unabhaengige Whole-Branch-Reviews + Codex-Zweitmeinungen; alle Critical/Important-Findings gefixt (u.a. Laderegeln-Aktor, Leiter-Vorrang, Fenster-Start in der laufenden Peak-Stunde).
- Bekannte akzeptierte Punkte: langsame Oszillation an der maxsoc-Kante bei langen Negativpreis-Fenstern (30-60-min-Halbzyklen, Folge-Fix-Kandidat), DST-Index-Limitation, Helfer-Aenderungen wirken erst beim naechsten Trigger.
- Live-Deploy + 24-48h-Beobachtung folgt separat (manuelle Checkliste; Live-Strategie ist das divergente Package `opti_canonical_strategie`, wird in-place aktualisiert; trigger-basierte Templates mit `variables:` brauchen HA >= 2024.10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vWz4Jg6U2hiQawvuKCypo