### PR TITLE
Feature: Viertelstunden-Raster-Support fuer die Peak-Reserve (Tibber 15-min-Umstellung)

### DIFF
--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -103,7 +103,7 @@ state: "{{ states('sensor.awattar_current_price') | float(0) * 100 }}"
 > **Hinweis:** Falls die Quelle bereits ct/kWh liefert, `* 100` weglassen und
 > den Availability-Check entsprechend anpassen.
 
-> **Stundenraster-Kontrakt:** `today`/`tomorrow` müssen Stundenlisten sein (max. 25 Einträge je Liste) — die Peak-Reserve (`sensor.opti_peak_reserve_soc`) ordnet Stunden über den Listenindex zu und deaktiviert sich bei 15-Minuten-Listen oder anderen Rastern über 25 Einträgen automatisch (`gueltig: false`).
+> **Raster-Kontrakt:** `today`/`tomorrow` müssen Stundenlisten (Länge 20-27) oder Viertelstundenlisten (Länge 80-108) sein - die Peak-Reserve (`sensor.opti_peak_reserve_soc`) leitet die Slot-Länge je Liste aus der Listenlänge ab und deaktiviert sich bei anderen Listenlängen automatisch (`gueltig: false`).
 
 ---
 

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -304,8 +304,12 @@ Die Regel wartet also nicht ewig auf einen Wert, der nicht mehr existiert.
 
 - **< 4 Preise gesamt** (`today` + `tomorrow`): `sensor.opti_peak_reserve_soc` wird `unavailable`, `binary_sensor.opti_peak_reserve_aktiv` fällt auf `off` - die komplette Leiter (L1-L4) ist inaktiv.
   Das ist **bewusst anders** als der NORMAL-Fallback von `sensor.opti_price_level` bei derselben Datenlage: eine Reserve von 0 % sähe wie „keine Peaks in Sicht" aus und würde die Leiter fälschlich freigeben, statt sie einfach abzuschalten.
-- **DST-Limitation:** Die Preislisten liefern keine Zeitstempel, die Stundenzuordnung erfolgt über den Listenindex ab Mitternacht.
-  An Tagen mit Zeitumstellung kann diese Zuordnung um eine Stunde verrutschen - akzeptiertes, bekanntes Verhalten.
+- **Raster-Erkennung:** Die Preislisten liefern keine Zeitstempel.
+  Die Slot-Länge (`slot_h`) wird pro Liste (`today`/`tomorrow` getrennt) aus der Listenlänge abgeleitet: 24 geteilt durch die Anzahl der Einträge.
+  Unterstützt werden Stundenraster (Listenlänge 20-27, inklusive Zeitumstellungstage) und Viertelstundenraster (Listenlänge 80-108, inklusive Zeitumstellungstage) - seit der Tibber-Umstellung auf 15-Minuten-Day-Ahead-Preise (Juli 2026) liefert `sensor.opti_price_series` 96 Werte pro Tag statt 24.
+  Jede andere Listenlänge macht die komplette Preisbasis `gueltig=false`.
+  An Tagen mit Zeitumstellung ist `slot_h` (z. B. 24/92 oder 24/100 bei Viertelstunden) leicht ungenau - akzeptiertes, bekanntes Verhalten.
+  Das Fenster beginnt weiterhin an der aktuellen vollen Stunde (nicht am aktuellen Slot): bei Viertelstundenraster zählen dadurch bis zu drei bereits vergangene Slots der laufenden Stunde konservativ mit.
 
 ### Wechselwirkung mit den alten Ladeblöcken
 

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -630,8 +630,15 @@ template:
   #    Fail-safe: < 4 Preise -> Sensor unavailable (BEWUSST anders als der
   #    NORMAL-Fallback von opti_price_level: Reserve 0 saehe aus wie "keine
   #    Peaks" und wuerde die Leiter falsch scharf schalten).
-  #    Bekannte Grenze: Preislisten ohne Zeitstempel, Stundenzuordnung per Index
-  #    (DST-Tage koennen 1 h verrutschen - akzeptiert).
+  #    Raster: today/tomorrow werden ueber die Listenlaenge erkannt (Stunden-
+  #    ODER Viertelstundenraster, siehe Tibber-15-min-Umstellung 07/2026);
+  #    slot_h wird PRO LISTE separat abgeleitet, da today/tomorrow in
+  #    Uebergangsphasen unterschiedliche Raster haben koennen. Bekannte
+  #    Grenze: Preislisten ohne Zeitstempel, Zuordnung per Index
+  #    (DST-Tage koennen slot_h leicht ungenau machen - akzeptiert).
+  #    Fensterstart bleibt die aktuelle volle STUNDE (nicht der aktuelle
+  #    Slot): bei Viertelstundenraster zaehlen dadurch bis zu 3 bereits
+  #    vergangene Slots der laufenden Stunde konservativ mit.
   # ---------------------------------------------------------------------------
   - triggers:
       - trigger: homeassistant
@@ -656,22 +663,34 @@ template:
         {% set max_soc = states('input_number.maxsoc') | float(95) %}
         {% set aufschlag = states('input_number.opti_peak_min_aufschlag_ct') | float(10) %}
         {% set eta = 0.9 %}
-        {# 1. Preisbasis + Zukunftsstunden einsammeln (Stundenindex -> Zeitpunkt).
-           Raster-Guard: Listen > 25 Eintraege (15-min-Raster o.ae.) -> ungueltig;
-           die Stundenzuordnung via Index setzt Stundenraster voraus. #}
+        {# 1. Preisbasis + Zukunftszeitpunkte einsammeln (Slot-Index -> Zeitpunkt).
+           slot_h wird PRO LISTE aus der Listenlaenge abgeleitet (24 / Laenge):
+           Stundenraster -> slot_h=1.0, Viertelstundenraster -> slot_h=0.25.
+           today/tomorrow koennen unterschiedliche Raster haben (z.B. waehrend
+           der Tibber-Umstellung auf 15-min-Day-Ahead-Preise).
+           Raster-Guard: nur Laengen 20-27 (Stundenraster inkl. DST) oder
+           80-108 (Viertelstundenraster inkl. DST) sind gueltig; jede andere
+           nicht-leere Laenge verwirft die GESAMTE Preisbasis (raster_ok=false).
+           Eine leere Liste (today/tomorrow fehlt) ist erlaubt und traegt
+           einfach nichts bei. Bei DST-Tagen ist slot_h leicht ungenau
+           (24/92 bzw. 24/100) - akzeptiert. #}
         {% set ns = namespace(prices=[], future=[], raster_ok=true) %}
         {% set heute = today_at('00:00') %}
         {% for key in ['today', 'tomorrow'] %}
           {% set arr = state_attr('sensor.opti_price_series', key) %}
-          {% if arr is iterable and arr is not string %}
-            {% if arr | length > 25 %}{% set ns.raster_ok = false %}{% endif %}
+          {% if arr is iterable and arr is not string and arr | length > 0 %}
+            {% set laenge = arr | length %}
+            {% if not ((20 <= laenge <= 27) or (80 <= laenge <= 108)) %}
+              {% set ns.raster_ok = false %}
+            {% endif %}
+            {% set slot_h = 24 / laenge %}
             {% set base = heute if key == 'today' else heute + timedelta(days=1) %}
             {% for it in arr %}
               {% if it is mapping %}{% set p = it.get('total', it.get('price', it.get('value'))) %}{% else %}{% set p = it %}{% endif %}
               {% set p = p | float(none) %}
               {% if p is not none %}
                 {% set ns.prices = ns.prices + [p] %}
-                {% set ns.future = ns.future + [[base + timedelta(hours=loop.index0), p]] %}
+                {% set ns.future = ns.future + [[base + timedelta(hours=loop.index0 * slot_h), p, slot_h]] %}
               {% endif %}
             {% endfor %}
           {% endif %}
@@ -714,35 +733,42 @@ template:
           {% endfor %}
         {% endif %}
         {% set fenster_min = fw.min %}
-        {# 3b. Zweiter Durchlauf: Zukunftsstunden im Horizont klassifizieren
+        {# 3b. Zweiter Durchlauf: Zukunftsslots im Horizont klassifizieren
            (Midrank-Perzentil, Grenzen unveraendert) UND zusaetzlich oekonomisch
            filtern (p >= fenster_min + aufschlag). Fenster ab der aktuellen
-           vollen Stunde: die laufende Peak-Stunde zaehlt mit, damit das Gate
+           vollen Stunde: die laufenden Peak-Slots zaehlen mit, damit das Gate
            waehrend der Spitze nicht abfaellt (laufende Stunde konservativ voll
-           gerechnet). min_preis_vor_peak_ct bezieht sich weiterhin auf die
-           erste GEZAEHLTE (also gefilterte) Peak-Stunde. #}
-        {% set f = namespace(ve=0, exp=0, minpre=none, summe=0.0, anz=0, peak_gesehen=false, ve_summe=0.0, ve_anz=0) %}
+           gerechnet - bei Viertelstundenraster zaehlen dadurch bis zu 3 bereits
+           vergangene Slots der laufenden Stunde mit). min_preis_vor_peak_ct
+           bezieht sich weiterhin auf die erste GEZAEHLTE (also gefilterte)
+           Peak-Stunde. f.ve/f.exp summieren STUNDEN (slot_h je Slot), nicht
+           Slot-Anzahlen, da today/tomorrow unterschiedliche slot_h haben
+           koennen - deshalb Namespace-Summe statt Zaehler * Konstante. #}
+        {% set f = namespace(ve=0.0, exp=0.0, minpre=none, summe=0.0, anz=0, peak_gesehen=false, ve_summe=0.0, ve_anz=0) %}
         {% if n >= 4 %}
           {% for eintrag in ns.future %}
             {% set t = eintrag[0] %}
             {% set p = eintrag[1] %}
+            {% set slot_h = eintrag[2] %}
             {% if t >= start and t < horizont_ende %}
               {% set kleiner = ns.prices | select('lt', p) | list | length %}
               {% set gleich  = ns.prices | select('eq', p) | list | length %}
               {% set pct = (kleiner + 0.5 * gleich) / n %}
               {% set ist_peak_preis = fenster_min is none or p >= fenster_min + aufschlag %}
               {% if pct >= 0.80 and ist_peak_preis %}
-                {% set f.ve = f.ve + 1 %}{% set f.summe = f.summe + p %}{% set f.anz = f.anz + 1 %}{% set f.peak_gesehen = true %}
+                {% set f.ve = f.ve + slot_h %}{% set f.summe = f.summe + p %}{% set f.anz = f.anz + 1 %}{% set f.peak_gesehen = true %}
                 {% set f.ve_summe = f.ve_summe + p %}{% set f.ve_anz = f.ve_anz + 1 %}
               {% elif pct >= 0.60 and ist_peak_preis %}
-                {% set f.exp = f.exp + 1 %}{% set f.summe = f.summe + p %}{% set f.anz = f.anz + 1 %}{% set f.peak_gesehen = true %}
+                {% set f.exp = f.exp + slot_h %}{% set f.summe = f.summe + p %}{% set f.anz = f.anz + 1 %}{% set f.peak_gesehen = true %}
               {% elif not f.peak_gesehen %}
                 {% set f.minpre = p if f.minpre is none else ([f.minpre, p] | min) %}
               {% endif %}
             {% endif %}
           {% endfor %}
         {% endif %}
-        {# 4. Reserve in kWh und SoC (mit Entladeverlusten), Kappung bei maxsoc #}
+        {# 4. Reserve in kWh und SoC (mit Entladeverlusten), Kappung bei maxsoc.
+           f.ve/f.exp sind bereits Stunden-Summen (siehe 3b), also direkt mit
+           verbrauch_kw multiplizieren statt mit einer Slot-Anzahl. #}
         {% set ve_kwh = f.ve * verbrauch_kw / eta %}
         {% set ges_kwh = (f.ve + f.exp) * verbrauch_kw / eta %}
         {% if cap_kwh > 0 %}
@@ -755,8 +781,8 @@ template:
         {{ {'gueltig': n >= 4,
             've_soc': ve_soc | round(1),
             'ges_soc': ges_soc | round(1),
-            've_stunden': f.ve,
-            'exp_stunden': f.exp,
+            've_stunden': f.ve | round(2),
+            'exp_stunden': f.exp | round(2),
             'benoetigt_kwh': ges_kwh | round(2),
             'min_preis_vor_peak_ct': (f.minpre | round(2)) if f.minpre is not none else none,
             'peak_preis_avg_ct': ((f.summe / f.anz) | round(2)) if f.anz > 0 else none,

--- a/tests/test_peak_reserve.py
+++ b/tests/test_peak_reserve.py
@@ -113,12 +113,46 @@ def test_exp_stunden_gehen_in_gesamt_nicht_ve():
     assert peak["ges_soc"] >= peak["ve_soc"]
 
 
-def test_viertelstunden_raster_ungueltig():
-    # 96 Werte (15-min-Raster statt Stunden-Raster): Stundenzuordnung per Index
-    # waere falsch -> gesamte Preisbasis wird verworfen.
-    today = [50.0] * 96
+def test_viertelstunden_raster_gueltig():
+    # 96 Werte (15-min-Raster): slot_h = 24/96 = 0.25 h. 12 teure Slots
+    # (19:00-22:00, je 200 ct) inmitten eines flachen 50-ct-Tages -> 3 h VE.
+    today = [50.0] * 76 + [200.0] * 12 + [50.0] * 8
+    peak = _peak(_hass(today, [50.0] * 24))
+    assert peak["gueltig"] is True
+    assert peak["benoetigt_kwh"] == 3.0
+    assert peak["ve_stunden"] == 3.0
+
+
+def test_gemischtes_raster():
+    # today im Stundenraster (24, flach -> 0 VE-Stunden), tomorrow im
+    # Viertelstundenraster (96, mit 12-Slot-Spitze -> 3 VE-Stunden):
+    # unterschiedliche slot_h pro Liste, beide muessen korrekt gezaehlt werden.
+    today = [50.0] * 24
+    tomorrow = [50.0] * 76 + [200.0] * 12 + [50.0] * 8
+    peak = _peak(_hass(today, tomorrow, score_morgen="1"))
+    assert peak["gueltig"] is True
+    assert peak["ve_stunden"] == 3.0
+    assert peak["benoetigt_kwh"] == 3.0
+
+
+def test_unplausible_laenge_ungueltig():
+    # 40 Werte passen weder ins Stundenraster (20-27) noch ins
+    # Viertelstundenraster (80-108) -> komplette Preisbasis wird verworfen.
+    today = [50.0] * 40
     peak = _peak(_hass(today, [50.0] * 24))
     assert peak["gueltig"] is False
+
+
+def test_dst_grenzfall_92_und_100_gueltig():
+    # DST-Tage koennen 92 (Fruehjahr, -1h) oder 100 (Herbst, +1h) Viertelstunden
+    # haben statt 96 - beide Grenzfaelle bleiben gueltig (Bereich 80-108).
+    today_92 = [50.0] * 92
+    peak_92 = _peak(_hass(today_92, [50.0] * 24))
+    assert peak_92["gueltig"] is True
+
+    today_100 = [50.0] * 100
+    peak_100 = _peak(_hass(today_100, [50.0] * 24))
+    assert peak_100["gueltig"] is True
 
 
 def test_laufende_peak_stunde_zaehlt():


### PR DESCRIPTION
## Anlass

Live-verifiziert heute Abend: Tibber liefert in den today/tomorrow-Attributen von `sensor.opti_price_series` jetzt 96 Viertelstunden-Werte pro Tag statt 24 Stundenwerte (deutsche 15-min-Day-Ahead-Umstellung).
Der bisherige Raster-Guard (Listen > 25 Eintraege -> `gueltig=false`) hat das erkannt und die komplette Peak-Reserve sicher deaktiviert.
Dieser PR liefert den echten Support fuer beide Raster.

## Rechenweg

- `slot_h` wird pro Preisliste (today/tomorrow getrennt) aus der Listenlaenge abgeleitet: `24 / laenge`.
  today und tomorrow koennen waehrend der Uebergangsphase unterschiedliche Raster haben.
- Zeitzuordnung je Eintrag: `base + timedelta(hours=loop.index0 * slot_h)`.
- Guard ersetzt: gueltige Laengen sind 20-27 (Stundenraster inkl. DST) und 80-108 (Viertelstundenraster inkl. DST).
  Jede andere nicht-leere Laenge verwirft die komplette Preisbasis (`gueltig=false`).
  Eine leere Liste (today/tomorrow fehlt) bleibt erlaubt, wie bisher.
- Energie-Rechnung summiert jetzt `slot_h` je gezaehltem Slot (Namespace-Summe), statt Slot-Anzahl mal Konstante, da today/tomorrow unterschiedliche `slot_h` haben koennen.
  `peak_stunden_ve`/`peak_stunden_exp` bleiben namentlich unveraendert und geben weiterhin Stunden aus (jetzt als Summe der `slot_h`, auf 2 Nachkommastellen gerundet).
- Fensterstart bleibt bewusst die aktuelle volle Stunde (nicht der aktuelle Slot): bei Viertelstundenraster zaehlen dadurch bis zu 3 bereits vergangene Slots der laufenden Stunde konservativ mit.
- Preisbasierte Teile (`fenster_min`, `min_preis_vor_peak_ct`, `peak_preis_avg_ct`, Midrank-Klassifikation, Aufschlag-Filter) sind logisch unveraendert und arbeiten jetzt einfach auf Slots statt auf Stunden.

## Bekannte Grenzen (Konzept-Entscheidung, nicht in diesem PR geaendert)

- Die Midrank-Perzentil-Klassifikation zaehlt Slots unweighted (nicht stundengewichtet).
  Bei gemischtem Raster (z. B. today 96 Viertelstunden-Slots, tomorrow 24 Stunden-Slots) traegt der hoeher aufgeloeste Tag mehr Samples zur Perzentil-Basis bei.
  Das ist eine bewusste Fortfuehrung der bestehenden Logik (Punkt 4 der Spezifikation): preisbasierte Klassifikation bleibt unveraendert, nur die Energie-Summe ist jetzt stundengewichtet.
- `peak_preis_avg_ct`/`ve_preis_avg_ct` bleiben Slot-Durchschnitte, nicht zeitgewichtete Durchschnitte.

## Tests

- Bestehende 24er-Tests bleiben unveraendert gruen (slot_h=1.0-Pfad).
- `test_viertelstunden_raster_ungueltig` ersetzt durch:
  - `test_viertelstunden_raster_gueltig`: 96er-Liste flach 50 ct mit 12 Slots 200 ct (19:00-22:00) -> gueltig True, benoetigt_kwh == 3.0, ve_stunden == 3.0.
  - `test_gemischtes_raster`: today 24er (flach), tomorrow 96er (mit Spitze) -> beide Listen korrekt geparst und gezaehlt.
  - `test_unplausible_laenge_ungueltig`: 40er-Liste -> gueltig False.
  - `test_dst_grenzfall_92_und_100_gueltig`: 92er/100er-Liste (DST-Grenzfaelle) -> gueltig True.
- Gesamtsuite: 64/64 Tests gruen (`uv run --with pytest --with jinja2 --with pyyaml pytest tests/ -v`).
- Jinja-Parse-Check (rekursive YAML-Struktur-Traversierung, echtes `jinja2.Environment().parse()`): 110 Templates, 0 Syntaxfehler.
- CLI-Backtest (`tools/backtest.py`, fuettert 24er-Listen): weiterhin unveraendert +2.93 EUR im Abendspitze-Szenario.

## Doku

- `docs/strategie-logik.md`: Raster-Absatz aktualisiert (Stunden- UND Viertelstundenraster, Ableitung ueber Listenlaenge, DST-Toleranz).
- `docs/canonical-layer.md`: Raster-Kontrakt-Satz minimal angepasst (ein Agent arbeitet parallel auf `docs/onboarding-fixes` an derselben Datei, Aenderung bewusst auf einen Satz begrenzt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vWz4Jg6U2hiQawvuKCypo