### PR TITLE
Fix-Runde Codebase-Review: Forecast-Score P10-Quelle, Availability, Privacy

### DIFF
--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -207,6 +207,8 @@ Die `opti_forecast_*_kwh`-Sensoren reichen das Attribut `estimate10` durch (10. 
 Der `opti_forecast_score` und der intelligente Ziel-SoC (`opti_target_soc`, siehe
 [strategie-logik.md](strategie-logik.md#der-intelligente-ziel-soc--herzstück-der-akkuschonung))
 nutzen diesen Wert als konservative Untergrenze.
+Beide lesen das P10 vom Rest-Tag-Sensor (`opti_forecast_remaining_today_kwh`), nicht vom Ganztags-Sensor:
+das Ganztags-P10 enthält die bereits gelaufene Vormittagsproduktion und wäre ab dem Nachmittag praktisch immer größer als der Rest-Median - als Sicherheitsnetz damit wirkungslos.
 
 **Kontrakt:** Das Attribut wird nur gesetzt, wenn die Quelle tatsächlich ein P10 liefert - fehlt es, bleibt `estimate10` weg (bzw. `none`), es wird NICHT auf `0` normalisiert.
 Grund: `0` ist von "keine Schätzung vorhanden" nicht unterscheidbar, würde aber als echter P10-Wert von 0 kWh interpretiert und die Restproduktion fälschlich auf 0 drücken.

--- a/old/configuration.yaml
+++ b/old/configuration.yaml
@@ -1,7 +1,7 @@
 modbus:
   - name: sma-sr_wr
     type: tcp
-    host: 192.168.10.2
+    host: 192.168.1.100  # <- durch die IP deines Wechselrichters ersetzen
     port: 502
     delay: 2
     message_wait_milliseconds: 60

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -102,15 +102,22 @@ template:
       #    Verbrauch: nutzt den 60-min-Mittelwert (Legacy-Muster) statt des
       #    Momentanwerts, damit kurze Lastspitzen (z.B. Wasserkocher) den
       #    Score nicht minuetlich auf 0 kippen.
+      #    P10: estimate10 kommt vom REST-Tag-Sensor (remaining_today), nicht
+      #    vom Ganztags-Sensor - das Ganztags-P10 enthaelt die schon gelaufene
+      #    Produktion und waere nachmittags kein Sicherheitsnetz mehr.
+      #    Availability spiegelt die Zweige: der Abend-Zweig braucht nur den
+      #    Morgen-Score, die Tages-Formel Rest-Prognose + Kapazitaet + SoC.
       # -----------------------------------------------------------------------
       - unique_id: opti_forecast_score
         name: "Opti Forecast Score"
         state_class: measurement
         availability: >
-          {{ has_value('sensor.opti_forecast_remaining_today_kwh')
-             and has_value('sensor.opti_forecast_today_kwh')
-             and has_value('sensor.opti_battery_capacity_kwh')
-             and has_value('sensor.opti_soc') }}
+          {% set setting = state_attr('sun.sun', 'next_setting') %}
+          {% set nach_sunset = setting is not none and (setting | as_datetime | as_local).date() != now().date() %}
+          {{ (nach_sunset and has_value('sensor.opti_forecast_score_tomorrow'))
+             or (has_value('sensor.opti_forecast_remaining_today_kwh')
+                 and has_value('sensor.opti_battery_capacity_kwh')
+                 and has_value('sensor.opti_soc')) }}
         state: >
           {% set setting = state_attr('sun.sun', 'next_setting') %}
           {% set nach_sunset = setting is not none and (setting | as_datetime | as_local).date() != now().date() %}
@@ -118,7 +125,7 @@ template:
           {{ states('sensor.opti_forecast_score_tomorrow') | int(0) }}
           {% else %}
           {% set median = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
-          {% set p10_raw = state_attr('sensor.opti_forecast_today_kwh','estimate10') | float(median) %}
+          {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh','estimate10') | float(median) %}
           {% set p10 = p10_raw if p10_raw > 0 else median %}
           {% set remaining = [median, p10] | min %}
           {% set cap = states('sensor.opti_battery_capacity_kwh') | float(0) %}
@@ -134,21 +141,23 @@ template:
         attributes:
           remaining_kwh: >
             {% set median = states('sensor.opti_forecast_remaining_today_kwh')|float(0) %}
-            {% set p10_raw = state_attr('sensor.opti_forecast_today_kwh','estimate10')|float(median) %}
+            {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh','estimate10')|float(median) %}
             {% set p10 = p10_raw if p10_raw > 0 else median %}
             {{ [median, p10]|min|round(2) }}
           needed_full_kwh: "{{ (states('sensor.opti_battery_capacity_kwh')|float(0) * (1-(states('sensor.opti_soc')|float(0))/100))|round(2) }}"
           hours_to_sunset: "{{ (((state_attr('sun.sun','next_setting')|as_datetime - now()).total_seconds()/3600) if state_attr('sun.sun','next_setting') else 0)|round(1) }}"
           pv_surplus_kwh: >
             {% set median = states('sensor.opti_forecast_remaining_today_kwh')|float(0) %}
-            {% set rem = [median, state_attr('sensor.opti_forecast_today_kwh','estimate10')|float(median)]|min %}
+            {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh','estimate10')|float(median) %}
+            {% set rem = [median, p10_raw if p10_raw > 0 else median]|min %}
             {% set sunset = state_attr('sun.sun','next_setting') %}
             {% set h = ((sunset|as_datetime - now()).total_seconds()/3600) if sunset else 0 %}
             {% set hausverbrauch = states('sensor.opti_house_consumption_60min_w')|float(states('sensor.opti_house_consumption_w')|float(400)) %}
             {{ [rem - (hausverbrauch/1000*([h,0]|max)), 0]|max|round(2) }}
           ueberschuss_ueber_voll_kwh: >
             {% set median = states('sensor.opti_forecast_remaining_today_kwh')|float(0) %}
-            {% set rem = [median, state_attr('sensor.opti_forecast_today_kwh','estimate10')|float(median)]|min %}
+            {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh','estimate10')|float(median) %}
+            {% set rem = [median, p10_raw if p10_raw > 0 else median]|min %}
             {% set sunset = state_attr('sun.sun','next_setting') %}
             {% set h = ((sunset|as_datetime - now()).total_seconds()/3600) if sunset else 0 %}
             {% set hausverbrauch = states('sensor.opti_house_consumption_60min_w')|float(states('sensor.opti_house_consumption_w')|float(400)) %}

--- a/tests/test_derived_sensoren.py
+++ b/tests/test_derived_sensoren.py
@@ -175,6 +175,27 @@ def test_score_p10_nutzt_rest_tag_sensor():
     # Score rechnet mit remaining=1.0: needed=13, verbrauch=0 -> surplus=1.0
     # -> ratio = 1/13 -> round(0.769) = 1.
     assert _score_state(hass) == "1"
+    # Auch die Surplus-Attribute muessen das Rest-P10 nutzen (verbrauch=0
+    # -> pv_surplus = remaining = 1.0).
+    assert float(_score_attr(hass, "pv_surplus_kwh")) == 1.0
+
+    # ueberschuss_ueber_voll diskriminierend pruefen: cap=0.5, soc=0
+    # -> needed=0.5 -> ueberschuss = 1.0 - 0.5 = 0.5 (Ganztags-P10 gaebe 1.5).
+    hass_klein = FakeHass(
+        states={
+            "sensor.opti_forecast_remaining_today_kwh": "2.0",
+            "sensor.opti_battery_capacity_kwh": "0.5",
+            "sensor.opti_soc": "0",
+            "sensor.opti_house_consumption_w": "0",
+        },
+        attrs={
+            "sun.sun": {"next_setting": next_setting},
+            "sensor.opti_forecast_remaining_today_kwh": {"estimate10": 1.0},
+            "sensor.opti_forecast_today_kwh": {"estimate10": 5.0},
+        },
+        now=now,
+    )
+    assert float(_score_attr(hass_klein, "ueberschuss_ueber_voll_kwh")) == 0.5
 
 
 def test_score_surplus_attribute_estimate10_null_guard():
@@ -223,6 +244,26 @@ def test_score_availability_abend_entkoppelt():
     )
     assert _score_availability(hass) == "True"
     assert _score_state(hass) == "8"
+
+
+def test_score_availability_abend_fallback_alte_formel():
+    # Nach Sonnenuntergang OHNE Morgen-Score: Fallback auf die alte Formel,
+    # dafuer reichen die Tages-Sensoren (opti_forecast_today_kwh wird nicht
+    # mehr verlangt).
+    now = dt.datetime(2026, 1, 15, 21, 45, tzinfo=TZ)
+    next_setting = dt.datetime(2026, 1, 16, 16, 30, tzinfo=TZ).isoformat()
+    hass = FakeHass(
+        states={
+            "sensor.opti_forecast_score_tomorrow": "unavailable",
+            "sensor.opti_forecast_remaining_today_kwh": "0",
+            "sensor.opti_battery_capacity_kwh": "10",
+            "sensor.opti_soc": "50",
+        },
+        attrs={"sun.sun": {"next_setting": next_setting}},
+        now=now,
+    )
+    assert _score_availability(hass) == "True"
+    assert _score_state(hass) == "0"
 
 
 def test_score_availability_tag():

--- a/tests/test_derived_sensoren.py
+++ b/tests/test_derived_sensoren.py
@@ -21,6 +21,11 @@ def _score_attr(hass, attr):
     return render(hass, entity["attributes"][attr])
 
 
+def _score_availability(hass):
+    entity = _entity("sensor", "opti_forecast_score")
+    return render(hass, entity["availability"])
+
+
 def _target_soc_state(hass):
     entity = _entity("sensor", "opti_target_soc")
     return render(hass, entity["state"])
@@ -84,7 +89,7 @@ def test_score_vor_sonnenaufgang_normale_formel():
     )
     # needed = 13 * (1 - 0.95) = 0.65; h = 13h; verbrauch = 0.4*13 = 5.2kWh
     # surplus = max(12 - 5.2, 0) = 6.8 -> ratio > 1 -> Score gedeckelt auf 10.
-    assert int(_score_state(hass)) > 0
+    assert _score_state(hass) == "10"
 
 
 # ---------------------------------------------------------------------------
@@ -139,11 +144,116 @@ def test_score_estimate10_null_ignoriert():
         },
         attrs={
             "sun.sun": {"next_setting": next_setting},
-            "sensor.opti_forecast_today_kwh": {"estimate10": 0},
+            "sensor.opti_forecast_remaining_today_kwh": {"estimate10": 0},
         },
         now=now,
     )
     assert float(_score_attr(hass, "remaining_kwh")) == 8.0
+
+
+def test_score_p10_nutzt_rest_tag_sensor():
+    # Nachmittag: Rest-Median 2 kWh mit Rest-P10 1 kWh; das Ganztags-P10 (5 kWh)
+    # ist um die schon gelaufene Vormittagsproduktion groesser und darf NICHT
+    # als Sicherheitsnetz dienen - remaining muss das Rest-P10 (1.0) sein.
+    now = dt.datetime(2026, 1, 15, 14, 0, tzinfo=TZ)
+    next_setting = dt.datetime(2026, 1, 15, 18, 0, tzinfo=TZ).isoformat()
+    hass = FakeHass(
+        states={
+            "sensor.opti_forecast_remaining_today_kwh": "2.0",
+            "sensor.opti_battery_capacity_kwh": "13",
+            "sensor.opti_soc": "0",
+            "sensor.opti_house_consumption_w": "0",
+        },
+        attrs={
+            "sun.sun": {"next_setting": next_setting},
+            "sensor.opti_forecast_remaining_today_kwh": {"estimate10": 1.0},
+            "sensor.opti_forecast_today_kwh": {"estimate10": 5.0},
+        },
+        now=now,
+    )
+    assert float(_score_attr(hass, "remaining_kwh")) == 1.0
+    # Score rechnet mit remaining=1.0: needed=13, verbrauch=0 -> surplus=1.0
+    # -> ratio = 1/13 -> round(0.769) = 1.
+    assert _score_state(hass) == "1"
+
+
+def test_score_surplus_attribute_estimate10_null_guard():
+    # estimate10 = 0 gilt auch in pv_surplus_kwh/ueberschuss_ueber_voll_kwh als
+    # "keine P10-Schaetzung" -> Median 8 kWh zaehlt, nicht 0.
+    # cap=5, soc=0 -> needed=5; verbrauch=0 -> surplus=8, ueberschuss=8-5=3.
+    now = dt.datetime(2026, 1, 15, 8, 0, tzinfo=TZ)
+    next_setting = dt.datetime(2026, 1, 15, 18, 0, tzinfo=TZ).isoformat()
+    hass = FakeHass(
+        states={
+            "sensor.opti_forecast_remaining_today_kwh": "8",
+            "sensor.opti_battery_capacity_kwh": "5",
+            "sensor.opti_soc": "0",
+            "sensor.opti_house_consumption_w": "0",
+        },
+        attrs={
+            "sun.sun": {"next_setting": next_setting},
+            "sensor.opti_forecast_remaining_today_kwh": {"estimate10": 0},
+            "sensor.opti_forecast_today_kwh": {"estimate10": 0},
+        },
+        now=now,
+    )
+    assert float(_score_attr(hass, "pv_surplus_kwh")) == 8.0
+    assert float(_score_attr(hass, "ueberschuss_ueber_voll_kwh")) == 3.0
+
+
+# ---------------------------------------------------------------------------
+# 2f. Availability opti_forecast_score
+# ---------------------------------------------------------------------------
+
+def test_score_availability_abend_entkoppelt():
+    # Nach Sonnenuntergang mit verfuegbarem Morgen-Score darf der Score nicht
+    # unavailable werden, nur weil die Tages-Sensoren wegkippen - der
+    # Abend-Zweig braucht sie nicht (Kommentar im Sensor verspricht das).
+    now = dt.datetime(2026, 1, 15, 21, 45, tzinfo=TZ)
+    next_setting = dt.datetime(2026, 1, 16, 16, 30, tzinfo=TZ).isoformat()
+    hass = FakeHass(
+        states={
+            "sensor.opti_forecast_score_tomorrow": "8",
+            "sensor.opti_forecast_remaining_today_kwh": "unavailable",
+            "sensor.opti_battery_capacity_kwh": "unavailable",
+            "sensor.opti_soc": "unavailable",
+        },
+        attrs={"sun.sun": {"next_setting": next_setting}},
+        now=now,
+    )
+    assert _score_availability(hass) == "True"
+    assert _score_state(hass) == "8"
+
+
+def test_score_availability_tag():
+    # Tagsueber braucht die Formel Rest-Prognose, Kapazitaet und SoC -
+    # aber NICHT mehr opti_forecast_today_kwh (Score liest P10 seit dem
+    # Quell-Fix vom Rest-Tag-Sensor).
+    now = dt.datetime(2026, 1, 15, 8, 0, tzinfo=TZ)
+    next_setting = dt.datetime(2026, 1, 15, 18, 0, tzinfo=TZ).isoformat()
+    attrs = {"sun.sun": {"next_setting": next_setting}}
+
+    hass_ok = FakeHass(
+        states={
+            "sensor.opti_forecast_remaining_today_kwh": "8",
+            "sensor.opti_battery_capacity_kwh": "13",
+            "sensor.opti_soc": "50",
+        },
+        attrs=attrs,
+        now=now,
+    )
+    assert _score_availability(hass_ok) == "True"
+
+    hass_missing = FakeHass(
+        states={
+            "sensor.opti_forecast_remaining_today_kwh": "unavailable",
+            "sensor.opti_battery_capacity_kwh": "13",
+            "sensor.opti_soc": "50",
+        },
+        attrs=attrs,
+        now=now,
+    )
+    assert _score_availability(hass_missing) == "False"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Kontext

Fix-Runde aus dem Codebase-Review vom 2026-07-05 (3x Opus-Reviewer + Codex-Zweitmeinung, Findings einzeln verifiziert).

## Änderungen

**P2: \`opti_forecast_score\` liest P10 jetzt vom Rest-Tag-Sensor.**
\`estimate10\` kam bisher vom Ganztags-Sensor und wurde gegen den Rest-Tag-Median gemint.
Nachmittags ist das Ganztags-P10 fast immer größer als der Rest-Median (live heute: 51,8 kWh vs. 0 kWh) - das P10-Sicherheitsnetz des Scores war damit praktisch wirkungslos.
State + alle drei Attribute nutzen jetzt wie \`opti_target_soc\` den Rest-Tag-Sensor; \`pv_surplus_kwh\`/\`ueberschuss_ueber_voll_kwh\` bekommen zusätzlich den \`p10 > 0\`-Guard.

**P2: Availability vom Abend-Zweig entkoppelt.**
Nach Sonnenuntergang braucht der Sensor nur noch den Morgen-Score - vorher konnte ein nächtlicher Ausfall von \`opti_forecast_today_kwh\`/\`opti_soc\`/\`opti_battery_capacity_kwh\` den Score (und damit die \`has_value\`-gegateten Strategie-Ladeblöcke) grundlos wegkippen. Der Sensor-Kommentar versprach die Entkopplung bereits.

**P3 Privacy: echte interne Host-IP in \`old/configuration.yaml\` durch Platzhalter ersetzt** (Repo ist public; die IP bleibt in der Git-Historie, ist aber RFC1918).

## Tests

TDD: 4 neue Tests (P10-Quelle, Attribut-Guards, Availability Abend/Tag) erst rot gesehen, dann gefixt.
Schwache \`> 0\`-Assertion auf \`== 10\` verschärft.
**96/96 Tests grün**, alle 178 Jinja-Templates parsen, neue Templates gegen Live-HA evaluiert.