### PR TITLE
Fix: Ueberschuss-Regeln entprellt und akkuunabhaengig (Anti-Flatter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Dieses Projekt lebt von der Community. Besonderer Dank geht an:
 - [ ] Netzladen zu Off-Peak-Zeiten / Paragraf-14a-Fenster (pauschal günstigere Nachtstunden)
 - [ ] Mindestentladepreis als echte Entlade-Bedingung nutzen (bisher nur informativ)
 - [ ] Akku im Winter mindestens 1x pro Woche automatisch auf 100 % laden (Zähler `tage_seit_akku100` existiert schon)
-- [ ] Hysterese-Band für die PV-Überschuss-Grenzen (verhindert Modus-Wechsel im Sekundentakt bei Wolken an der Grenze)
+- [x] Hysterese-Band für die PV-Überschuss-Grenzen — erledigt als entprellte Binärsensoren `opti_ueberschuss_70_aktiv`/`opti_ueberschuss_ac_aktiv` (akkuunabhängiges Signal, 30 s beidseitig, Hysterese)
 - [ ] `opti_peak_verbrauch_kw` statistisch aus der Verbrauchshistorie ableiten statt fix zu konfigurieren
 - [ ] Wirkleistungsbegrenzung bei negativen Strompreisen über Modbus (Register 41255) - experimentell, kein aktiver Support
 

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -37,10 +37,16 @@
     - trigger: state
       entity_id:
         - binary_sensor.opti_ueberschuss_ac_aktiv
+      to:
+        - "on"
+        - "off"
       id: "AC-Überschuss geändert"
     - trigger: state
       entity_id:
         - binary_sensor.opti_ueberschuss_70_aktiv
+      to:
+        - "on"
+        - "off"
       id: "PV-70%-Überschuss geändert"
     # Prognose-Scores statt PV-Forecast-Bewertungslabels
     - trigger: state

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -31,44 +31,17 @@
         - sensor.opti_mindestentladepreis_ct_kwh
       below: sensor.opti_price_current_ct_kwh
       id: "Entladeschwelle"
-    # AC-Überschuss = PV-Leistung über Grenze
-    - trigger: numeric_state
+    # Überschuss-Signale: entprellte Binärsensoren (akkuunabhängig, Hysterese,
+    # 30 s beidseitig in opti_derived.yaml) statt Rohwert-Schwellen. Beide
+    # Flanken triggern, damit auch das Zurückschalten sofort neu bewertet wird.
+    - trigger: state
       entity_id:
-        - sensor.opti_pv_power_w
-      above: input_number.akkusteuerung_wr_ac_ueberschuss_grenze
-      for:
-        hours: 0
-        minutes: 0
-        seconds: 30
-      id: "AC-Überschuss"
-    - trigger: numeric_state
+        - binary_sensor.opti_ueberschuss_ac_aktiv
+      id: "AC-Überschuss geändert"
+    - trigger: state
       entity_id:
-        - sensor.opti_pv_power_w
-      below: input_number.akkusteuerung_wr_ac_ueberschuss_grenze
-      for:
-        hours: 0
-        minutes: 0
-        seconds: 30
-      id: "AC-Überschuss-Aus"
-    # 70%-Überschuss = Netzeinspeisung über Grenze
-    - trigger: numeric_state
-      entity_id:
-        - sensor.opti_grid_export_w
-      above: input_number.akkusteuerung_wr_70proz_ueberschuss_grenze
-      for:
-        hours: 0
-        minutes: 0
-        seconds: 30
-      id: "PV-70%-Überschuss"
-    - trigger: numeric_state
-      entity_id:
-        - sensor.opti_grid_export_w
-      below: input_number.akkusteuerung_wr_70proz_ueberschuss_grenze
-      for:
-        hours: 0
-        minutes: 0
-        seconds: 30
-      id: "PV-70%-Überschuss-Aus"
+        - binary_sensor.opti_ueberschuss_70_aktiv
+      id: "PV-70%-Überschuss geändert"
     # Prognose-Scores statt PV-Forecast-Bewertungslabels
     - trigger: state
       entity_id:
@@ -483,14 +456,15 @@
             - condition: state
               entity_id: input_boolean.opti_pv_ueberschuss_ladung
               state: "on"
-            - condition: template
-              value_template: "{{ has_value('sensor.opti_grid_export_w') }}"
             - condition: sun
               after: sunrise
               before: sunset
-            - condition: numeric_state
-              entity_id: sensor.opti_grid_export_w
-              above: input_number.akkusteuerung_wr_70proz_ueberschuss_grenze
+            # Entprelltes, akkuunabhängiges Signal (opti_derived.yaml) statt
+            # Rohwert: verhindert, dass ein anderer Trigger den Zweig mit dem
+            # Momentanwert sofort zieht (Flatter-Fix 2026-07-03).
+            - condition: state
+              entity_id: binary_sensor.opti_ueberschuss_70_aktiv
+              state: "on"
             - condition: numeric_state
               entity_id: sensor.opti_soc
               below: 100
@@ -508,14 +482,13 @@
             - condition: state
               entity_id: input_boolean.opti_pv_ueberschuss_ladung
               state: "on"
-            - condition: template
-              value_template: "{{ has_value('sensor.opti_pv_power_w') }}"
             - condition: sun
               after: sunrise
               before: sunset
-            - condition: numeric_state
-              entity_id: sensor.opti_pv_power_w
-              above: input_number.akkusteuerung_wr_ac_ueberschuss_grenze
+            # Entprelltes, akkuunabhängiges Signal, siehe 70%-Zweig.
+            - condition: state
+              entity_id: binary_sensor.opti_ueberschuss_ac_aktiv
+              state: "on"
             - condition: numeric_state
               entity_id: sensor.opti_soc
               below: 100

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -354,7 +354,7 @@ du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
 |---|---|---|---|
 | **Nacht / Reserve halten (Entladesperre)** | `opti_forecast_score` ≤ 2, SoC < 30 %, `opti_price_level` CHEAP | **Akku nur Laden** | Gate `input_boolean.opti_prognose_netzladen` muss `on` sein |
 | **Nacht / kein Ladegrund** | Score ≤ 2, SoC > 60 %, Preis EXPENSIVE | **Akku Dynamisch** (Default) | Kein Ladeblock greift → Default-Pfad |
-| **Sonne / PV-Überschuss** | `opti_grid_export_w` > 70%-Grenze, SoC < 100 % | **Akku Dynamisch** | Gate `input_boolean.opti_pv_ueberschuss_ladung` muss `on` sein |
+| **Sonne / PV-Überschuss** | `binary_sensor.opti_ueberschuss_70_aktiv` = on (Export + Batterieleistung > 70%-Grenze, 30 s entprellt, 1 kW Hysterese), SoC < 100 % | **Akku Dynamisch** | Gate `input_boolean.opti_pv_ueberschuss_ladung` muss `on` sein |
 | **Tagsüber unter Ziel-SoC** | SoC < `opti_target_soc` **− 3 %**, nach Sonnenaufgang | **Akku Dynamisch** | Option „Dynamisch laden wenn SOC < ZielSoC"; das ±3 %-Band verhindert Modus-Pendeln direkt an der Ziel-Kante — siehe [strategie-logik.md](strategie-logik.md#der-intelligente-ziel-soc--herzstück-der-akkuschonung) |
 | **Entladen über Ziel-SoC** | SoC > `opti_target_soc` **+ 3 %** | **Akku nur Entladen** | Option „Nur Entladen wenn SOC > DynZielSoC" |
 | **MinSOC-Schutz** | SoC < `input_number.minsoc` | **Akku nur Laden** | Höchste Priorität, überstimmt alle anderen Blöcke |
@@ -378,7 +378,7 @@ hat. Bereits durchgeführte Dashboard-Swaps (sicher, geprüft):
 | Alt (`sma_templates.yaml`) | Neu (`opti_derived.yaml`) | Status |
 |---|---|---|
 | `sensor.akkusteuerung_dynamische_ladestaerke` | `sensor.opti_charge_power_w` | Swap OK — SoC-/Temp-Staffelung 1:1 übernommen, nur die Tages-Güte-Klassifikation wurde bewusst von 5 Text-Kategorien auf 3 Score-Bänder umgebaut (nicht byte-identisch bei jedem Prognosewert, aber gleiche Kennlinie) |
-| `sensor.ueberschuss_pv_watt` | `sensor.opti_grid_export_w` | Swap OK — strukturell identische Formel (`max(0, Netzeinspeisung)`) |
+| `sensor.ueberschuss_pv_watt` | `binary_sensor.opti_ueberschuss_70_aktiv` | Nachkorrektur 2026-07-03: der erste Swap auf `opti_grid_export_w` war eine Regression. Das Alt-Signal war PV minus Haus (akkuunabhängig), der Export ist über den Akku rückgekoppelt (Laden drückt Export unter die Grenze -> Modus-Flattern, live beobachtet). Jetzt: Export + Batterieleistung (= Export ohne Akku-Eingriff) + 30-s-Entprellung + Hysterese im Binärsensor |
 | `sensor.pv_forecast_bewertung_heute` | `sensor.opti_forecast_score` | Swap vertretbar — andere Formel (PV-Fit statt Kapazitäts-Multiples), aber `opti_forecast_score` ist der Sensor, den die Strategie tatsächlich konsumiert |
 | `sensor.akku_net_verfugbare_energie` | Attribut `net_available_kwh` von `sensor.opti_target_soc` | Swap OK — Formel äquivalent |
 

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -516,7 +516,7 @@ Stunden rechtfertigen das Netzladen bei diesem SoC-Niveau.
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | `sensor.opti_grid_export_w` über der konfigurierten 70%-Grenze, SoC < 100 %, tagsüber |
+| Bedingung | `binary_sensor.opti_ueberschuss_70_aktiv` = on (Export **plus Batterieleistung** über der 70%-Grenze, 30 s entprellt, 1 kW Hysterese), SoC < 100 %, tagsüber |
 | Preis | irrelevant |
 | Tageszeit | nach Sonnenaufgang bis Sonnenuntergang |
 | Gesetzter Modus | **Akku Dynamisch** |
@@ -525,6 +525,10 @@ Stunden rechtfertigen das Netzladen bei diesem SoC-Niveau.
 **Warum:** Sobald die PV mehr ins Netz einspeist als die konfigurierte 70%-Grenze erlaubt,
 soll dieser Überschuss in den Akku. „Dynamisch" gibt dem Adapter die Freiheit, genau die
 richtige Ladeleistung zu wählen.
+Das Signal rechnet die Batterieleistung mit ein (= Export ohne Akku-Eingriff): der rohe
+Export ist über den Akku rückgekoppelt (Laden drückt ihn unter die Grenze und würde die
+eigene Freigabe sofort wieder beenden - live beobachtetes Minutentakt-Flattern).
+Entprellung 30 s beidseitig plus Hysterese-Band, wie in der bewährten Opti-2.0-Automatik.
 
 ---
 
@@ -532,7 +536,7 @@ richtige Ladeleistung zu wählen.
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | `sensor.opti_pv_power_w` über der konfigurierten WR-Nennleistungsgrenze, SoC < 100 %, tagsüber |
+| Bedingung | `binary_sensor.opti_ueberschuss_ac_aktiv` = on (WR-AC-Leistung **plus Batterieleistung** über der WR-Nennleistungsgrenze, 30 s entprellt, 300 W Hysterese), SoC < 100 %, tagsüber |
 | Preis | irrelevant |
 | Tageszeit | nach Sonnenaufgang bis Sonnenuntergang |
 | Gesetzter Modus | **Akku Dynamisch** |

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -58,7 +58,7 @@ template:
           {% set aus = ein - 1000 %}
           {% set war_an = this is defined and this.state == 'on' %}
           {{ ok and (export_ohne_akku > ein
-                     or (export_ohne_akku >= aus and war_an)) }}
+                     or (aus > 0 and export_ohne_akku >= aus and war_an)) }}
         attributes:
           export_ohne_akku_w: >
             {{ [0, states('sensor.opti_grid_export_w')|float(0)
@@ -82,7 +82,7 @@ template:
           {% set aus = ein - 300 %}
           {% set war_an = this is defined and this.state == 'on' %}
           {{ ok and (ac_ohne_akku > ein
-                     or (ac_ohne_akku >= aus and war_an)) }}
+                     or (aus > 0 and ac_ohne_akku >= aus and war_an)) }}
         attributes:
           ac_ohne_akku_w: >
             {{ [0, states('sensor.opti_pv_power_w')|float(0)

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -28,6 +28,68 @@ template:
         name: "Opti Winter Charging Allowed"
         state: "{{ true }}"
 
+      # -----------------------------------------------------------------------
+      # 0a. Entprellte Überschuss-Signale (Anti-Flatter, 2026-07-03)
+      #    Rohwert-Vergleiche (grid > g70, pv > gac) flatterten live im
+      #    Minutentakt: das Export-Signal ist über den Akku rückgekoppelt
+      #    (Laden drückt den Export unter die Grenze und beendet damit die
+      #    eigene Freigabe). Diese Sensoren rechnen deshalb den Akku aus dem
+      #    Signal heraus (Export bzw. WR-AC + Batterieleistung, Vorzeichen
+      #    positiv = laden -> "Wert ohne Akku-Eingriff") und entprellen wie
+      #    die alte Opti-2.0-Automatik mit 30 s beidseitig; dazu ein
+      #    Hysterese-Band gegen Pendeln am Grenzwert. Quellen unavailable
+      #    -> off (fail-safe: im Zweifel keine Lade-Freigabe).
+      #    Policy-Gates (Toggle, Tag, SoC < 100) bleiben bewusst in
+      #    Strategie/Vorschau - hier steht nur das physikalische Signal.
+      # -----------------------------------------------------------------------
+      - unique_id: opti_ueberschuss_70_aktiv
+        name: "Opti Ueberschuss 70 Aktiv"
+        icon: mdi:transmission-tower-export
+        delay_on:
+          seconds: 30
+        delay_off:
+          seconds: 30
+        state: >
+          {% set ok = has_value('sensor.opti_grid_export_w')
+                      and has_value('sensor.opti_battery_power_w') %}
+          {% set export_ohne_akku = [0, states('sensor.opti_grid_export_w')|float(0)
+                                        + states('sensor.opti_battery_power_w')|float(0)] | max %}
+          {% set ein = states('input_number.akkusteuerung_wr_70proz_ueberschuss_grenze')|float(999999) %}
+          {% set aus = ein - 1000 %}
+          {% set war_an = this is defined and this.state == 'on' %}
+          {{ ok and (export_ohne_akku > ein
+                     or (export_ohne_akku >= aus and war_an)) }}
+        attributes:
+          export_ohne_akku_w: >
+            {{ [0, states('sensor.opti_grid_export_w')|float(0)
+                   + states('sensor.opti_battery_power_w')|float(0)] | max | round(0) }}
+          grenze_ein_w: "{{ states('input_number.akkusteuerung_wr_70proz_ueberschuss_grenze') }}"
+          hysterese_w: 1000
+
+      - unique_id: opti_ueberschuss_ac_aktiv
+        name: "Opti Ueberschuss AC Aktiv"
+        icon: mdi:sine-wave
+        delay_on:
+          seconds: 30
+        delay_off:
+          seconds: 30
+        state: >
+          {% set ok = has_value('sensor.opti_pv_power_w')
+                      and has_value('sensor.opti_battery_power_w') %}
+          {% set ac_ohne_akku = [0, states('sensor.opti_pv_power_w')|float(0)
+                                    + states('sensor.opti_battery_power_w')|float(0)] | max %}
+          {% set ein = states('input_number.akkusteuerung_wr_ac_ueberschuss_grenze')|float(999999) %}
+          {% set aus = ein - 300 %}
+          {% set war_an = this is defined and this.state == 'on' %}
+          {{ ok and (ac_ohne_akku > ein
+                     or (ac_ohne_akku >= aus and war_an)) }}
+        attributes:
+          ac_ohne_akku_w: >
+            {{ [0, states('sensor.opti_pv_power_w')|float(0)
+                   + states('sensor.opti_battery_power_w')|float(0)] | max | round(0) }}
+          grenze_ein_w: "{{ states('input_number.akkusteuerung_wr_ac_ueberschuss_grenze') }}"
+          hysterese_w: 300
+
   - sensor:
 
       # -----------------------------------------------------------------------
@@ -513,10 +575,6 @@ template:
           {% set win = states('binary_sensor.opti_winter_charging_allowed') != 'off' %}
           {% set hv_s = has_value('sensor.opti_forecast_score') %}
           {% set hv_st = has_value('sensor.opti_forecast_score_tomorrow') %}
-          {% set grid = states('sensor.opti_grid_export_w')|float(0) %}
-          {% set pv = states('sensor.opti_pv_power_w')|float(0) %}
-          {% set g70 = states('input_number.akkusteuerung_wr_70proz_ueberschuss_grenze')|float(999999) %}
-          {% set gac = states('input_number.akkusteuerung_wr_ac_ueberschuss_grenze')|float(999999) %}
           {% set p_e = price in ['VERY_CHEAP','CHEAP','NORMAL','EXPENSIVE'] %}
           {% set p_n = price in ['VERY_CHEAP','CHEAP','NORMAL'] %}
           {% set p_c = price in ['VERY_CHEAP','CHEAP'] %}
@@ -546,8 +604,8 @@ template:
           {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}Akku nur Laden
           {%- elif prog and hv_s and soc < 15 and s < 3 and p_e %}Akku nur Laden
           {%- elif prog and hv_s and soc < 45 and s < 3 and p_c %}Akku nur Laden
-          {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}Akku Dynamisch
-          {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}Akku Dynamisch
+          {%- elif ueb and day and is_state('binary_sensor.opti_ueberschuss_70_aktiv','on') and soc < 100 %}Akku Dynamisch
+          {%- elif ueb and day and is_state('binary_sensor.opti_ueberschuss_ac_aktiv','on') and soc < 100 %}Akku Dynamisch
           {%- elif soc > 99 %}Akku Dynamisch
           {%- elif aktiv and hv_cur and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Akku nur Laden
           {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Akku nur Laden
@@ -569,10 +627,6 @@ template:
             {% set win = states('binary_sensor.opti_winter_charging_allowed') != 'off' %}
             {% set hv_s = has_value('sensor.opti_forecast_score') %}
             {% set hv_st = has_value('sensor.opti_forecast_score_tomorrow') %}
-            {% set grid = states('sensor.opti_grid_export_w')|float(0) %}
-            {% set pv = states('sensor.opti_pv_power_w')|float(0) %}
-            {% set g70 = states('input_number.akkusteuerung_wr_70proz_ueberschuss_grenze')|float(999999) %}
-            {% set gac = states('input_number.akkusteuerung_wr_ac_ueberschuss_grenze')|float(999999) %}
             {% set p_e = price in ['VERY_CHEAP','CHEAP','NORMAL','EXPENSIVE'] %}
             {% set p_n = price in ['VERY_CHEAP','CHEAP','NORMAL'] %}
             {% set p_c = price in ['VERY_CHEAP','CHEAP'] %}
@@ -602,8 +656,8 @@ template:
             {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}SOC<80 Wintermodus
             {%- elif prog and hv_s and soc < 15 and s < 3 and p_e %}SOC<15 Notfall
             {%- elif prog and hv_s and soc < 45 and s < 3 and p_c %}SOC<45 sehr guenstig
-            {%- elif ueb and has_value('sensor.opti_grid_export_w') and day and grid > g70 and soc < 100 %}70% Ueberschuss (tag)
-            {%- elif ueb and has_value('sensor.opti_pv_power_w') and day and pv > gac and soc < 100 %}AC Ueberschuss (tag)
+            {%- elif ueb and day and is_state('binary_sensor.opti_ueberschuss_70_aktiv','on') and soc < 100 %}70% Ueberschuss (tag, entprellt)
+            {%- elif ueb and day and is_state('binary_sensor.opti_ueberschuss_ac_aktiv','on') and soc < 100 %}AC Ueberschuss (tag, entprellt)
             {%- elif soc > 99 %}Akku voll
             {%- elif aktiv and hv_cur and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Peak-Leiter L3 (halten fuer VE, Reserve {{ve_res}}%, Spread {{(ve_avg - cur)|round(1)}}ct)
             {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Peak-Leiter L4 (halten fuer Peaks, Reserve {{ges_res}}%)

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -101,7 +101,9 @@ input_number:
   akkusteuerung_wr_70proz_ueberschuss_grenze:
     name: "Akkusteuerung 70%-Überschuss Grenze"
     min: 0
-    max: 15000
+    # 25000: 15000 konnte die 70%-Grenze von Anlagen ueber ~21 kWp
+    # nicht abbilden.
+    max: 25000
     step: 100
     unit_of_measurement: W
     mode: box

--- a/tests/ha_harness.py
+++ b/tests/ha_harness.py
@@ -16,11 +16,13 @@ REPO = pathlib.Path(__file__).resolve().parent.parent
 
 
 class FakeHass:
-    def __init__(self, states=None, attrs=None, now=None, this_attributes=None):
+    def __init__(self, states=None, attrs=None, now=None, this_attributes=None,
+                 this_state=None):
         self.states_map = dict(states or {})
         self.attrs_map = {k: dict(v) for k, v in (attrs or {}).items()}
         self.now_value = now or dt.datetime(2026, 1, 15, 18, 30, tzinfo=TZ)
         self.this_attributes = dict(this_attributes or {})
+        self.this_state = this_state
 
     def states(self, entity_id):
         return self.states_map.get(entity_id, "unknown")
@@ -76,7 +78,8 @@ def _setup(env, hass):
         states=hass.states, state_attr=hass.state_attr, has_value=hass.has_value,
         is_state=hass.is_state, now=hass.now, today_at=hass.today_at,
         timedelta=dt.timedelta, min=min, max=max,
-        this=types.SimpleNamespace(attributes=hass.this_attributes),
+        this=types.SimpleNamespace(attributes=hass.this_attributes,
+                                   state=hass.this_state),
     )
     env.filters.update({
         "float": _float, "int": _int,

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -8,8 +8,8 @@ BASIS = {
     "sensor.opti_price_level": "NORMAL",
     "sensor.opti_target_soc": "60",
     "sensor.opti_price_current_ct_kwh": "30",
-    "sensor.opti_grid_export_w": "0",
-    "sensor.opti_pv_power_w": "0",
+    "binary_sensor.opti_ueberschuss_70_aktiv": "off",
+    "binary_sensor.opti_ueberschuss_ac_aktiv": "off",
     "sensor.opti_peak_reserve_soc": "unavailable",
     "binary_sensor.opti_peak_reserve_aktiv": "off",
     "binary_sensor.opti_winter_charging_allowed": "on",
@@ -20,8 +20,6 @@ BASIS = {
     # halte_spread "0" = alte Tests bleiben semantisch unveraendert (L3 haelt
     # sobald ve_avg gesetzt ist); neue Tests setzen halte_spread aktiv.
     "input_number.opti_halte_spread_ct": "0",
-    "input_number.akkusteuerung_wr_70proz_ueberschuss_grenze": "500",
-    "input_number.akkusteuerung_wr_ac_ueberschuss_grenze": "4500",
     "input_boolean.opti_prognose_netzladen": "on",
     "input_boolean.opti_pv_ueberschuss_ladung": "on",
     "input_select.akkusteuerung_modus": "Akku Dynamisch",
@@ -317,3 +315,48 @@ def test_l3_kein_halten_bei_unavailable_preissensor():
     out = grund(**{**L3_HALTE_FALL, "sensor.opti_price_current_ct_kwh": "unavailable"},
                 _attrs=attrs)
     assert "Peak-Leiter L3" not in out
+
+
+# --- Ueberschuss-Regeln (entprellt, 2026-07-03): Vorschau konsumiert Binaries ---
+
+UEBERSCHUSS_TAG = {"sun.sun": "above_horizon", "sensor.opti_soc": "70",
+                   "sensor.opti_target_soc": "50"}
+
+
+def test_ueberschuss_70_schaltet_dynamisch():
+    out = vorschau(**UEBERSCHUSS_TAG,
+                   **{"binary_sensor.opti_ueberschuss_70_aktiv": "on"})
+    assert out == "Akku Dynamisch"
+    assert "70% Ueberschuss" in grund(
+        **UEBERSCHUSS_TAG, **{"binary_sensor.opti_ueberschuss_70_aktiv": "on"})
+
+
+def test_ueberschuss_ac_schaltet_dynamisch():
+    assert "AC Ueberschuss" in grund(
+        **UEBERSCHUSS_TAG, **{"binary_sensor.opti_ueberschuss_ac_aktiv": "on"})
+
+
+def test_ueberschuss_nicht_nachts():
+    g = grund(**{**UEBERSCHUSS_TAG, "sun.sun": "below_horizon",
+                 "binary_sensor.opti_ueberschuss_70_aktiv": "on"})
+    assert "Ueberschuss" not in g
+
+
+def test_ueberschuss_gate_aus():
+    g = grund(**{**UEBERSCHUSS_TAG,
+                 "input_boolean.opti_pv_ueberschuss_ladung": "off",
+                 "binary_sensor.opti_ueberschuss_70_aktiv": "on"})
+    assert "Ueberschuss" not in g
+
+
+def test_ueberschuss_nicht_bei_vollem_akku():
+    g = grund(**{**UEBERSCHUSS_TAG, "sensor.opti_soc": "100",
+                 "binary_sensor.opti_ueberschuss_70_aktiv": "on"})
+    assert "Ueberschuss" not in g
+
+
+def test_ueberschuss_binary_unavailable_ist_aus():
+    # Fail-safe: unavailable darf nie wie "on" wirken.
+    g = grund(**{**UEBERSCHUSS_TAG,
+                 "binary_sensor.opti_ueberschuss_70_aktiv": "unavailable"})
+    assert "Ueberschuss" not in g

--- a/tests/test_ueberschuss_entprellung.py
+++ b/tests/test_ueberschuss_entprellung.py
@@ -68,6 +68,17 @@ def test_70_hysterese_haelt_im_band():
     assert b70(this_state="off", **zw) == "False"
 
 
+def test_70_kanten_exakt_auf_grenze():
+    # Genau == ein (18000): noch KEIN Einschalten (Bedingung ist strikt >)...
+    assert b70(**{"sensor.opti_grid_export_w": "18000"}) == "False"
+    # ...aber Halten, wenn schon an (Band schliesst die Ein-Kante ein).
+    assert b70(this_state="on", **{"sensor.opti_grid_export_w": "18000"}) == "True"
+    # Genau == aus (17000): Band ist inklusiv -> an bleibt an.
+    assert b70(this_state="on", **{"sensor.opti_grid_export_w": "17000"}) == "True"
+    # Knapp darunter: aus.
+    assert b70(this_state="on", **{"sensor.opti_grid_export_w": "16999"}) == "False"
+
+
 def test_70_failsafe_bei_unavailable():
     assert b70(this_state="on",
                **{"sensor.opti_grid_export_w": "unavailable"}) == "False"

--- a/tests/test_ueberschuss_entprellung.py
+++ b/tests/test_ueberschuss_entprellung.py
@@ -1,0 +1,144 @@
+"""Entprellte Ueberschuss-Binärsensoren (Anti-Flatter, 2026-07-03).
+
+Hintergrund: Die Ueberschuss-Regeln pruefen bis dahin Momentanwerte, und das
+70%-Signal (opti_grid_export_w) ist ueber den Akku rueckgekoppelt: Laden drueckt
+den Export unter die Grenze, die Regel kippt zurueck, Laden stoppt, Export
+steigt - Selbstschwingung im Minutentakt (live 2026-07-03, 11:25-13:35).
+Fix: akkuunabhaengiges Signal (Export + Batterieleistung signed = Export ohne
+Akku-Eingriff) + Hysterese-Band + 30-s-Entprellung (delay_on/delay_off).
+"""
+from .ha_harness import REPO, FakeHass, find_template_entity, load_yaml, render
+
+BASIS = {
+    "sensor.opti_grid_export_w": "0",
+    "sensor.opti_battery_power_w": "0",
+    "sensor.opti_pv_power_w": "0",
+    "input_number.akkusteuerung_wr_70proz_ueberschuss_grenze": "18000",
+    "input_number.akkusteuerung_wr_ac_ueberschuss_grenze": "9500",
+}
+
+
+def _entity(uid):
+    cfg = load_yaml(REPO / "packages" / "opti_derived.yaml")
+    return find_template_entity(cfg, "binary_sensor", uid)
+
+
+def _render(uid, overrides, this_state="off"):
+    states = dict(BASIS)
+    states.update(overrides)
+    hass = FakeHass(states=states, this_state=this_state)
+    return render(hass, _entity(uid)["state"])
+
+
+def b70(this_state="off", **overrides):
+    return _render("opti_ueberschuss_70_aktiv", overrides, this_state)
+
+
+def bac(this_state="off", **overrides):
+    return _render("opti_ueberschuss_ac_aktiv", overrides, this_state)
+
+
+# --- 70%-Ueberschuss: akkuunabhaengiges Signal ---
+
+def test_70_ein_bei_export_ueber_grenze():
+    assert b70(**{"sensor.opti_grid_export_w": "19000"}) == "True"
+
+
+def test_70_aus_weit_unter_grenze():
+    assert b70(this_state="on", **{"sensor.opti_grid_export_w": "5000"}) == "False"
+
+
+def test_70_akkuunabhaengig_laden_zaehlt_dazu():
+    # DER Flatterfall: Akku laedt 5 kW, Export faellt dadurch auf 14 kW.
+    # Ohne Akku waeren es 19 kW -> Signal muss AN bleiben.
+    assert b70(this_state="on", **{"sensor.opti_grid_export_w": "14000",
+                                   "sensor.opti_battery_power_w": "5000"}) == "True"
+
+
+def test_70_entladen_wird_rausgerechnet():
+    # Akku entlaedt 5 kW in den Export: gemessen 18.5 kW, ohne Akku 13.5 kW.
+    assert b70(**{"sensor.opti_grid_export_w": "18500",
+                  "sensor.opti_battery_power_w": "-5000"}) == "False"
+
+
+def test_70_hysterese_haelt_im_band():
+    # 17.5 kW liegt im Band (aus < 17000, ein > 18000): Zustand bleibt.
+    zw = {"sensor.opti_grid_export_w": "17500"}
+    assert b70(this_state="on", **zw) == "True"
+    assert b70(this_state="off", **zw) == "False"
+
+
+def test_70_failsafe_bei_unavailable():
+    assert b70(this_state="on",
+               **{"sensor.opti_grid_export_w": "unavailable"}) == "False"
+    assert b70(this_state="on",
+               **{"sensor.opti_battery_power_w": "unavailable"}) == "False"
+
+
+# --- AC-Ueberschuss (Hybrid-WR-AC-Limit): gleiche Mechanik ---
+
+def test_ac_ein_bei_pv_ueber_grenze():
+    assert bac(**{"sensor.opti_pv_power_w": "9700"}) == "True"
+
+
+def test_ac_akkuunabhaengig_laden_zaehlt_dazu():
+    # Akku laedt 4 kW DC-seitig, AC-Ausgang faellt auf 6 kW - ohne Akku 10 kW.
+    assert bac(this_state="on", **{"sensor.opti_pv_power_w": "6000",
+                                   "sensor.opti_battery_power_w": "4000"}) == "True"
+
+
+def test_ac_hysterese_haelt_im_band():
+    zw = {"sensor.opti_pv_power_w": "9300"}
+    assert bac(this_state="on", **zw) == "True"
+    assert bac(this_state="off", **zw) == "False"
+
+
+def test_ac_aus_unter_band():
+    assert bac(this_state="on", **{"sensor.opti_pv_power_w": "8000"}) == "False"
+
+
+def test_ac_failsafe_bei_unavailable():
+    assert bac(this_state="on",
+               **{"sensor.opti_pv_power_w": "unavailable"}) == "False"
+
+
+# --- Entprellung: 30 s beidseitig wie in der alten Opti-2.0-Automatik ---
+
+def test_delay_on_off_30s():
+    for uid in ("opti_ueberschuss_70_aktiv", "opti_ueberschuss_ac_aktiv"):
+        entity = _entity(uid)
+        assert entity["delay_on"] == {"seconds": 30}, uid
+        assert entity["delay_off"] == {"seconds": 30}, uid
+
+
+# --- Strategie-Automation konsumiert nur noch die entprellten Sensoren ---
+
+def _automation():
+    return load_yaml(REPO / "automations" / "opti_strategie.yaml")
+
+
+def _flat(obj):
+    import json
+    return json.dumps(obj, ensure_ascii=False)
+
+
+def test_automation_trigger_nutzen_binaersensoren():
+    triggers = _flat(_automation()[0]["triggers"])
+    assert "binary_sensor.opti_ueberschuss_70_aktiv" in triggers
+    assert "binary_sensor.opti_ueberschuss_ac_aktiv" in triggers
+    # Keine Rohwert-Ueberschuss-Trigger mehr (Entprellung lebt im Sensor).
+    assert "akkusteuerung_wr_70proz_ueberschuss_grenze" not in triggers
+    assert "akkusteuerung_wr_ac_ueberschuss_grenze" not in triggers
+
+
+def test_automation_conditions_nutzen_binaersensoren():
+    from .ha_harness import find_automation_condition
+    cfg = _automation()
+    c70 = _flat(find_automation_condition(
+        cfg, "Modus 'Dynamisch': 70% PV-Überschuss in den Akku (nur tagsüber)"))
+    cac = _flat(find_automation_condition(
+        cfg, "Modus 'Dynamisch': AC-PV-Überschuss in den Akku (nur tagsüber)"))
+    assert "binary_sensor.opti_ueberschuss_70_aktiv" in c70
+    assert "sensor.opti_grid_export_w" not in c70
+    assert "binary_sensor.opti_ueberschuss_ac_aktiv" in cac
+    assert "sensor.opti_pv_power_w" not in cac


### PR DESCRIPTION
## Problem

Die 70%-/AC-Ueberschuss-Regeln pruefen Momentanwerte, und das 70%-Signal (`opti_grid_export_w`) ist ueber den Akku rueckgekoppelt: Regel feuert -> Akku laedt -> Export faellt unter die Grenze -> Regel kippt zurueck -> Laden stoppt -> Export steigt -> Regel feuert erneut. Live am 2026-07-03 (11:25-13:35): Modus-Flattern Dynamisch/nur-Entladen im Minutentakt mit 2-5-kW-Lade-Bursts.

Die Vorgaenger-Automatik (Opti 2.0) war stabil, weil ihr Signal (PV minus Haus) akkuunabhaengig war und beidseitig 30 s entprellt wurde. Der Canonical-Swap auf den rohen Export war eine unerkannte Regression (Swap-Tabelle in docs/canonical-layer.md entsprechend korrigiert).

## Fix

- **Neu:** `binary_sensor.opti_ueberschuss_70_aktiv` / `opti_ueberschuss_ac_aktiv` (opti_derived.yaml):
  - Signal = Export bzw. WR-AC **plus Batterieleistung** (Vorzeichen positiv = laden) = Wert ohne Akku-Eingriff, akkuunabhaengig und rueckkopplungsfrei. Beruecksichtigt anders als das alte PV-minus-Haus auch Wallbox-Verbrauch korrekt.
  - Hysterese-Band (1000 W bzw. 300 W) + `delay_on`/`delay_off` 30 s (wie Opti 2.0)
  - Quellen unavailable -> off (fail-safe: keine Lade-Freigabe im Zweifel)
- Strategie-Automation und Strategie-Vorschau (state + grund) konsumieren nur noch die entprellten Sensoren; Rohwert-Trigger und -Conditions entfernt (die alten `for: 30s`-Trigger liefen ins Leere, weil jeder andere Trigger die Rohwert-Conditions sofort ziehen konnte)
- `sma_helpers.yaml`: 70%-Grenzen-Helper max 15000 -> 25000
- Doku: canonical-layer.md (Swap-Tabelle, Testfaelle), strategie-logik.md (Optionen 11/12), README-Roadmap (Hysterese-Punkt erledigt)

## Tests

17 neue Faelle (Hysterese inkl. Kanten, Akku-Kompensation laden/entladen, fail-safe bei unavailable, Entprell-Config, Automation-Verdrahtung, Vorschau-Gates); Harness um `this.state` erweitert. Suite: 85 passed.

Zweitmeinung + Review durch Codex (read-only): Ansatz bestaetigt, keine High/Medium-Findings; beide Low-Findings in diesem PR behoben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vWz4Jg6U2hiQawvuKCypo