### PR TITLE
Tuning: Oekonomische Peak-Filterung + L3-Halte-Spread (Winter-Backtest-Sweep)

### DIFF
--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -556,6 +556,12 @@
         # Laden schlaegt Halten).
         # Freigabeband asymmetrisch: aus dem Halten erst bei Reserve+5 wieder
         # freigeben, beim Entladen bis Reserve+3 runter (Modus = Gedaechtnis).
+        # L3-Halte-Spread (Tuning-Hebel 2): zusaetzlich muss der VE-Preis-
+        # durchschnitt der kommenden Peak-Stunden mindestens
+        # opti_halte_spread_ct ueber dem aktuellen Preis liegen - Halten ohne
+        # echten VE-Vorteil kostet nur Netzbezug. Greift die Bedingung nicht,
+        # faellt EXPENSIVE ohne Halten durch (L2 hat oberhalb der VE-Reserve
+        # bereits entladen; unterhalb geht es zu den Ziel-SoC-Optionen/Default).
         # ---------------------------------------------------------------------
         - alias: "Peak-Leiter L3 'nur Laden' (halten): EXPENSIVE, Reserve fuer VERY_EXPENSIVE"
           conditions:
@@ -571,6 +577,12 @@
                 {% set ve = state_attr('sensor.opti_peak_reserve_soc', 'reserve_ve_soc') | float(none) %}
                 {% set band = 5 if is_state('input_select.akkusteuerung_modus', 'Akku nur Laden') else 3 %}
                 {{ soc is not none and ve is not none and soc <= ve + band }}
+            - condition: template
+              value_template: >-
+                {% set ve_avg = state_attr('sensor.opti_peak_reserve_soc', 'peak_preis_ve_avg_ct') | float(none) %}
+                {% set cur = states('sensor.opti_price_current_ct_kwh') | float(none) %}
+                {% set halte_spread = states('input_number.opti_halte_spread_ct') | float(3) %}
+                {{ ve_avg is not none and cur is not none and (ve_avg - cur) >= halte_spread }}
           sequence:
             - action: input_select.select_option
               data:

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -252,6 +252,7 @@ Empfohlener Startwert aus dem Winter-Backtest-Sweep: **5 ct**.
 **Tuning-Runde Winter-Backtest (2026-07-02).**
 Beide Hebel wurden per gestuftem Parameter-Sweep gegen einen 120-Tage-Winter-Backtest (Nov 2025 - Feb 2026, echte Preise/Last/PV) kalibriert; `opti_netzlade_spread_ct` = 10 wurde dabei bestätigt (15 drückt die VE-Abdeckung unter die Vorgabe).
 Gewinner-Kombination: `opti_peak_min_aufschlag_ct` = 5, `opti_halte_spread_ct` = 5, `opti_netzlade_spread_ct` = 10.
+Die ersten beiden Helfer haben Template-Fallbacks (10 ct bzw. 3 ct), die beim initialen Setup von den empfohlenen Startwerten abweichen - manuell setzen für optimale Performance.
 Ergebnis: VE-Stunden-Abdeckung aus dem Akku steigt von 26.2 % (alt) auf 32.9 %, die Mehrkosten der Peak-Allokation sinken von 17.07 EUR auf 3.61 EUR pro Winter (inkl. Rest-SoC-Korrektur), die PV-Verdrängung von 131 kWh auf 53 kWh.
 Das ursprüngliche Ziel "billiger als alt bei mehr VE-Abdeckung" wurde damit **nicht** erreicht - die Peak-Allokation kostet im Backtest-Winter noch ~3.6 EUR Aufpreis für +6.7 Prozentpunkte VE-Abdeckung.
 

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -24,7 +24,7 @@ Zentrales Entitäts-Modell (Canonical-`opti_*`-Layer):
 - `binary_sensor.opti_winter_charging_allowed` — Winterladefreigabe (Standard: `true`)
 - `sensor.opti_peak_reserve_soc` - berechneter Reserve-SoC für kommende Preisspitzen (36h-Horizont)
 - `binary_sensor.opti_peak_reserve_aktiv` - Gate: Peaks im Wiederauflade-Horizont vorhanden
-- `input_number.opti_peak_verbrauch_kw` / `opti_einspeiseverguetung_ct` / `opti_netzlade_spread_ct` - Konfiguration der Peak-Allokation
+- `input_number.opti_peak_verbrauch_kw` / `opti_einspeiseverguetung_ct` / `opti_netzlade_spread_ct` / `opti_peak_min_aufschlag_ct` / `opti_halte_spread_ct` - Konfiguration der Peak-Allokation
 - `input_select.akkusteuerung_modus` — Ziel-Ausgang dieser Automation
 
 ---
@@ -212,6 +212,12 @@ Ein sonniger Tag von morgen schließt die heutige Abendspitze also nicht aus dem
 **Klassifikation.**
 Jede Stunde im Horizont wird mit demselben **Midrank-Perzentil** wie `sensor.opti_price_level` eingestuft (gleiche Grenzen: ≥ 80 % → VERY_EXPENSIVE, ≥ 60 % → EXPENSIVE) - ein konsistentes Preisniveau-Konzept für die ganze Strategie.
 
+**Ökonomische Peak-Filterung (Tuning-Hebel 1).**
+Zusätzlich zur Perzentil-Einstufung zählt eine Stunde nur dann als Peak, wenn ihr Preis das Horizont-Tief (`fenster_min_ct`, günstigster Preis im Horizont) um mindestens `input_number.opti_peak_min_aufschlag_ct` übersteigt (UND-Bedingung, Grenzfall `>=` zählt).
+Das filtert die Perzentil-Zwangs-Peaks flacher Tage heraus: bei 30.0 vs 30.5 ct gibt es nichts zu reservieren, auch wenn die 30.5-ct-Stunden formal im obersten Quintil liegen.
+`min_preis_vor_peak_ct` bezieht sich weiterhin auf die erste **gezählte** Peak-Stunde.
+Empfohlener Startwert aus dem Winter-Backtest-Sweep (Nov 25 - Feb 26, siehe unten): **5 ct**.
+
 **Formel.**
 Für jede VERY_EXPENSIVE- bzw. VERY_EXPENSIVE+EXPENSIVE-Stunde im Horizont:
 
@@ -232,10 +238,22 @@ Sie steht in der Optionsliste **vor** den normalen Ziel-SoC-Optionen, sonst wür
 |---|---|---|---|
 | **L1** | VERY_EXPENSIVE | - | Akku nur Entladen |
 | **L2** | EXPENSIVE | SoC > `reserve_ve_soc` + Band | Akku nur Entladen |
-| **L3** | EXPENSIVE | SoC ≤ `reserve_ve_soc` + Band | Akku nur Laden (halten) |
+| **L3** | EXPENSIVE | SoC ≤ `reserve_ve_soc` + Band **und** `peak_preis_ve_avg_ct` - aktueller Preis ≥ `opti_halte_spread_ct` | Akku nur Laden (halten) |
 | **L4** | NORMAL oder billiger | SoC ≤ `reserve_gesamt_soc` + Band | Akku nur Laden (halten) |
 
 Ist keine Stufe einschlägig (z. B. NORMAL-Preis mit ausreichend SoC über der Reserve), fällt die Prüfung durch zu den normalen Ziel-SoC-Optionen.
+
+**L3-Halte-Spread (Tuning-Hebel 2).**
+L3 hält bei EXPENSIVE nur noch, wenn der Preisdurchschnitt der kommenden gezählten VERY_EXPENSIVE-Stunden (neues Attribut `peak_preis_ve_avg_ct` am Reserve-Sensor, `none` ohne VE-Stunden) mindestens `input_number.opti_halte_spread_ct` über dem aktuellen Preis liegt.
+Halten bei dünnem VE/EXP-Spread (3-6 ct) kostet mehr Netzbezug, als das spätere VE-Entladen zurückbringt.
+Greift die Bedingung nicht, fällt EXPENSIVE ohne Halten zur restlichen Kette durch (L2 hat oberhalb der VE-Reserve bereits entladen, unterhalb geht es zu den Ziel-SoC-Optionen bzw. dem Default).
+Empfohlener Startwert aus dem Winter-Backtest-Sweep: **5 ct**.
+
+**Tuning-Runde Winter-Backtest (2026-07-02).**
+Beide Hebel wurden per gestuftem Parameter-Sweep gegen einen 120-Tage-Winter-Backtest (Nov 2025 - Feb 2026, echte Preise/Last/PV) kalibriert; `opti_netzlade_spread_ct` = 10 wurde dabei bestätigt (15 drückt die VE-Abdeckung unter die Vorgabe).
+Gewinner-Kombination: `opti_peak_min_aufschlag_ct` = 5, `opti_halte_spread_ct` = 5, `opti_netzlade_spread_ct` = 10.
+Ergebnis: VE-Stunden-Abdeckung aus dem Akku steigt von 26.2 % (alt) auf 32.9 %, die Mehrkosten der Peak-Allokation sinken von 17.07 EUR auf 3.61 EUR pro Winter (inkl. Rest-SoC-Korrektur), die PV-Verdrängung von 131 kWh auf 53 kWh.
+Das ursprüngliche Ziel "billiger als alt bei mehr VE-Abdeckung" wurde damit **nicht** erreicht - die Peak-Allokation kostet im Backtest-Winter noch ~3.6 EUR Aufpreis für +6.7 Prozentpunkte VE-Abdeckung.
 
 **Asymmetrisches Freigabeband.**
 Damit der Modus nicht direkt an der Reserve-Kante flattert, ist das Band abhängig vom *aktuellen* Modus - der Modus dient als Gedächtnis des Vorzustands:
@@ -539,13 +557,16 @@ einspeisen, bei Verbrauch den Akku nutzen — je nach aktuellem Systemzustand.
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | `binary_sensor.opti_peak_reserve_aktiv` = on, SoC ≤ `reserve_ve_soc` + Freigabeband |
+| Bedingung | `binary_sensor.opti_peak_reserve_aktiv` = on, SoC ≤ `reserve_ve_soc` + Freigabeband, `peak_preis_ve_avg_ct` - aktueller Preis ≥ `opti_halte_spread_ct` |
 | Preis | EXPENSIVE |
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Laden** (Entladesperre, hält die VE-Reserve) |
 
 **Warum:** Reicht der SoC nicht mehr deutlich über der VERY_EXPENSIVE-Reserve, wird das
 Entladen gesperrt, damit die kommende VERY_EXPENSIVE-Stunde nicht leerläuft.
+Der Halte-Spread verhindert Halten ohne echten VE-Vorteil: liegen die kommenden VE-Stunden
+preislich kaum über der aktuellen EXPENSIVE-Stunde, kostet die Entladesperre nur Netzbezug
+(siehe [L3-Halte-Spread](#die-leiter-l1-l4)).
 
 ---
 

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -549,7 +549,7 @@ template:
           {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}Akku Dynamisch
           {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}Akku Dynamisch
           {%- elif soc > 99 %}Akku Dynamisch
-          {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Akku nur Laden
+          {%- elif aktiv and hv_cur and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Akku nur Laden
           {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Akku nur Laden
           {%- elif soc > minsoc and soc < target - H and day %}Akku Dynamisch
           {%- elif soc > target + H %}Akku nur Entladen
@@ -605,7 +605,7 @@ template:
             {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}70% Ueberschuss (tag)
             {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}AC Ueberschuss (tag)
             {%- elif soc > 99 %}Akku voll
-            {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Peak-Leiter L3 (halten fuer VE, Reserve {{ve_res}}%, Spread {{(ve_avg - cur)|round(1)}}ct)
+            {%- elif aktiv and hv_cur and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Peak-Leiter L3 (halten fuer VE, Reserve {{ve_res}}%, Spread {{(ve_avg - cur)|round(1)}}ct)
             {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Peak-Leiter L4 (halten fuer Peaks, Reserve {{ges_res}}%)
             {%- elif soc > minsoc and soc < target - H and day %}dyn bis Ziel (tag)
             {%- elif soc > target + H %}ueber Ziel-SoC

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -531,6 +531,8 @@ template:
           {% set minv_raw = state_attr('sensor.opti_peak_reserve_soc','min_preis_vor_peak_ct') %}
           {% set minv = minv_raw|float(none) if minv_raw is not none else none %}
           {% set avg = state_attr('sensor.opti_peak_reserve_soc','peak_preis_avg_ct')|float(none) %}
+          {% set ve_avg = state_attr('sensor.opti_peak_reserve_soc','peak_preis_ve_avg_ct')|float(none) %}
+          {% set halte_spread = states('input_number.opti_halte_spread_ct')|float(3) %}
           {% set band = 5 if states('input_select.akkusteuerung_modus') == 'Akku nur Laden' else 3 %}
           {% set stopband = 0 if states('input_select.akkusteuerung_modus') == 'Akku Netzladen' else 3 %}
           {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
@@ -547,7 +549,7 @@ template:
           {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}Akku Dynamisch
           {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}Akku Dynamisch
           {%- elif soc > 99 %}Akku Dynamisch
-          {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' %}Akku nur Laden
+          {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Akku nur Laden
           {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Akku nur Laden
           {%- elif soc > minsoc and soc < target - H and day %}Akku Dynamisch
           {%- elif soc > target + H %}Akku nur Entladen
@@ -585,6 +587,8 @@ template:
             {% set minv_raw = state_attr('sensor.opti_peak_reserve_soc','min_preis_vor_peak_ct') %}
             {% set minv = minv_raw|float(none) if minv_raw is not none else none %}
             {% set avg = state_attr('sensor.opti_peak_reserve_soc','peak_preis_avg_ct')|float(none) %}
+            {% set ve_avg = state_attr('sensor.opti_peak_reserve_soc','peak_preis_ve_avg_ct')|float(none) %}
+            {% set halte_spread = states('input_number.opti_halte_spread_ct')|float(3) %}
             {% set band = 5 if states('input_select.akkusteuerung_modus') == 'Akku nur Laden' else 3 %}
             {% set stopband = 0 if states('input_select.akkusteuerung_modus') == 'Akku Netzladen' else 3 %}
             {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
@@ -601,7 +605,7 @@ template:
             {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}70% Ueberschuss (tag)
             {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}AC Ueberschuss (tag)
             {%- elif soc > 99 %}Akku voll
-            {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' %}Peak-Leiter L3 (halten fuer VE, Reserve {{ve_res}}%)
+            {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Peak-Leiter L3 (halten fuer VE, Reserve {{ve_res}}%, Spread {{(ve_avg - cur)|round(1)}}ct)
             {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Peak-Leiter L4 (halten fuer Peaks, Reserve {{ges_res}}%)
             {%- elif soc > minsoc and soc < target - H and day %}dyn bis Ziel (tag)
             {%- elif soc > target + H %}ueber Ziel-SoC
@@ -643,12 +647,14 @@ template:
           - input_number.opti_peak_verbrauch_kw
           - input_number.minsoc
           - input_number.maxsoc
+          - input_number.opti_peak_min_aufschlag_ct
     variables:
       peak: >
         {% set cap_kwh = states('sensor.opti_battery_capacity_kwh') | float(0) %}
         {% set verbrauch_kw = states('input_number.opti_peak_verbrauch_kw') | float(0.8) %}
         {% set min_soc = states('input_number.minsoc') | float(10) %}
         {% set max_soc = states('input_number.maxsoc') | float(95) %}
+        {% set aufschlag = states('input_number.opti_peak_min_aufschlag_ct') | float(10) %}
         {% set eta = 0.9 %}
         {# 1. Preisbasis + Zukunftsstunden einsammeln (Stundenindex -> Zeitpunkt).
            Raster-Guard: Listen > 25 Eintraege (15-min-Raster o.ae.) -> ungueltig;
@@ -692,12 +698,30 @@ template:
             {% set horizont_ende = horizont_max %}
           {% endif %}
         {% endif %}
-        {# 3. Zukunftsstunden im Horizont klassifizieren (Midrank-Perzentil).
-           Fenster ab der aktuellen vollen Stunde: die laufende Peak-Stunde
-           zaehlt mit, damit das Gate waehrend der Spitze nicht abfaellt
-           (laufende Stunde konservativ voll gerechnet). #}
+        {# 3a. Erster Durchlauf: Horizont-Tief (fenster_min) unter den
+           Zukunftsstunden im Horizont bestimmen - Basis fuer die oekonomische
+           Peak-Filterung (Hebel 1: nur Stunden, die den Aufschlag ueber dem
+           Horizont-Tief bringen, zaehlen als Peak). #}
         {% set start = now().replace(minute=0, second=0, microsecond=0) %}
-        {% set f = namespace(ve=0, exp=0, minpre=none, summe=0.0, anz=0, peak_gesehen=false) %}
+        {% set fw = namespace(min=none) %}
+        {% if n >= 4 %}
+          {% for eintrag in ns.future %}
+            {% set t = eintrag[0] %}
+            {% set p = eintrag[1] %}
+            {% if t >= start and t < horizont_ende %}
+              {% set fw.min = p if fw.min is none else ([fw.min, p] | min) %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        {% set fenster_min = fw.min %}
+        {# 3b. Zweiter Durchlauf: Zukunftsstunden im Horizont klassifizieren
+           (Midrank-Perzentil, Grenzen unveraendert) UND zusaetzlich oekonomisch
+           filtern (p >= fenster_min + aufschlag). Fenster ab der aktuellen
+           vollen Stunde: die laufende Peak-Stunde zaehlt mit, damit das Gate
+           waehrend der Spitze nicht abfaellt (laufende Stunde konservativ voll
+           gerechnet). min_preis_vor_peak_ct bezieht sich weiterhin auf die
+           erste GEZAEHLTE (also gefilterte) Peak-Stunde. #}
+        {% set f = namespace(ve=0, exp=0, minpre=none, summe=0.0, anz=0, peak_gesehen=false, ve_summe=0.0, ve_anz=0) %}
         {% if n >= 4 %}
           {% for eintrag in ns.future %}
             {% set t = eintrag[0] %}
@@ -706,9 +730,11 @@ template:
               {% set kleiner = ns.prices | select('lt', p) | list | length %}
               {% set gleich  = ns.prices | select('eq', p) | list | length %}
               {% set pct = (kleiner + 0.5 * gleich) / n %}
-              {% if pct >= 0.80 %}
+              {% set ist_peak_preis = fenster_min is none or p >= fenster_min + aufschlag %}
+              {% if pct >= 0.80 and ist_peak_preis %}
                 {% set f.ve = f.ve + 1 %}{% set f.summe = f.summe + p %}{% set f.anz = f.anz + 1 %}{% set f.peak_gesehen = true %}
-              {% elif pct >= 0.60 %}
+                {% set f.ve_summe = f.ve_summe + p %}{% set f.ve_anz = f.ve_anz + 1 %}
+              {% elif pct >= 0.60 and ist_peak_preis %}
                 {% set f.exp = f.exp + 1 %}{% set f.summe = f.summe + p %}{% set f.anz = f.anz + 1 %}{% set f.peak_gesehen = true %}
               {% elif not f.peak_gesehen %}
                 {% set f.minpre = p if f.minpre is none else ([f.minpre, p] | min) %}
@@ -734,6 +760,8 @@ template:
             'benoetigt_kwh': ges_kwh | round(2),
             'min_preis_vor_peak_ct': (f.minpre | round(2)) if f.minpre is not none else none,
             'peak_preis_avg_ct': ((f.summe / f.anz) | round(2)) if f.anz > 0 else none,
+            've_preis_avg_ct': ((f.ve_summe / f.ve_anz) | round(2)) if f.ve_anz > 0 else none,
+            'fenster_min_ct': (fenster_min | round(2)) if fenster_min is not none else none,
             'horizont_ende': horizont_ende.isoformat(),
             'branch': 've=' ~ f.ve ~ ' exp=' ~ f.exp ~ ' n=' ~ n ~ ' ende=' ~ horizont_ende.strftime('%d.%m %H:%M')} }}
     sensor:
@@ -751,6 +779,8 @@ template:
           benoetigt_kwh: "{{ peak.benoetigt_kwh }}"
           min_preis_vor_peak_ct: "{{ peak.min_preis_vor_peak_ct }}"
           peak_preis_avg_ct: "{{ peak.peak_preis_avg_ct }}"
+          peak_preis_ve_avg_ct: "{{ peak.ve_preis_avg_ct }}"
+          fenster_min_ct: "{{ peak.fenster_min_ct }}"
           horizont_ende: "{{ peak.horizont_ende }}"
           branch: "{{ peak.branch }}"
     binary_sensor:

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -182,6 +182,35 @@ input_number:
     mode: box
     icon: mdi:swap-vertical-bold
 
+  opti_peak_min_aufschlag_ct:
+    name: "Opti Peak Mindestaufschlag"
+    # Eine Stunde zaehlt nur als Peak (VE/EXP) fuer die Reserve, wenn ihr Preis
+    # das Horizont-Tief (fenster_min_ct) um mindestens diesen Aufschlag
+    # uebersteigt - filtert die Perzentil-Zwangs-Peaks flacher Tage raus
+    # (z.B. 30.0 vs 30.5 ct waeren sonst schon ein "Peak"). UND-Bedingung
+    # zusaetzlich zu den unveraenderten Perzentil-Grenzen.
+    # Empfehlung aus dem Winter-Backtest-Sweep (Tuning-Runde 2026-07-02): 10.
+    min: 0
+    max: 100
+    step: 0.5
+    unit_of_measurement: ct/kWh
+    mode: box
+    icon: mdi:filter-outline
+
+  opti_halte_spread_ct:
+    name: "Opti Halte-Spread"
+    # L3 haelt bei EXPENSIVE nur noch, wenn der Preisdurchschnitt der
+    # kommenden VERY_EXPENSIVE-Stunden (peak_preis_ve_avg_ct) mindestens
+    # diesen Aufschlag ueber dem aktuellen Preis liegt - Halten ohne echten
+    # VE-Vorteil kostet nur Netzbezug ohne Gegenwert.
+    # Empfehlung aus dem Winter-Backtest-Sweep (Tuning-Runde 2026-07-02): 3.
+    min: 0
+    max: 50
+    step: 0.5
+    unit_of_measurement: ct/kWh
+    mode: box
+    icon: mdi:hand-back-right-outline
+
 input_boolean:
   akku_opti_automatik:
     name: "Akku Opti-Automatik"

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -194,6 +194,7 @@ input_number:
     # Empfohlener Startwert aus dem Winter-Backtest-Sweep (2026-07-02): 5.
     # (Sweep 0/5/10/15: 5 ist der guenstigste Wert, der die VE-Abdeckungs-
     # Vorgabe >= 31.2% haelt; ab 10 faellt die Abdeckung unter die Vorgabe.)
+    # Solange der Helfer nicht manuell gesetzt ist, gilt der Template-Fallback von 10 ct, nicht der empfohlene Startwert 5.
     min: 0
     max: 100
     step: 0.5
@@ -210,6 +211,7 @@ input_number:
     # Empfohlener Startwert aus dem Winter-Backtest-Sweep (2026-07-02): 5.
     # (Sweep 0/3/5 bei aufschlag 5: 5 war die guenstigste Variante bei
     # praktisch gleicher VE-Abdeckung.)
+    # Solange der Helfer nicht manuell gesetzt ist, gilt der Template-Fallback von 3 ct, nicht der empfohlene Startwert 5.
     min: 0
     max: 50
     step: 0.5

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -175,6 +175,8 @@ input_number:
     # Wirtschaftliche Mindest-Differenz zwischen Peak-Durchschnittspreis und
     # aktuellem Ladepreis (ct/kWh), ab der Peak-Vorladen aus dem Netz lohnt.
     # Deckt Round-Trip-Verluste des Akkus ab.
+    # Winter-Backtest-Sweep (2026-07-02): 10 bestaetigt (15 drueckt die
+    # VE-Abdeckung unter die Vorgabe >= 31.2%).
     min: 0
     max: 100
     step: 0.5
@@ -189,7 +191,9 @@ input_number:
     # uebersteigt - filtert die Perzentil-Zwangs-Peaks flacher Tage raus
     # (z.B. 30.0 vs 30.5 ct waeren sonst schon ein "Peak"). UND-Bedingung
     # zusaetzlich zu den unveraenderten Perzentil-Grenzen.
-    # Empfehlung aus dem Winter-Backtest-Sweep (Tuning-Runde 2026-07-02): 10.
+    # Empfohlener Startwert aus dem Winter-Backtest-Sweep (2026-07-02): 5.
+    # (Sweep 0/5/10/15: 5 ist der guenstigste Wert, der die VE-Abdeckungs-
+    # Vorgabe >= 31.2% haelt; ab 10 faellt die Abdeckung unter die Vorgabe.)
     min: 0
     max: 100
     step: 0.5
@@ -203,7 +207,9 @@ input_number:
     # kommenden VERY_EXPENSIVE-Stunden (peak_preis_ve_avg_ct) mindestens
     # diesen Aufschlag ueber dem aktuellen Preis liegt - Halten ohne echten
     # VE-Vorteil kostet nur Netzbezug ohne Gegenwert.
-    # Empfehlung aus dem Winter-Backtest-Sweep (Tuning-Runde 2026-07-02): 3.
+    # Empfohlener Startwert aus dem Winter-Backtest-Sweep (2026-07-02): 5.
+    # (Sweep 0/3/5 bei aufschlag 5: 5 war die guenstigste Variante bei
+    # praktisch gleicher VE-Abdeckung.)
     min: 0
     max: 50
     step: 0.5

--- a/tests/test_peak_reserve.py
+++ b/tests/test_peak_reserve.py
@@ -8,7 +8,10 @@ WINTER_ABEND = dt.datetime(2026, 1, 15, 17, 30, tzinfo=TZ)  # nach Sonnenunterga
 
 def _hass(today, tomorrow, *, now=WINTER_ABEND, score_heute="1", score_morgen="1",
           cap="12.8", verbrauch="0.9", minsoc="10", maxsoc="95",
-          sun_state="below_horizon", next_rising="2026-01-16T08:15:00+01:00"):
+          sun_state="below_horizon", next_rising="2026-01-16T08:15:00+01:00",
+          aufschlag="0"):
+    # aufschlag default "0" = alte Tests bleiben semantisch unveraendert (keine
+    # oekonomische Filterung); neue Tests setzen aufschlag explizit aktiv.
     return FakeHass(
         now=now,
         states={
@@ -18,6 +21,7 @@ def _hass(today, tomorrow, *, now=WINTER_ABEND, score_heute="1", score_morgen="1
             "input_number.opti_peak_verbrauch_kw": verbrauch,
             "input_number.minsoc": minsoc,
             "input_number.maxsoc": maxsoc,
+            "input_number.opti_peak_min_aufschlag_ct": aufschlag,
             "sun.sun": sun_state,
         },
         attrs={
@@ -127,3 +131,64 @@ def test_laufende_peak_stunde_zaehlt():
     peak = _peak(_hass(today, [50.0] * 24, now=mitten_spitze))
     assert peak["ve_stunden"] == 2  # Stunden 20 + 21
     assert peak["benoetigt_kwh"] > 0
+
+
+# --- Tuning-Runde: Hebel 1 (oekonomische Peak-Filterung) ---
+
+def test_oekonomische_filterung_flacher_tag_gate_off():
+    # 24x 30.0 (heute) + 24x 30.5 (morgen): ohne Filterung waeren die 30.5-
+    # Stunden EXP (Perzentil 0.75), obwohl der Spread zum Horizont-Tief nur
+    # 0.5 ct betraegt - ein Zwangs-Peak eines flachen Tages.
+    today = [30.0] * 24
+    tomorrow = [30.5] * 24
+    gefiltert = _peak(_hass(today, tomorrow, aufschlag="10"))
+    assert gefiltert["benoetigt_kwh"] == 0.0
+    assert gefiltert["ve_stunden"] == 0
+    assert gefiltert["exp_stunden"] == 0
+
+    ungefiltert = _peak(_hass(today, tomorrow, aufschlag="0"))
+    assert ungefiltert["exp_stunden"] == 24
+    assert ungefiltert["benoetigt_kwh"] > 0
+
+
+def test_oekonomische_filterung_spike_tag_unveraendert():
+    # Spread 200-50=150 ct >> aufschlag 10 -> Filterung aendert nichts.
+    today = [50.0] * 19 + [200.0, 200.0, 200.0, 50.0, 50.0]
+    peak = _peak(_hass(today, [50.0] * 24, aufschlag="10"))
+    assert peak["ve_stunden"] == 3
+    assert peak["benoetigt_kwh"] == 3.0
+
+
+def test_oekonomische_filterung_grenzfall_gleich_zaehlt():
+    # Peak exakt fenster_min (50) + aufschlag (10) = 60 -> zaehlt (>=).
+    today = [50.0] * 20 + [60.0, 60.0, 60.0, 60.0]
+    tomorrow = [50.0] * 24
+    genau = _peak(_hass(today, tomorrow, aufschlag="10"))
+    assert genau["ve_stunden"] == 4
+    assert genau["fenster_min_ct"] == 50.0
+    # Knapp drueber am Schwellwert (10.5) -> faellt raus.
+    knapp_drueber = _peak(_hass(today, tomorrow, aufschlag="10.5"))
+    assert knapp_drueber["ve_stunden"] == 0
+
+
+# --- Tuning-Runde: Hebel 2 (peak_preis_ve_avg_ct) ---
+
+def test_peak_preis_ve_avg_nur_ve_stunden():
+    # Aufsteigende Preisreihe: ve_stunden und exp_stunden beide > 0, der
+    # VE-Durchschnitt muss sich vom Gesamt-Peak-Durchschnitt unterscheiden.
+    today = [20.0 + i for i in range(24)]
+    tomorrow = [20.0 + i for i in range(24)]
+    peak = _peak(_hass(today, tomorrow, aufschlag="0"))
+    assert peak["ve_stunden"] > 0
+    assert peak["exp_stunden"] > 0
+    assert peak["ve_preis_avg_ct"] == 41.0
+    assert peak["ve_preis_avg_ct"] != peak["peak_preis_avg_ct"]
+
+
+def test_peak_preis_ve_avg_none_ohne_peaks():
+    mittag = dt.datetime(2026, 6, 20, 12, 0, tzinfo=TZ)
+    today = [20.0] * 18 + [80.0, 80.0, 80.0, 20.0, 20.0, 20.0]
+    peak = _peak(_hass(today, [20.0] * 24, now=mittag, score_heute="9",
+                       sun_state="above_horizon"))
+    assert peak["ve_stunden"] == 0
+    assert peak["ve_preis_avg_ct"] is None

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -17,6 +17,9 @@ BASIS = {
     "input_number.maxsoc": "95",
     "input_number.opti_einspeiseverguetung_ct": "8",
     "input_number.opti_netzlade_spread_ct": "10",
+    # halte_spread "0" = alte Tests bleiben semantisch unveraendert (L3 haelt
+    # sobald ve_avg gesetzt ist); neue Tests setzen halte_spread aktiv.
+    "input_number.opti_halte_spread_ct": "0",
     "input_number.akkusteuerung_wr_70proz_ueberschuss_grenze": "500",
     "input_number.akkusteuerung_wr_ac_ueberschuss_grenze": "4500",
     "input_boolean.opti_prognose_netzladen": "on",
@@ -46,10 +49,15 @@ def grund(**overrides):
     return _render_vorschau("grund", overrides)
 
 
-def reserve_attrs(ve=30.0, min_vor=None, avg=None):
+def reserve_attrs(ve=30.0, min_vor=None, avg=None, ve_avg=None):
+    # ve_avg default = avg: alte Fixturen (nur avg gesetzt) nehmen an, dass die
+    # Reserve rein aus VE-Stunden besteht, damit L3-Alt-Tests mit halte_spread
+    # "0" unveraendert bleiben (ve_avg is not none noetig, Wert selbst ist bei
+    # halte_spread 0 irrelevant, solange ve_avg >= cur).
     return {"sensor.opti_peak_reserve_soc": {
         "reserve_ve_soc": ve, "min_preis_vor_peak_ct": min_vor,
-        "peak_preis_avg_ct": avg}}
+        "peak_preis_avg_ct": avg,
+        "peak_preis_ve_avg_ct": ve_avg if ve_avg is not None else avg}}
 
 
 # --- Task 4: Negativpreis-Laderegel ---
@@ -273,3 +281,28 @@ def test_leiter_inaktiv_ohne_gate():
                    "binary_sensor.opti_peak_reserve_aktiv": "off"},
                 _attrs=LEITER_ATTRS)
     assert "Peak-Leiter" not in out
+
+
+# --- Tuning-Runde: Hebel 2 (L3-Halte-Spread) ---
+
+L3_HALTE_FALL = {
+    **LEITER, "sensor.opti_price_level": "EXPENSIVE",
+    "sensor.opti_soc": "31",  # unter VE-Reserve (30 + Band)
+    "input_boolean.opti_prognose_netzladen": "off",
+    "input_number.opti_halte_spread_ct": "3",
+}
+
+
+def test_l3_halte_spread_zu_klein_faellt_durch():
+    # cur=50 (LEITER), ve_avg=52 -> Spread 2 < halte_spread 3 -> KEIN Halten,
+    # faellt zur restlichen Kette durch (hier: Default, da Nacht).
+    attrs = reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0, ve_avg=52.0)
+    assert vorschau(**L3_HALTE_FALL, _attrs=attrs) == "Akku Dynamisch"
+    assert "Peak-Leiter L3" not in grund(**L3_HALTE_FALL, _attrs=attrs)
+
+
+def test_l3_halte_spread_ausreichend_haelt():
+    # cur=50, ve_avg=55 -> Spread 5 >= halte_spread 3 -> Halten wie bisher.
+    attrs = reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0, ve_avg=55.0)
+    assert vorschau(**L3_HALTE_FALL, _attrs=attrs) == "Akku nur Laden"
+    assert "Peak-Leiter L3" in grund(**L3_HALTE_FALL, _attrs=attrs)

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -306,3 +306,14 @@ def test_l3_halte_spread_ausreichend_haelt():
     attrs = reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0, ve_avg=55.0)
     assert vorschau(**L3_HALTE_FALL, _attrs=attrs) == "Akku nur Laden"
     assert "Peak-Leiter L3" in grund(**L3_HALTE_FALL, _attrs=attrs)
+
+
+def test_l3_kein_halten_bei_unavailable_preissensor():
+    # hv_cur guard: preis_current_ct_kwh unavailable -> L3 greift nicht.
+    # Szenario: Fixture EXPENSIVE, SoC < VE-Reserve, halte_spread erfuellt waere,
+    # ABER Sensor fehlt -> keine L3-Aktion, faellt durch zur Default-Kette.
+    attrs = reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0, ve_avg=55.0)
+    # price_current_ct_kwh ist unavailable (nicht gesetzt in overrides)
+    out = grund(**{**L3_HALTE_FALL, "sensor.opti_price_current_ct_kwh": "unavailable"},
+                _attrs=attrs)
+    assert "Peak-Leiter L3" not in out

--- a/tools/backtest.py
+++ b/tools/backtest.py
@@ -91,13 +91,14 @@ def _price_level(prices, current):
 def simulate_day(prices_today, prices_tomorrow, *, load_kw, pv_kwh_per_hour,
                  start_soc, cap_kwh, neu, modus_start="Akku Dynamisch",
                  aufschlag_ct=None, halte_spread_ct=None, netzlade_spread_ct=None):
-    # Tuning-Hebel (Winter-Sweep): neu=True -> Gewinner-Defaults (aufschlag 10,
-    # halte 3, netzlade_spread 10), neu=False -> Gate stillgelegt, Parameter
-    # egal (aufschlag/halte 0 zur Klarheit). Ueberschreibbar fuer den Sweep.
+    # Tuning-Hebel: neu=True -> Gewinner-Defaults aus dem Winter-Backtest-Sweep
+    # 2026-07-02 (aufschlag 5, halte 5, netzlade_spread 10), neu=False -> Gate
+    # stillgelegt, Parameter egal (aufschlag/halte 0 zur Klarheit).
+    # Ueberschreibbar fuer Sweeps.
     if aufschlag_ct is None:
-        aufschlag_ct = 10 if neu else 0
+        aufschlag_ct = 5 if neu else 0
     if halte_spread_ct is None:
-        halte_spread_ct = 3 if neu else 0
+        halte_spread_ct = 5 if neu else 0
     if netzlade_spread_ct is None:
         netzlade_spread_ct = 10
     soc = start_soc

--- a/tools/backtest.py
+++ b/tools/backtest.py
@@ -31,9 +31,11 @@ _vorschau = find_template_entity(_derived, "sensor", "opti_strategie_vorschau")
 _peak_template = find_trigger_block_variables(_derived, "peak")
 
 
-def _states(hour_price, soc, load_kw, neu, cap_kwh, peak):
+def _states(hour_price, soc, load_kw, neu, cap_kwh, peak, *,
+            halte_spread_ct, netzlade_spread_ct):
     minv = peak["min_preis_vor_peak_ct"] if peak else None
     avg = peak["peak_preis_avg_ct"] if peak else None
+    ve_avg = peak["ve_preis_avg_ct"] if peak else None
     aktiv = bool(peak and peak["gueltig"] and peak["benoetigt_kwh"] > 0)
     return FakeHass(
         states={
@@ -54,7 +56,8 @@ def _states(hour_price, soc, load_kw, neu, cap_kwh, peak):
             "input_number.maxsoc": "95",
             "input_number.opti_peak_verbrauch_kw": str(load_kw),
             "input_number.opti_einspeiseverguetung_ct": "8" if neu else "0",
-            "input_number.opti_netzlade_spread_ct": "10" if neu else "999",
+            "input_number.opti_netzlade_spread_ct": str(netzlade_spread_ct) if neu else "999",
+            "input_number.opti_halte_spread_ct": str(halte_spread_ct),
             "input_number.akkusteuerung_wr_70proz_ueberschuss_grenze": "500",
             "input_number.akkusteuerung_wr_ac_ueberschuss_grenze": "4500",
             "input_boolean.opti_prognose_netzladen": "on",
@@ -65,7 +68,8 @@ def _states(hour_price, soc, load_kw, neu, cap_kwh, peak):
         attrs={"sensor.opti_peak_reserve_soc": {
             "reserve_ve_soc": peak["ve_soc"] if peak else None,
             "min_preis_vor_peak_ct": minv,
-            "peak_preis_avg_ct": avg}},
+            "peak_preis_avg_ct": avg,
+            "peak_preis_ve_avg_ct": ve_avg}},
     )
 
 
@@ -85,7 +89,17 @@ def _price_level(prices, current):
 
 
 def simulate_day(prices_today, prices_tomorrow, *, load_kw, pv_kwh_per_hour,
-                 start_soc, cap_kwh, neu, modus_start="Akku Dynamisch"):
+                 start_soc, cap_kwh, neu, modus_start="Akku Dynamisch",
+                 aufschlag_ct=None, halte_spread_ct=None, netzlade_spread_ct=None):
+    # Tuning-Hebel (Winter-Sweep): neu=True -> Gewinner-Defaults (aufschlag 10,
+    # halte 3, netzlade_spread 10), neu=False -> Gate stillgelegt, Parameter
+    # egal (aufschlag/halte 0 zur Klarheit). Ueberschreibbar fuer den Sweep.
+    if aufschlag_ct is None:
+        aufschlag_ct = 10 if neu else 0
+    if halte_spread_ct is None:
+        halte_spread_ct = 3 if neu else 0
+    if netzlade_spread_ct is None:
+        netzlade_spread_ct = 10
     soc = start_soc
     modus = modus_start
     cost = 0.0
@@ -104,6 +118,7 @@ def simulate_day(prices_today, prices_tomorrow, *, load_kw, pv_kwh_per_hour,
                 "input_number.opti_peak_verbrauch_kw": str(load_kw),
                 "input_number.minsoc": "10",
                 "input_number.maxsoc": "95",
+                "input_number.opti_peak_min_aufschlag_ct": str(aufschlag_ct),
                 "sun.sun": "below_horizon",
             },
             attrs={
@@ -113,7 +128,9 @@ def simulate_day(prices_today, prices_tomorrow, *, load_kw, pv_kwh_per_hour,
             })
         peak = render_native(peak_hass, _peak_template)
         # 2. Strategie-Entscheidung mit echtem Vorschau-Template
-        hass = _states(preis, soc, load_kw, neu, cap_kwh, peak)
+        hass = _states(preis, soc, load_kw, neu, cap_kwh, peak,
+                       halte_spread_ct=halte_spread_ct,
+                       netzlade_spread_ct=netzlade_spread_ct)
         hass.now_value = now
         hass.states_map["sensor.opti_price_level"] = _price_level(alle_preise, preis)
         hass.states_map["input_select.akkusteuerung_modus"] = modus


### PR DESCRIPTION
## Was

Zwei neue Tuning-Hebel fuer die Entlade-Peak-Allokation, Parameter per Sweep gegen einen 120-Tage-Winter-Backtest (Nov 25 - Feb 26, echte Day-Ahead-Preise auf Tibber-Niveau, echte Last-/PV-Profile) bestimmt:

- **Oekonomische Peak-Filterung** (`input_number.opti_peak_min_aufschlag_ct`): Eine Stunde zaehlt nur als Peak fuer die Reserve, wenn ihr Preis das Horizont-Tief um mindestens den Aufschlag uebersteigt. Filtert die Perzentil-Zwangs-Peaks flacher Tage raus (Hauptursache der PV-Verdraengung).
- **L3-Halte-Spread** (`input_number.opti_halte_spread_ct`): Halten bei EXPENSIVE nur noch, wenn die kommenden VE-Stunden einen echten Aufschlag ueber dem aktuellen Preis bieten.
- Neue Sensor-Attribute `fenster_min_ct` / `peak_preis_ve_avg_ct`, Vorschau synchron, hv_cur-Guard, Doku.

## Sweep-Ergebnis (ehrlich)

Empfohlene Startwerte **aufschlag 5 / halte 5 / netzlade-spread 10**: Aufpreis der Peak-Allokation sinkt von 17.07 auf **3.61 EUR pro Winter** (bei VE-Abdeckung 26.2 -> 32.9 % und PV-Verdraengung 131 -> 53 kWh). Das Kosten-Ziel (billiger als alt) wird knapp verfehlt - der Trade-off ist jetzt aber ein Helfer-Drehknopf: aufschlag 15 waere 1.45 EUR im PLUS bei nur noch 28.5 % VE-Abdeckung. Details in der Doku-Sektion.

Hinweis: Helfer haben bewusst kein initial: (Restart-Fix aus PR #21) - Startwerte 5/5 nach Deploy einmal manuell setzen; bis dahin gelten die dokumentierten Template-Fallbacks 10/3.

## Verifikation

61/61 Tests (8 neue, TDD rot->gruen inkl. Grenzfall und unavailable-Preissensor), Jinja-Parse 141 Templates 0 Fehler, 2-EUR-Szenario-Backtest weiter +2.93 EUR/Tag, Review + Fix-Runde (2 Important gefixt: Vorschau-hv_cur, Fallback-Doku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vWz4Jg6U2hiQawvuKCypo