### PR TITLE
feat: einstellbarer Forecast-Optimismus (P10 ↔ Median), zentraler Blend-Sensor

### DIFF
--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -206,7 +206,7 @@ oben mit derselben Seriennummer ersetzen.
 Die `opti_forecast_*_kwh`-Sensoren reichen das Attribut `estimate10` durch (10. Perzentil der Prognose - pessimistischer Worst-Case-Wert).
 Der `opti_forecast_score` und der intelligente Ziel-SoC (`opti_target_soc`, siehe
 [strategie-logik.md](strategie-logik.md#der-intelligente-ziel-soc--herzstück-der-akkuschonung))
-nutzen diesen Wert als konservative Untergrenze.
+nutzen diesen Wert als - per Default konservative - Referenz; der Optimismus-Grad ist einstellbar (siehe unten).
 Beide lesen das P10 vom Rest-Tag-Sensor (`opti_forecast_remaining_today_kwh`), nicht vom Ganztags-Sensor:
 das Ganztags-P10 enthält die bereits gelaufene Vormittagsproduktion und wäre ab dem Nachmittag praktisch immer größer als der Rest-Median - als Sicherheitsnetz damit wirkungslos.
 
@@ -219,8 +219,14 @@ attributes:
   estimate10: "{{ state_attr('sensor.solcast_pv_forecast_forecast_today', 'estimate10') if state_attr('sensor.solcast_pv_forecast_forecast_today', 'estimate10') is not none else none }}"
 ```
 
-Auf der Konsumenten-Seite (`opti_derived.yaml`) gilt: `estimate10 <= 0` wird als fehlend behandelt und fällt auf den Median (die normale Prognose) zurück, statt remaining auf 0 zu drücken.
-Fehlt `estimate10` komplett, greift derselbe Median-Fallback - `opti_forecast_score` und `opti_target_soc` laufen in beiden Fällen fehlerfrei weiter.
+Auf der Konsumenten-Seite bündelt der zentrale Sensor `sensor.opti_forecast_effective_remaining_kwh` diese Logik an genau einer Stelle: `estimate10 <= 0` (oder komplett fehlend) gilt als "keine P10-Schätzung" und fällt auf den Median zurück, statt remaining auf 0 zu drücken.
+`opti_forecast_score` und `opti_target_soc` lesen ausschließlich diesen Sensor (die `min(median, P10)`-Rechnung war früher an neun Stellen dupliziert).
+
+**Einstellbarer Optimismus (`input_number.opti_forecast_optimismus`, 0-100 %):**
+Der Sensor mischt Median und P10: `P_eff = min(median, α·median + (1-α)·P10)` mit α = Regler / 100.
+α=0 (Default) = konservatives `min(median, P10)` wie bisher; α=50 = `(median+P10)/2`; α=100 = reiner Median.
+Höheres α lässt die Ziel-SoC-Treppe später steigen (der Akku wird weniger früh voll gefahren) - sinnvoll in ertragssicheren Monaten/Regionen, in denen der reale Tagesertrag fast immer über P10 liegt.
+Die äußere `min(median, …)`-Klammer sorgt dafür, dass der Wert nie optimistischer als der Median wird (greift nur beim seltenen Solcast-Fall P10 > Median).
 
 ---
 
@@ -323,6 +329,7 @@ des betreffenden Sensors testen — häufig ist der Quell-Sensor noch falsch ben
 |---|---|
 | `sensor.opti_forecast_score` | PV-Fit heute (0–10); nutzt `estimate10` als P10-Sicherheitsnetz; nach dem heutigen Sonnenuntergang Fallback auf `opti_forecast_score_tomorrow`, falls verfügbar (sonst alte Formel) |
 | `sensor.opti_forecast_score_tomorrow` | PV-Fit morgen (0–10) |
+| `sensor.opti_forecast_effective_remaining_kwh` | Effektive Rest-Prognose (kWh): Blend aus Median und P10 über `input_number.opti_forecast_optimismus` (0–100 %, Default 0 = `min(median, P10)`). Einzige Quelle für Score und Ziel-SoC. |
 | `sensor.opti_target_soc` | Ziel-SoC (%) basierend auf Restprognose und geglättetem Hausverbrauch |
 | `sensor.opti_charge_power_w` | Dynamische Ladestärke (W) nach SoC-Stufe und Forecast-Score |
 | `sensor.opti_price_level` | Preisniveau-Enum (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE / VERY_EXPENSIVE); Midrank-Perzentil (Gleichstände zählen halb) - flache Preistage (viele identische Werte) landen dadurch bei NORMAL statt fälschlich bei VERY_EXPENSIVE |

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -117,11 +117,11 @@ net_available   = max(0, restproduktion_kWh − hausverbrauch_kW × remaining_ho
 ratio           = net_available / akku_kapazität_kWh
 ```
 
-- `restproduktion_kWh` = `min(median, p10)` aus `sensor.opti_forecast_remaining_today_kwh`
-  (Median/`estimate`-Wert von Solcast) und dessen optionalem `estimate10`-Attribut
-  (P10-Perzentil) - der jeweils konservativere der beiden Werte gewinnt. Fehlt
-  `estimate10` oder ist er `<= 0`, gilt das als "keine P10-Schätzung vorhanden" und es
-  bleibt beim Median (siehe [canonical-layer.md](canonical-layer.md#solcast-anbindung)).
+- `restproduktion_kWh` = `sensor.opti_forecast_effective_remaining_kwh`, der zentrale
+  Blend aus Median und P10 der Rest-Tag-Prognose. Default ist `min(median, p10)` (der
+  konservativere der beiden gewinnt); über den Regler `input_number.opti_forecast_optimismus`
+  (0-100 %) lässt sich Richtung Median optimieren. Fehlt `estimate10` oder ist er `<= 0`,
+  bleibt es beim Median (siehe [canonical-layer.md](canonical-layer.md#solcast-anbindung)).
 - `hausverbrauch_kW` = `sensor.opti_house_consumption_w` / 1000.
 - `ratio` ist also der erwartete **PV-Überschuss bis Sonnenuntergang, ausgedrückt in
   „Akku-Kapazitäten"** — wie viele Akkufüllungen an Überschuss noch kommen.
@@ -677,7 +677,7 @@ Steuer-Automation parallel aktiv lassen.
 
 | Baustein | Beschreibung |
 |---|---|
-| **P10-Sicherheitsnetz** | `sensor.opti_forecast_score` / `_tomorrow` und `sensor.opti_target_soc` verwenden das 10. Perzentil der Solcast-Prognose (`estimate10`) als konservativen Referenzwert — schützt vor Überoptimismus bei unsicheren Prognosen |
+| **P10-Sicherheitsnetz** | `sensor.opti_forecast_score` / `_tomorrow` und `sensor.opti_target_soc` verwenden das 10. Perzentil der Solcast-Prognose (`estimate10`) als konservativen Referenzwert — schützt vor Überoptimismus bei unsicheren Prognosen. Der Grad ist über `input_number.opti_forecast_optimismus` einstellbar (0 = reines P10, 100 = reiner Median); der zentrale Sensor `opti_forecast_effective_remaining_kwh` liefert den Blend |
 | **Score-Abendfallback** | `sensor.opti_forecast_score` zählt nach dem heutigen Sonnenuntergang den Morgen-Score (`sensor.opti_forecast_score_tomorrow`), falls verfügbar, statt jeden Abend auf 0 zu fallen.<br>Ohne diesen Fallback degradieren die "heute schlecht"-Blöcke der Strategie abends zu reinen Preis-Bedingungen, egal wie sonnig der nächste Tag wird.<br>Fehlt der Morgen-Score, bleibt die alte Formel als Fallback (best-effort, keine Availability-Kopplung).<br>Der Verbrauchsanteil in `opti_forecast_score`, `_tomorrow` und `opti_target_soc` nutzt außerdem den geglätteten 60-min-Mittelwert (`sensor.opti_house_consumption_60min_w`) statt des Momentanwerts, damit kurze Lastspitzen (z. B. ein Wasserkocher) den Score nicht minütlich auf 0 kippen und Modus-Flips auslösen. |
 | **Ziel-SoC-Hysterese** | `sensor.opti_target_soc` hält die aktuelle `ratio`-Stufe im Attribut `level` (Schmitt-Trigger, Marge 0.10) → kein Flattern der Zielstufe. Siehe [Der intelligente Ziel-SoC](#der-intelligente-ziel-soc--herzstück-der-akkuschonung) |
 | **Decision-Trace-Attribute** | `sensor.opti_target_soc` hängt Debugging-Attribute an (`branch`, `level`, `ratio`, `net_available_kwh`, `remaining_hours`), lesbar über HA-Entwicklerwerkzeuge |

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -116,6 +116,7 @@ template:
           {% set nach_sunset = setting is not none and (setting | as_datetime | as_local).date() != now().date() %}
           {{ (nach_sunset and has_value('sensor.opti_forecast_score_tomorrow'))
              or (has_value('sensor.opti_forecast_remaining_today_kwh')
+                 and has_value('sensor.opti_forecast_effective_remaining_kwh')
                  and has_value('sensor.opti_battery_capacity_kwh')
                  and has_value('sensor.opti_soc')) }}
         state: >
@@ -205,7 +206,10 @@ template:
           {% set p10 = p10_raw if p10_raw > 0 else median %}
           {% set alpha = ([0, [100, states('input_number.opti_forecast_optimismus') | float(0)] | min] | max) / 100 %}
           {% set blended = alpha * median + (1 - alpha) * p10 %}
-          {{ ([median, blended] | min) | round(3) }}
+          {# Roh, NICHT gerundet: haelt alpha=0 bit-identisch zum alten
+             min(median, P10) und vermeidet einen Rundungs-Kipp an den
+             Ziel-SoC-Stufengrenzen. Anzeige-Rundung nur in den Attributen. #}
+          {{ [median, blended] | min }}
         attributes:
           median_kwh: "{{ states('sensor.opti_forecast_remaining_today_kwh') | float(0) | round(3) }}"
           p10_kwh: >
@@ -228,7 +232,8 @@ template:
         # haelt die vorige Stufe, bis ratio die Grenze um die Marge m ueber-/unterschreitet.
         availability: >
           {{ has_value('sensor.opti_battery_capacity_kwh') and
-             has_value('sensor.opti_forecast_remaining_today_kwh') }}
+             has_value('sensor.opti_forecast_remaining_today_kwh') and
+             has_value('sensor.opti_forecast_effective_remaining_kwh') }}
         state: >
           {% set cap_kwh        = states('sensor.opti_battery_capacity_kwh') | float(12.8) %}
           {% set restproduktion = states('sensor.opti_forecast_effective_remaining_kwh') | float(0) %}

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -124,10 +124,7 @@ template:
           {% if nach_sunset and has_value('sensor.opti_forecast_score_tomorrow') %}
           {{ states('sensor.opti_forecast_score_tomorrow') | int(0) }}
           {% else %}
-          {% set median = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
-          {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh','estimate10') | float(median) %}
-          {% set p10 = p10_raw if p10_raw > 0 else median %}
-          {% set remaining = [median, p10] | min %}
+          {% set remaining = states('sensor.opti_forecast_effective_remaining_kwh') | float(0) %}
           {% set cap = states('sensor.opti_battery_capacity_kwh') | float(0) %}
           {% set needed = cap * (1 - (states('sensor.opti_soc') | float(0))/100) %}
           {% set sunset = state_attr('sun.sun','next_setting') %}
@@ -140,24 +137,17 @@ template:
           {% endif %}
         attributes:
           remaining_kwh: >
-            {% set median = states('sensor.opti_forecast_remaining_today_kwh')|float(0) %}
-            {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh','estimate10')|float(median) %}
-            {% set p10 = p10_raw if p10_raw > 0 else median %}
-            {{ [median, p10]|min|round(2) }}
+            {{ states('sensor.opti_forecast_effective_remaining_kwh') | float(0) | round(2) }}
           needed_full_kwh: "{{ (states('sensor.opti_battery_capacity_kwh')|float(0) * (1-(states('sensor.opti_soc')|float(0))/100))|round(2) }}"
           hours_to_sunset: "{{ (((state_attr('sun.sun','next_setting')|as_datetime - now()).total_seconds()/3600) if state_attr('sun.sun','next_setting') else 0)|round(1) }}"
           pv_surplus_kwh: >
-            {% set median = states('sensor.opti_forecast_remaining_today_kwh')|float(0) %}
-            {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh','estimate10')|float(median) %}
-            {% set rem = [median, p10_raw if p10_raw > 0 else median]|min %}
+            {% set rem = states('sensor.opti_forecast_effective_remaining_kwh') | float(0) %}
             {% set sunset = state_attr('sun.sun','next_setting') %}
             {% set h = ((sunset|as_datetime - now()).total_seconds()/3600) if sunset else 0 %}
             {% set hausverbrauch = states('sensor.opti_house_consumption_60min_w')|float(states('sensor.opti_house_consumption_w')|float(400)) %}
             {{ [rem - (hausverbrauch/1000*([h,0]|max)), 0]|max|round(2) }}
           ueberschuss_ueber_voll_kwh: >
-            {% set median = states('sensor.opti_forecast_remaining_today_kwh')|float(0) %}
-            {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh','estimate10')|float(median) %}
-            {% set rem = [median, p10_raw if p10_raw > 0 else median]|min %}
+            {% set rem = states('sensor.opti_forecast_effective_remaining_kwh') | float(0) %}
             {% set sunset = state_attr('sun.sun','next_setting') %}
             {% set h = ((sunset|as_datetime - now()).total_seconds()/3600) if sunset else 0 %}
             {% set hausverbrauch = states('sensor.opti_house_consumption_60min_w')|float(states('sensor.opti_house_consumption_w')|float(400)) %}
@@ -190,6 +180,41 @@ template:
           {{ (([ [tomorrow / denom_kwh, 1]|min, 0]|max) * 10)|round(0)|int }}
 
       # -----------------------------------------------------------------------
+      # 2a. Effektive Rest-Prognose (kWh) — einstellbarer Forecast-Optimismus
+      #    (Feature #30). Zentraler Blend-Sensor zwischen Median und P10 der
+      #    Rest-Tag-Prognose, gesteuert ueber input_number.opti_forecast_optimismus
+      #    (alpha in % 0..100, aus sma_helpers.yaml). alpha=0 (Default, kein
+      #    initial gesetzt) ist bit-identisch zum bisherigen min(median, P10)
+      #    - alle Konsumenten (opti_target_soc, opti_forecast_score) lasen
+      #    diese Kombination bislang lokal dupliziert; sie lesen jetzt nur noch
+      #    diesen Sensor. alpha=50 -> (median+P10)/2, alpha=100 -> reiner
+      #    Median (optimistisch: Ziel-SoC-Treppe steigt spaeter, Akku wird
+      #    weniger frueh voll gefahren - mehr Puffer fuer Nachmittags-PV).
+      #    Aeussere min(median, blended): nie optimistischer als der Median
+      #    selbst - greift nur, wenn P10 > Median waere (Solcast-Ausreisser).
+      # -----------------------------------------------------------------------
+      - unique_id: opti_forecast_effective_remaining_kwh
+        name: "Opti Forecast Effective Remaining kWh"
+        unit_of_measurement: kWh
+        state_class: measurement
+        availability: >
+          {{ has_value('sensor.opti_forecast_remaining_today_kwh') }}
+        state: >
+          {% set median = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
+          {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh', 'estimate10') | float(median) %}
+          {% set p10 = p10_raw if p10_raw > 0 else median %}
+          {% set alpha = ([0, [100, states('input_number.opti_forecast_optimismus') | float(0)] | min] | max) / 100 %}
+          {% set blended = alpha * median + (1 - alpha) * p10 %}
+          {{ ([median, blended] | min) | round(3) }}
+        attributes:
+          median_kwh: "{{ states('sensor.opti_forecast_remaining_today_kwh') | float(0) | round(3) }}"
+          p10_kwh: >
+            {% set median = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
+            {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh', 'estimate10') | float(median) %}
+            {{ (p10_raw if p10_raw > 0 else median) | round(3) }}
+          alpha: "{{ ([0, [100, states('input_number.opti_forecast_optimismus') | float(0)] | min] | max) / 100 }}"
+
+      # -----------------------------------------------------------------------
       # 3. Ziel-SoC (%) — abgeleitet aus akku_target_soc_intelligent (SMA-Templates
       #    Z.206-305): Quell-Entitäten auf opti_*-Layer getauscht. Stufen-Kennlinie 1:1,
       #    aber Flatter-Fix: 0.25-Quantisierung → echte Schmitt-Hysterese (siehe state).
@@ -206,10 +231,7 @@ template:
              has_value('sensor.opti_forecast_remaining_today_kwh') }}
         state: >
           {% set cap_kwh        = states('sensor.opti_battery_capacity_kwh') | float(12.8) %}
-          {% set median = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
-          {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh', 'estimate10') | float(median) %}
-          {% set p10 = p10_raw if p10_raw > 0 else median %}
-          {% set restproduktion = [median, p10] | min %}
+          {% set restproduktion = states('sensor.opti_forecast_effective_remaining_kwh') | float(0) %}
           {# Verbrauch geglaettet (60-min-Mittelwert, Legacy-Muster): sonst kippt eine
              kurze Lastspitze das Ziel-SoC-Band und erzeugt Flattern. #}
           {% set hausverbrauch  = states('sensor.opti_house_consumption_60min_w') | float(states('sensor.opti_house_consumption_w') | float(1500)) %}
@@ -256,10 +278,7 @@ template:
         attributes:
           branch: >
             {% set cap_kwh        = states('sensor.opti_battery_capacity_kwh') | float(12.8) %}
-            {% set median = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
-            {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh', 'estimate10') | float(median) %}
-            {% set p10 = p10_raw if p10_raw > 0 else median %}
-            {% set restproduktion = [median, p10] | min %}
+            {% set restproduktion = states('sensor.opti_forecast_effective_remaining_kwh') | float(0) %}
             {% set hausverbrauch  = states('sensor.opti_house_consumption_60min_w') | float(states('sensor.opti_house_consumption_w') | float(1500)) %}
             {% set max_soc        = states('input_number.maxsoc') | float(95) %}
             {% set netzladen      = states('input_boolean.hausakku_aus_netz_laden') %}
@@ -293,10 +312,7 @@ template:
           # zurueckgelesen; state + branch berechnen dieselbe Schmitt-Logik unabhaengig.
           level: >
             {% set cap_kwh        = states('sensor.opti_battery_capacity_kwh') | float(12.8) %}
-            {% set median = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
-            {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh', 'estimate10') | float(median) %}
-            {% set p10 = p10_raw if p10_raw > 0 else median %}
-            {% set restproduktion = [median, p10] | min %}
+            {% set restproduktion = states('sensor.opti_forecast_effective_remaining_kwh') | float(0) %}
             {% set hausverbrauch  = states('sensor.opti_house_consumption_60min_w') | float(states('sensor.opti_house_consumption_w') | float(1500)) %}
             {% set max_soc        = states('input_number.maxsoc') | float(95) %}
             {% set netzladen      = states('input_boolean.hausakku_aus_netz_laden') %}
@@ -327,10 +343,7 @@ template:
             {% endif %}
           ratio: >
             {% set cap_kwh        = states('sensor.opti_battery_capacity_kwh') | float(12.8) %}
-            {% set median = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
-            {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh', 'estimate10') | float(median) %}
-            {% set p10 = p10_raw if p10_raw > 0 else median %}
-            {% set restproduktion = [median, p10] | min %}
+            {% set restproduktion = states('sensor.opti_forecast_effective_remaining_kwh') | float(0) %}
             {% set hausverbrauch  = states('sensor.opti_house_consumption_60min_w') | float(states('sensor.opti_house_consumption_w') | float(1500)) %}
             {% set sunset_time = state_attr('sun.sun', 'next_setting') %}
             {% if sunset_time %}
@@ -342,10 +355,7 @@ template:
             {% set net_available = [0, restproduktion - (hausverbrauch / 1000 * remaining_hours)] | max %}
             {{ (0 if cap_kwh <= 0 else net_available / cap_kwh) | round(3) }}
           net_available_kwh: >
-            {% set median = states('sensor.opti_forecast_remaining_today_kwh') | float(0) %}
-            {% set p10_raw = state_attr('sensor.opti_forecast_remaining_today_kwh', 'estimate10') | float(median) %}
-            {% set p10 = p10_raw if p10_raw > 0 else median %}
-            {% set restproduktion = [median, p10] | min %}
+            {% set restproduktion = states('sensor.opti_forecast_effective_remaining_kwh') | float(0) %}
             {% set hausverbrauch  = states('sensor.opti_house_consumption_60min_w') | float(states('sensor.opti_house_consumption_w') | float(1500)) %}
             {% set sunset_time = state_attr('sun.sun', 'next_setting') %}
             {% if sunset_time %}

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -211,6 +211,20 @@ input_number:
     mode: box
     icon: mdi:filter-outline
 
+  opti_forecast_optimismus:
+    name: "Opti Forecast-Optimismus"
+    # Blend-Regler zwischen konservativem P10 und Median der Solcast-Rest-
+    # prognose (sensor.opti_forecast_effective_remaining_kwh). alpha=0
+    # (Erststart, kein initial gesetzt) -> min(median, P10), heutiges
+    # Verhalten. alpha=50 -> (median+P10)/2. alpha=100 -> reiner Median
+    # (optimistisch: Ziel-SoC steigt spaeter, Akku wird weniger frueh voll).
+    min: 0
+    max: 100
+    step: 5
+    unit_of_measurement: "%"
+    mode: slider
+    icon: mdi:weather-sunny
+
   opti_halte_spread_ct:
     name: "Opti Halte-Spread"
     # L3 haelt bei EXPENSIVE nur noch, wenn der Preisdurchschnitt der

--- a/tests/test_derived_sensoren.py
+++ b/tests/test_derived_sensoren.py
@@ -47,7 +47,7 @@ def test_score_abend_fallback():
     next_setting = dt.datetime(2026, 1, 16, 16, 30, tzinfo=TZ).isoformat()
     hass = FakeHass(
         states={
-            "sensor.opti_forecast_remaining_today_kwh": "0",
+            "sensor.opti_forecast_effective_remaining_kwh": "0",
             "sensor.opti_battery_capacity_kwh": "10",
             "sensor.opti_soc": "50",
             "sensor.opti_forecast_score_tomorrow": "8",
@@ -61,7 +61,7 @@ def test_score_abend_fallback():
     # (remaining=0 -> Score 0, unabhaengig von nach_sunset).
     hass2 = FakeHass(
         states={
-            "sensor.opti_forecast_remaining_today_kwh": "0",
+            "sensor.opti_forecast_effective_remaining_kwh": "0",
             "sensor.opti_battery_capacity_kwh": "10",
             "sensor.opti_soc": "50",
             "sensor.opti_forecast_score_tomorrow": "unavailable",
@@ -74,12 +74,15 @@ def test_score_abend_fallback():
 
 def test_score_vor_sonnenaufgang_normale_formel():
     # 05:00, next_setting zeigt auf HEUTE Abend (18:00) -> kein Fallback,
-    # normale Formel laeuft, obwohl es noch dunkel ist.
+    # normale Formel laeuft, obwohl es noch dunkel ist. remaining kommt jetzt
+    # direkt vom zentralen Effective-Sensor (Feature #30) statt aus einem
+    # lokalen median/P10-Blend - die P10-Auswahl selbst sitzt in
+    # test_forecast_effective.py.
     now = dt.datetime(2026, 1, 15, 5, 0, tzinfo=TZ)
     next_setting = dt.datetime(2026, 1, 15, 18, 0, tzinfo=TZ).isoformat()
     hass = FakeHass(
         states={
-            "sensor.opti_forecast_remaining_today_kwh": "12",
+            "sensor.opti_forecast_effective_remaining_kwh": "12",
             "sensor.opti_battery_capacity_kwh": "13",
             "sensor.opti_soc": "95",
             "sensor.opti_house_consumption_w": "400",
@@ -98,11 +101,11 @@ def test_score_vor_sonnenaufgang_normale_formel():
 
 def test_score_geglaetteter_verbrauch():
     # 08:00, next_setting HEUTE 18:00 (kein Fallback) -> h=10h.
-    # cap=13kWh, soc=0% -> needed=13kWh. remaining=12kWh.
+    # cap=13kWh, soc=0% -> needed=13kWh. remaining=12kWh (Effective-Sensor).
     now = dt.datetime(2026, 1, 15, 8, 0, tzinfo=TZ)
     next_setting = dt.datetime(2026, 1, 15, 18, 0, tzinfo=TZ).isoformat()
     base_states = {
-        "sensor.opti_forecast_remaining_today_kwh": "12",
+        "sensor.opti_forecast_effective_remaining_kwh": "12",
         "sensor.opti_battery_capacity_kwh": "13",
         "sensor.opti_soc": "0",
         "sensor.opti_house_consumption_w": "2400",
@@ -128,94 +131,66 @@ def test_score_geglaetteter_verbrauch():
 
 
 # ---------------------------------------------------------------------------
-# 2c. estimate10-Guard
+# 2c. remaining_kwh / pv_surplus_kwh / ueberschuss_ueber_voll_kwh lesen den
+#    zentralen Effective-Sensor (Feature #30). Die P10-/estimate10-Guard-
+#    Semantik selbst (inkl. "P10 kommt vom Rest-Tag-, nicht vom Ganztags-
+#    Sensor") sitzt jetzt in test_forecast_effective.py - hier wird nur noch
+#    geprueft, dass alle drei Attribute + der State konsistent denselben
+#    Effective-Wert konsumieren.
 # ---------------------------------------------------------------------------
 
-def test_score_estimate10_null_ignoriert():
-    # estimate10 = 0 (Solcast-Artefakt "keine Schaetzung") darf remaining
-    # nicht auf 0 druecken - median (8 kWh) muss statt dessen zaehlen.
-    now = dt.datetime(2026, 1, 15, 8, 0, tzinfo=TZ)
-    next_setting = dt.datetime(2026, 1, 15, 18, 0, tzinfo=TZ).isoformat()
-    hass = FakeHass(
-        states={
-            "sensor.opti_forecast_remaining_today_kwh": "8",
-            "sensor.opti_battery_capacity_kwh": "13",
-            "sensor.opti_soc": "0",
-        },
-        attrs={
-            "sun.sun": {"next_setting": next_setting},
-            "sensor.opti_forecast_remaining_today_kwh": {"estimate10": 0},
-        },
-        now=now,
-    )
-    assert float(_score_attr(hass, "remaining_kwh")) == 8.0
-
-
 def test_score_p10_nutzt_rest_tag_sensor():
-    # Nachmittag: Rest-Median 2 kWh mit Rest-P10 1 kWh; das Ganztags-P10 (5 kWh)
-    # ist um die schon gelaufene Vormittagsproduktion groesser und darf NICHT
-    # als Sicherheitsnetz dienen - remaining muss das Rest-P10 (1.0) sein.
+    # Effective-Sensor liefert 1.0 kWh (waere z.B. das Rest-P10 bei Median 2.0).
     now = dt.datetime(2026, 1, 15, 14, 0, tzinfo=TZ)
     next_setting = dt.datetime(2026, 1, 15, 18, 0, tzinfo=TZ).isoformat()
     hass = FakeHass(
         states={
-            "sensor.opti_forecast_remaining_today_kwh": "2.0",
+            "sensor.opti_forecast_effective_remaining_kwh": "1.0",
             "sensor.opti_battery_capacity_kwh": "13",
             "sensor.opti_soc": "0",
             "sensor.opti_house_consumption_w": "0",
         },
-        attrs={
-            "sun.sun": {"next_setting": next_setting},
-            "sensor.opti_forecast_remaining_today_kwh": {"estimate10": 1.0},
-            "sensor.opti_forecast_today_kwh": {"estimate10": 5.0},
-        },
+        attrs={"sun.sun": {"next_setting": next_setting}},
         now=now,
     )
     assert float(_score_attr(hass, "remaining_kwh")) == 1.0
     # Score rechnet mit remaining=1.0: needed=13, verbrauch=0 -> surplus=1.0
     # -> ratio = 1/13 -> round(0.769) = 1.
     assert _score_state(hass) == "1"
-    # Auch die Surplus-Attribute muessen das Rest-P10 nutzen (verbrauch=0
-    # -> pv_surplus = remaining = 1.0).
+    # Auch die Surplus-Attribute muessen denselben Effective-Wert nutzen
+    # (verbrauch=0 -> pv_surplus = remaining = 1.0).
     assert float(_score_attr(hass, "pv_surplus_kwh")) == 1.0
 
     # ueberschuss_ueber_voll diskriminierend pruefen: cap=0.5, soc=0
-    # -> needed=0.5 -> ueberschuss = 1.0 - 0.5 = 0.5 (Ganztags-P10 gaebe 1.5).
+    # -> needed=0.5 -> ueberschuss = 1.0 - 0.5 = 0.5.
     hass_klein = FakeHass(
         states={
-            "sensor.opti_forecast_remaining_today_kwh": "2.0",
+            "sensor.opti_forecast_effective_remaining_kwh": "1.0",
             "sensor.opti_battery_capacity_kwh": "0.5",
             "sensor.opti_soc": "0",
             "sensor.opti_house_consumption_w": "0",
         },
-        attrs={
-            "sun.sun": {"next_setting": next_setting},
-            "sensor.opti_forecast_remaining_today_kwh": {"estimate10": 1.0},
-            "sensor.opti_forecast_today_kwh": {"estimate10": 5.0},
-        },
+        attrs={"sun.sun": {"next_setting": next_setting}},
         now=now,
     )
     assert float(_score_attr(hass_klein, "ueberschuss_ueber_voll_kwh")) == 0.5
 
 
 def test_score_surplus_attribute_estimate10_null_guard():
-    # estimate10 = 0 gilt auch in pv_surplus_kwh/ueberschuss_ueber_voll_kwh als
-    # "keine P10-Schaetzung" -> Median 8 kWh zaehlt, nicht 0.
+    # Effective-Sensor liefert 8.0 kWh (waere z.B. der Median, falls estimate10
+    # als "keine Schaetzung" verworfen wurde - dieser Guard sitzt jetzt in
+    # test_forecast_effective.py).
     # cap=5, soc=0 -> needed=5; verbrauch=0 -> surplus=8, ueberschuss=8-5=3.
     now = dt.datetime(2026, 1, 15, 8, 0, tzinfo=TZ)
     next_setting = dt.datetime(2026, 1, 15, 18, 0, tzinfo=TZ).isoformat()
     hass = FakeHass(
         states={
-            "sensor.opti_forecast_remaining_today_kwh": "8",
+            "sensor.opti_forecast_effective_remaining_kwh": "8",
             "sensor.opti_battery_capacity_kwh": "5",
             "sensor.opti_soc": "0",
             "sensor.opti_house_consumption_w": "0",
         },
-        attrs={
-            "sun.sun": {"next_setting": next_setting},
-            "sensor.opti_forecast_remaining_today_kwh": {"estimate10": 0},
-            "sensor.opti_forecast_today_kwh": {"estimate10": 0},
-        },
+        attrs={"sun.sun": {"next_setting": next_setting}},
         now=now,
     )
     assert float(_score_attr(hass, "pv_surplus_kwh")) == 8.0
@@ -305,7 +280,7 @@ def test_target_soc_cap_null():
     hass = FakeHass(
         states={
             "sensor.opti_battery_capacity_kwh": "0",
-            "sensor.opti_forecast_remaining_today_kwh": "5",
+            "sensor.opti_forecast_effective_remaining_kwh": "5",
             "input_number.maxsoc": "95",
             "input_number.minsoc": "10",
             "input_boolean.hausakku_aus_netz_laden": "off",
@@ -317,10 +292,10 @@ def test_target_soc_cap_null():
 
 def test_target_soc_geglaettet():
     # netzladen off, kein sun.sun-next_setting -> remaining_hours=6 (else-Zweig).
-    # restproduktion=8kWh, cap=10kWh.
+    # restproduktion=8kWh (Effective-Sensor), cap=10kWh.
     base_states = {
         "sensor.opti_battery_capacity_kwh": "10",
-        "sensor.opti_forecast_remaining_today_kwh": "8",
+        "sensor.opti_forecast_effective_remaining_kwh": "8",
         "input_number.maxsoc": "95",
         "input_number.minsoc": "10",
         "input_boolean.hausakku_aus_netz_laden": "off",
@@ -343,67 +318,33 @@ def test_target_soc_geglaettet():
 
 
 # ---------------------------------------------------------------------------
-# 2e. P10-Sicherheitsnetz opti_target_soc
+# 2e. opti_target_soc konsumiert den zentralen Effective-Sensor (Feature #30)
+#    an allen fuenf Stellen (state/branch/level/ratio/net_available_kwh)
+#    konsistent. Die P10-/estimate10-Sicherheitsnetz-Semantik selbst (Median
+#    vs. P10, Guards fuer fehlendes/nulles/hoeheres estimate10) sitzt jetzt in
+#    test_forecast_effective.py, direkt am Effective-Sensor - keine
+#    Semantik-Abdeckung verloren, nur die Zustaendigkeit verschoben.
 # ---------------------------------------------------------------------------
 
-def _p10_states(estimate10=None, remaining="8"):
-    states = {
-        "sensor.opti_battery_capacity_kwh": "10",
-        "sensor.opti_forecast_remaining_today_kwh": remaining,
-        "sensor.opti_house_consumption_w": "0",
-        "input_number.maxsoc": "95",
-        "input_number.minsoc": "10",
-        "input_boolean.hausakku_aus_netz_laden": "off",
-    }
-    attrs = {}
-    if estimate10 is not None:
-        attrs["sensor.opti_forecast_remaining_today_kwh"] = {"estimate10": estimate10}
-    return states, attrs
-
-
-def test_target_soc_p10_niedriger_als_median_wird_verwendet():
-    # Median 8 kWh, P10 3 kWh -> restproduktion soll 3 sein (konservativer).
+def test_target_soc_effective_sensor_alle_fuenf_stellen():
+    # Effective-Sensor liefert 3.0 kWh (entspraeche z.B. einem P10-gedeckelten
+    # Median von 8 kWh - siehe test_forecast_effective.py fuer diese Auswahl).
     # ratio = 3/10 = 0.3 < 0.375 -> tiefste Stufe -> maxsoc statt 90%.
     # Prueft alle fuenf restproduktion-Stellen gleichzeitig (state/level/ratio/
     # net_available_kwh/branch) - das deckt die Fuenffach-Duplikation ab.
-    states, attrs = _p10_states(estimate10=3)
-    hass = FakeHass(states=states, attrs=attrs, this_attributes={})
+    hass = FakeHass(
+        states={
+            "sensor.opti_battery_capacity_kwh": "10",
+            "sensor.opti_forecast_effective_remaining_kwh": "3",
+            "sensor.opti_house_consumption_w": "0",
+            "input_number.maxsoc": "95",
+            "input_number.minsoc": "10",
+            "input_boolean.hausakku_aus_netz_laden": "off",
+        },
+        this_attributes={},
+    )
     assert float(_target_soc_state(hass)) == 95.0
     assert float(_target_soc_attr(hass, "net_available_kwh")) == 3.0
     assert float(_target_soc_attr(hass, "ratio")) == 0.3
     assert _target_soc_attr(hass, "level") == "0"
     assert "ratio=0.3" in _target_soc_attr(hass, "branch")
-
-
-def test_target_soc_ohne_p10_bleibt_beim_median():
-    # Kein estimate10-Attribut vorhanden -> Fallback auf Median (8 kWh),
-    # identisch zum Vor-Fix-Verhalten. ratio = 8/10 = 0.8 -> 90%.
-    states, attrs = _p10_states(estimate10=None)
-    hass = FakeHass(states=states, attrs=attrs, this_attributes={})
-    assert float(_target_soc_state(hass)) == 90.0
-    assert float(_target_soc_attr(hass, "net_available_kwh")) == 8.0
-
-
-def test_target_soc_p10_null_faellt_auf_median_zurueck():
-    # estimate10 <= 0 gilt per Kontrakt als "keine P10-Schaetzung" -> Median.
-    states, attrs = _p10_states(estimate10=0)
-    hass = FakeHass(states=states, attrs=attrs, this_attributes={})
-    assert float(_target_soc_state(hass)) == 90.0
-
-
-def test_target_soc_p10_hoeher_als_median_median_gewinnt():
-    # P10 > Median waere fuer eine Solcast-Quelle untypisch, aber min() muss
-    # trotzdem den kleineren (konservativeren) Wert nehmen - hier den Median.
-    states, attrs = _p10_states(estimate10=20)
-    hass = FakeHass(states=states, attrs=attrs, this_attributes={})
-    assert float(_target_soc_attr(hass, "net_available_kwh")) == 8.0
-
-
-def test_target_soc_p10_sonnenuntergang_randfall():
-    # Median und P10 beide 0 (kurz vor/nach Sonnenuntergang) -> estimate10 <= 0
-    # -> Fallback Median (ebenfalls 0), kein Sonderverhalten, ratio 0 -> maxsoc
-    # wie schon vor diesem Fix.
-    states, attrs = _p10_states(estimate10=0, remaining="0")
-    hass = FakeHass(states=states, attrs=attrs, this_attributes={})
-    assert float(_target_soc_attr(hass, "net_available_kwh")) == 0.0
-    assert float(_target_soc_state(hass)) == 95.0

--- a/tests/test_derived_sensoren.py
+++ b/tests/test_derived_sensoren.py
@@ -231,6 +231,7 @@ def test_score_availability_abend_fallback_alte_formel():
         states={
             "sensor.opti_forecast_score_tomorrow": "unavailable",
             "sensor.opti_forecast_remaining_today_kwh": "0",
+            "sensor.opti_forecast_effective_remaining_kwh": "0",
             "sensor.opti_battery_capacity_kwh": "10",
             "sensor.opti_soc": "50",
         },
@@ -252,6 +253,7 @@ def test_score_availability_tag():
     hass_ok = FakeHass(
         states={
             "sensor.opti_forecast_remaining_today_kwh": "8",
+            "sensor.opti_forecast_effective_remaining_kwh": "8",
             "sensor.opti_battery_capacity_kwh": "13",
             "sensor.opti_soc": "50",
         },
@@ -263,6 +265,7 @@ def test_score_availability_tag():
     hass_missing = FakeHass(
         states={
             "sensor.opti_forecast_remaining_today_kwh": "unavailable",
+            "sensor.opti_forecast_effective_remaining_kwh": "unavailable",
             "sensor.opti_battery_capacity_kwh": "13",
             "sensor.opti_soc": "50",
         },
@@ -270,6 +273,37 @@ def test_score_availability_tag():
         now=now,
     )
     assert _score_availability(hass_missing) == "False"
+
+    # Startup-/Ordering-Fenster: Quelle schon da, Effective-Sensor noch nicht
+    # ausgewertet. Der Tages-Zweig braucht ihn -> unavailable statt still aus
+    # float(0) zu rechnen (Codex-Review #30, Finding 3).
+    hass_eff_fehlt = FakeHass(
+        states={
+            "sensor.opti_forecast_remaining_today_kwh": "8",
+            "sensor.opti_forecast_effective_remaining_kwh": "unknown",
+            "sensor.opti_battery_capacity_kwh": "13",
+            "sensor.opti_soc": "50",
+        },
+        attrs=attrs,
+        now=now,
+    )
+    assert _score_availability(hass_eff_fehlt) == "False"
+
+
+def test_target_soc_availability_braucht_effective_sensor():
+    # opti_target_soc liest restproduktion NUR aus dem Effective-Sensor -> er
+    # gehoert in die Availability, sonst rechnet der Ziel-SoC im Startup-Fenster
+    # still aus float(0) (= ratio 0 -> maxsoc). (Codex-Review #30, Finding 3.)
+    base = {
+        "sensor.opti_battery_capacity_kwh": "13",
+        "sensor.opti_forecast_remaining_today_kwh": "8",
+    }
+    cfg = _cfg()
+    entity = find_template_entity(cfg, "sensor", "opti_target_soc")
+    ok = FakeHass(states={**base, "sensor.opti_forecast_effective_remaining_kwh": "8"})
+    fehlt = FakeHass(states={**base, "sensor.opti_forecast_effective_remaining_kwh": "unknown"})
+    assert render(ok, entity["availability"]) == "True"
+    assert render(fehlt, entity["availability"]) == "False"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_forecast_effective.py
+++ b/tests/test_forecast_effective.py
@@ -201,8 +201,8 @@ def test_p10_sonnenuntergang_randfall():
 def test_aeussere_min_mutant_waere_optimistischer():
     real = _cfg()
     mutant = _mutant_cfg(
-        "{{ ([median, blended] | min) | round(3) }}",
-        "{{ blended | round(3) }}",
+        "{{ [median, blended] | min }}",
+        "{{ blended }}",
     )
     states, attrs = _states(remaining="10", estimate10=20, alpha="0")
     hass = FakeHass(states=states, attrs=attrs)

--- a/tests/test_forecast_effective.py
+++ b/tests/test_forecast_effective.py
@@ -1,0 +1,211 @@
+"""sensor.opti_forecast_effective_remaining_kwh (packages/opti_derived.yaml).
+
+Zentraler Blend-Sensor zwischen Median (opti_forecast_remaining_today_kwh) und
+dessen P10 (estimate10-Attribut), gesteuert ueber input_number.opti_forecast_optimismus
+(alpha in % 0..100). Formel:
+    p10     = estimate10 falls > 0, sonst median (Solcast-"keine Schaetzung"-Guard)
+    alpha   = clamp(helper, 0, 100) / 100
+    blended = alpha * median + (1 - alpha) * p10
+    state   = min(median, blended)   # nie optimistischer als der Median
+
+alpha=0 (Default/Erststart, kein Helfer-initial) ist bit-identisch zum
+bisherigen min(median, p10)-Verhalten der Konsumenten (opti_target_soc,
+opti_forecast_score) - das ist die Regressions-Garantie fuer Feature #30.
+
+Diese Datei uebernimmt zusaetzlich die reine P10-Auswahl-Semantik, die vorher
+in test_derived_sensoren.py an opti_target_soc haing (jetzt Konsumenten-seitig
+nur noch ein Passthrough des Effective-Sensors) - keine Coverage-Luecke.
+"""
+import os
+import pathlib
+import tempfile
+
+from .ha_harness import REPO, FakeHass, find_template_entity, load_yaml, render
+
+YAML = REPO / "packages" / "opti_derived.yaml"
+UID = "opti_forecast_effective_remaining_kwh"
+
+
+def _cfg(path=None):
+    return load_yaml(path or YAML)
+
+
+def _entity(cfg=None):
+    return find_template_entity(cfg or _cfg(), "sensor", UID)
+
+
+def _state(hass, cfg=None):
+    return render(hass, _entity(cfg)["state"])
+
+
+def _attr(hass, attr, cfg=None):
+    return render(hass, _entity(cfg)["attributes"][attr])
+
+
+def _availability(hass, cfg=None):
+    return render(hass, _entity(cfg)["availability"])
+
+
+def _states(remaining="10", estimate10=None, alpha=None):
+    states = {"sensor.opti_forecast_remaining_today_kwh": remaining}
+    if alpha is not None:
+        states["input_number.opti_forecast_optimismus"] = alpha
+    attrs = {}
+    if estimate10 is not None:
+        attrs["sensor.opti_forecast_remaining_today_kwh"] = {"estimate10": estimate10}
+    return states, attrs
+
+
+def _mutant_cfg(old, new):
+    """opti_derived.yaml nach /private/tmp kopieren, Konstante mutieren, laden."""
+    src = YAML.read_text(encoding="utf-8")
+    assert old in src, f"Mutations-Anker {old!r} nicht im Template gefunden"
+    fd, path = tempfile.mkstemp(suffix=".yaml", dir="/private/tmp")
+    os.close(fd)
+    p = pathlib.Path(path)
+    try:
+        p.write_text(src.replace(old, new), encoding="utf-8")
+        return _cfg(path)
+    finally:
+        p.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# alpha=0 (Default/Erststart) = heutiges min(median, p10)-Verhalten.
+# ---------------------------------------------------------------------------
+
+def test_alpha_0_helper_explizit_null():
+    states, attrs = _states(remaining="10", estimate10=3, alpha="0")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_state(hass)) == 3.0
+
+
+def test_alpha_0_helper_fehlt_ganz():
+    # Kein input_number gesetzt -> float(0) Fallback -> identisch zu alpha="0".
+    states, attrs = _states(remaining="10", estimate10=3, alpha=None)
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_state(hass)) == 3.0
+
+
+def test_alpha_0_ohne_estimate10_faellt_auf_median():
+    states, attrs = _states(remaining="10", estimate10=None, alpha="0")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_state(hass)) == 10.0
+
+
+def test_alpha_0_estimate10_null_faellt_auf_median():
+    states, attrs = _states(remaining="10", estimate10=0, alpha="0")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_state(hass)) == 10.0
+
+
+def test_alpha_0_estimate10_hoeher_als_median_median_gewinnt():
+    states, attrs = _states(remaining="10", estimate10=20, alpha="0")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_state(hass)) == 10.0
+
+
+# ---------------------------------------------------------------------------
+# alpha=50 / alpha=100: Blend Richtung Median.
+# ---------------------------------------------------------------------------
+
+def test_alpha_50_blend():
+    states, attrs = _states(remaining="10", estimate10=4, alpha="50")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_state(hass)) == 7.0
+
+
+def test_alpha_100_reiner_median():
+    states, attrs = _states(remaining="10", estimate10=4, alpha="100")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_state(hass)) == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Clamp: Helper-Werte ausserhalb [0,100] werden auf die Grenzen geklemmt.
+# ---------------------------------------------------------------------------
+
+def test_clamp_ueber_100_wie_100():
+    states, attrs = _states(remaining="10", estimate10=4, alpha="150")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_state(hass)) == 10.0
+
+
+def test_clamp_unter_0_wie_0():
+    states, attrs = _states(remaining="10", estimate10=3, alpha="-10")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_state(hass)) == 3.0
+
+
+# ---------------------------------------------------------------------------
+# Attribute: median_kwh / p10_kwh / alpha.
+# ---------------------------------------------------------------------------
+
+def test_attribute_median_p10_alpha():
+    states, attrs = _states(remaining="10", estimate10=4, alpha="50")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_attr(hass, "median_kwh")) == 10.0
+    assert float(_attr(hass, "p10_kwh")) == 4.0
+    assert float(_attr(hass, "alpha")) == 0.5
+
+
+def test_attribute_p10_kwh_faellt_bei_fehlendem_estimate10_auf_median():
+    states, attrs = _states(remaining="10", estimate10=None, alpha="0")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_attr(hass, "p10_kwh")) == 10.0
+
+
+def test_attribute_alpha_geklemmt():
+    states, attrs = _states(remaining="10", estimate10=4, alpha="150")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_attr(hass, "alpha")) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Availability: haengt nur am Median-Sensor.
+# ---------------------------------------------------------------------------
+
+def test_availability_folgt_remaining_today():
+    hass_ok = FakeHass(states={"sensor.opti_forecast_remaining_today_kwh": "10"})
+    assert _availability(hass_ok) == "True"
+
+    hass_missing = FakeHass(
+        states={"sensor.opti_forecast_remaining_today_kwh": "unavailable"})
+    assert _availability(hass_missing) == "False"
+
+
+# ---------------------------------------------------------------------------
+# P10-Auswahl-Semantik (verschoben aus test_derived_sensoren.py, vormals an
+# opti_target_soc gepinnt - jetzt zentral am Effective-Sensor).
+# ---------------------------------------------------------------------------
+
+def test_p10_niedriger_als_median_wird_verwendet():
+    states, attrs = _states(remaining="8", estimate10=3, alpha="0")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_state(hass)) == 3.0
+
+
+def test_p10_sonnenuntergang_randfall():
+    # Median und P10 beide 0 -> estimate10 <= 0 -> Fallback Median (ebenfalls 0).
+    states, attrs = _states(remaining="0", estimate10=0, alpha="0")
+    hass = FakeHass(states=states, attrs=attrs)
+    assert float(_state(hass)) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Mutations-Diskriminierung (permanent, Muster wie test_target_soc_hysterese.py):
+# entfernt man die aeussere min(median, blended), waere der Kern-Test bei
+# est10 > median und alpha=0 optimistischer (20 statt 10).
+# ---------------------------------------------------------------------------
+
+def test_aeussere_min_mutant_waere_optimistischer():
+    real = _cfg()
+    mutant = _mutant_cfg(
+        "{{ ([median, blended] | min) | round(3) }}",
+        "{{ blended | round(3) }}",
+    )
+    states, attrs = _states(remaining="10", estimate10=20, alpha="0")
+    hass = FakeHass(states=states, attrs=attrs)
+
+    assert float(_state(hass, real)) == 10.0
+    assert float(_state(hass, mutant)) == 20.0

--- a/tests/test_target_soc_hysterese.py
+++ b/tests/test_target_soc_hysterese.py
@@ -46,10 +46,13 @@ def _attr(hass, attr, cfg=None):
 
 def _states(remaining, cap="10"):
     # hausverbrauch=0, kein sun.sun -> net_available = restproduktion = remaining.
-    # cap=10 -> ratio = remaining/10. netzladen off, kein estimate10 -> p10=median.
+    # cap=10 -> ratio = remaining/10. netzladen off. remaining wird direkt auf
+    # den zentralen Effective-Sensor gestellt (kein estimate10/Blend-Setup
+    # mehr noetig - opti_target_soc liest seit Feature #30 nur noch
+    # opti_forecast_effective_remaining_kwh).
     return {
         "sensor.opti_battery_capacity_kwh": cap,
-        "sensor.opti_forecast_remaining_today_kwh": remaining,
+        "sensor.opti_forecast_effective_remaining_kwh": remaining,
         "sensor.opti_house_consumption_60min_w": "0",
         "input_number.maxsoc": "95",
         "input_number.minsoc": "10",


### PR DESCRIPTION
## Was

Implementiert #30: einstellbarer Forecast-Optimismus. Neuer Regler `input_number.opti_forecast_optimismus` (0-100 %) mischt die Solcast-Rest-Prognose:

```
P_eff = min(median, α·median + (1-α)·P10)     α = Regler/100
```

- **α=0 (Default, Erststart ohne `initial`)** = `min(median, P10)`, **bit-identisch zum bisherigen Verhalten**.
- **α=50** = `(median+P10)/2` (der in #29 vorgeschlagene Mittelweg).
- **α=100** = reiner Median (optimistisch: Ziel-SoC steigt später, Akku wird weniger früh voll gefahren).

## Wie

Ein neuer zentraler Sensor `sensor.opti_forecast_effective_remaining_kwh` berechnet den Blend **einmalig**. Die zuvor **9-fach duplizierte** `min(median, P10)`-Logik (`opti_target_soc` 5×, `opti_forecast_score` 4×) liest jetzt nur noch diesen Sensor - Feature und Dedup in einem, Produktionscode netto kürzer. `opti_forecast_score_tomorrow` (Ganztags-Quelle) bleibt bewusst unverändert (Scope: nur Rest-Tag; sauberer Follow-up möglich).

## Robustheit (aus dem Codex-Review eingearbeitet)

- Der State ist **nicht gerundet** → α=0 ist beweisbar bit-identisch, kein Rundungs-Kipp an den Ziel-SoC-Stufengrenzen.
- Beide Konsumenten hängen jetzt auch an `has_value(opti_forecast_effective_remaining_kwh)` (Tages-Zweig) → im Startup-/Ordering-Fenster werden sie *unavailable* statt still aus `float(0)` zu rechnen.

## Tests

Neues `tests/test_forecast_effective.py` (Blend, alle P10-Guards, Clamp, Availability, permanente Mutations-Diskriminierung gegen die äußere `min`). Bestehende Konsumententests auf den zentralen Sensor umgestellt - **die α=0-Erwartungswerte sind unverändert, das ist der Regressionsbeweis**. Availability-Fälle für beide Konsumenten ergänzt.

**Suite 136 → 148 grün**, alle 183 Jinja-Templates parsen. Doku in `docs/canonical-layer.md` + `docs/strategie-logik.md` ergänzt.

## Review-Kette

Architektur: Fable/Opus · Implementierung: Sonnet 5 (TDD) · unabhängiger Review: Codex (GPT-5.5), 5 Findings, die 2 substantiellen (P2 Availability, P3/P1 Rundung) eingearbeitet.

Closes #30
