### PR TITLE
feat: Balancing-/Deep-Charge-Watchdog (#31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ docs/superpowers/
 
 # Privates Canonical-Mapping mit echten Entitäts-IDs — nicht committen
 packages/opti_mapping.yaml
+
+# Lokale Python-Test-Umgebung
+.venv/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -248,15 +248,19 @@ der Wert jeden weiteren Neustart:
 | `input_number.opti_balancing_intervall_tage` | 0 Tage (= Watchdog aus) | 14 Tage |
 | `input_number.opti_balancing_karenz_tage` | 0 Tage | 3 Tage |
 | `input_number.opti_balancing_max_ct` | 0 ct/kWh (= kein bezahltes Netzladen) | 25 ct/kWh |
+| `input_boolean.opti_balancing_netzladen` | aus (= Balancing rein per PV) | nach Wunsch an |
 
-Die vier `opti_balancing_*`-Helfer steuern den **Balancing-/Deep-Charge-Watchdog**
+Die `opti_balancing_*`-Helfer steuern den **Balancing-/Deep-Charge-Watchdog**
 (`sensor.opti_balancing_watchdog`): `intervall_tage` = Tage ohne Voll-/Done-Ladung bis
 der Watchdog fällig wird (0 = aus), `karenz_tage` = zusätzliche Wartezeit vor dem
 bezahlten Netz-Fallback, `max_ct` = absoluter Brutto-Preisdeckel fürs bezahlte
-Balancing-Netzladen (0 = fail-safe aus). Der vierte Helfer
-`input_number.opti_balancing_done_soc` hat als einziger ein `initial:` (98.5 %) und muss
-nicht von Hand gesetzt werden — er definiert die „Akku ~voll"-Schwelle für Counter-Reset
-und tägliches Increment.
+Balancing-Netzladen (0 = fail-safe aus). `input_number.opti_balancing_done_soc` hat als
+einziger ein `initial:` (98.5 %) und muss nicht von Hand gesetzt werden — er definiert die
+„Akku ~voll"-Schwelle für Counter-Reset und tägliches Increment. Der Schalter
+`input_boolean.opti_balancing_netzladen` (**Default aus**) entscheidet, ob der Watchdog fürs
+BMS-Balancing auch aus dem **Netz** laden darf; ohne ihn balancet er rein per PV. Er ist
+bewusst von `opti_prognose_netzladen` entkoppelt, damit Balancing-Netzladen unabhängig vom
+allgemeinen Prognose-Netzladen freigegeben werden kann.
 
 **9. Feinjustieren:** SoC-Grenzen, Lade-/Entladegrenzen, Prognose-Schwellen über die
 HA-Oberfläche weiter an die eigene Anlage anpassen (alle als Helfer vorhanden).

--- a/README.md
+++ b/README.md
@@ -207,10 +207,12 @@ sie an deine Anlage/Strategie anpassen kannst. Zwei Wege, sie einzuspielen:
       # ... restlicher Inhalt aus automations/opti_strategie.yaml unverändert ...
   ```
 
-  Auf demselben Weg gehört die zweite Automation `automations/opti_balancing_counter.yaml`
-  eingespielt (zählt `counter.tage_seit_akku100` täglich um 23:59 hoch und speist den
-  Balancing-Watchdog). Ersetzt eine ggf. bereits live vorhandene, gleichnamige
-  Increment-Automation.
+  Auf demselben Weg gehört die Datei `automations/opti_balancing_counter.yaml` eingespielt -
+  sie enthält **zwei** Automationen, die den Balancing-Watchdog speisen:
+  `opti_balancing_counter_increment` (zählt `counter.tage_seit_akku100` täglich um 23:59 hoch)
+  und `opti_balancing_counter_reset` (setzt den Zähler auf 0, sobald der Akku 30 min stabil
+  über dem Done-SoC steht - numeric_state-Trigger mit `for:`). Ersetzt eine ggf. bereits live
+  vorhandene, gleichnamige Increment-Automation.
 
 **7. Einschalten:** die Strategie-Automation bleibt wirkungslos, solange ihr Master-Schalter
 aus ist — und frisch angelegte `input_boolean`-Helfer starten **aus** (kein `initial:`, siehe

--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ sie an deine Anlage/Strategie anpassen kannst. Zwei Wege, sie einzuspielen:
       # ... restlicher Inhalt aus automations/opti_strategie.yaml unverändert ...
   ```
 
+  Auf demselben Weg gehört die zweite Automation `automations/opti_balancing_counter.yaml`
+  eingespielt (zählt `counter.tage_seit_akku100` täglich um 23:59 hoch und speist den
+  Balancing-Watchdog). Ersetzt eine ggf. bereits live vorhandene, gleichnamige
+  Increment-Automation.
+
 **7. Einschalten:** die Strategie-Automation bleibt wirkungslos, solange ihr Master-Schalter
 aus ist — und frisch angelegte `input_boolean`-Helfer starten **aus** (kein `initial:`, siehe
 Warnung unten). Über die HA-Oberfläche auf **an** stellen:
@@ -238,6 +243,18 @@ der Wert jeden weiteren Neustart:
 | `input_number.opti_netzlade_spread_ct` | 0 ct/kWh | 10 ct/kWh |
 | `input_number.opti_peak_min_aufschlag_ct` | 0 ct/kWh | 5 ct/kWh |
 | `input_number.opti_halte_spread_ct` | 0 ct/kWh | 5 ct/kWh |
+| `input_number.opti_balancing_intervall_tage` | 0 Tage (= Watchdog aus) | 14 Tage |
+| `input_number.opti_balancing_karenz_tage` | 0 Tage | 3 Tage |
+| `input_number.opti_balancing_max_ct` | 0 ct/kWh (= kein bezahltes Netzladen) | 25 ct/kWh |
+
+Die vier `opti_balancing_*`-Helfer steuern den **Balancing-/Deep-Charge-Watchdog**
+(`sensor.opti_balancing_watchdog`): `intervall_tage` = Tage ohne Voll-/Done-Ladung bis
+der Watchdog fällig wird (0 = aus), `karenz_tage` = zusätzliche Wartezeit vor dem
+bezahlten Netz-Fallback, `max_ct` = absoluter Brutto-Preisdeckel fürs bezahlte
+Balancing-Netzladen (0 = fail-safe aus). Der vierte Helfer
+`input_number.opti_balancing_done_soc` hat als einziger ein `initial:` (98.5 %) und muss
+nicht von Hand gesetzt werden — er definiert die „Akku ~voll"-Schwelle für Counter-Reset
+und tägliches Increment.
 
 **9. Feinjustieren:** SoC-Grenzen, Lade-/Entladegrenzen, Prognose-Schwellen über die
 HA-Oberfläche weiter an die eigene Anlage anpassen (alle als Helfer vorhanden).
@@ -311,7 +328,7 @@ Dieses Projekt lebt von der Community. Besonderer Dank geht an:
 **Strategie**
 - [ ] Netzladen zu Off-Peak-Zeiten / Paragraf-14a-Fenster (pauschal günstigere Nachtstunden)
 - [ ] Mindestentladepreis als echte Entlade-Bedingung nutzen (bisher nur informativ)
-- [ ] Akku im Winter mindestens 1x pro Woche automatisch auf 100 % laden (Zähler `tage_seit_akku100` existiert schon)
+- [x] Akku regelmäßig automatisch auf 100 % balancen — erledigt als saison-übergreifender **Balancing-/Deep-Charge-Watchdog** (`sensor.opti_balancing_watchdog`): erzwingt einen Voll-Zyklus fürs BMS, wenn der Akku länger als `opti_balancing_intervall_tage` (Default 14) nicht mehr ~voll war. Staffelt PV-Vollladung (tagsüber) → Gratis-/Negativ-Netz → bezahltes Netz erst nach `opti_balancing_karenz_tage` und nur unter dem Deckel `opti_balancing_max_ct`. Rein abgeleitet aus `counter.tage_seit_akku100` → restart-durabel. Details: [`docs/strategie-logik.md`](docs/strategie-logik.md#balancing-deep-charge-watchdog)
 - [x] Hysterese-Band für die PV-Überschuss-Grenzen — erledigt als entprellte Binärsensoren `opti_ueberschuss_70_aktiv`/`opti_ueberschuss_ac_aktiv` (akkuunabhängiges Signal, 30 s beidseitig, Hysterese)
 - [ ] `opti_peak_verbrauch_kw` statistisch aus der Verbrauchshistorie ableiten statt fix zu konfigurieren
 - [ ] Wirkleistungsbegrenzung bei negativen Strompreisen über Modbus (Register 41255) - experimentell, kein aktiver Support

--- a/automations/opti_balancing_counter.yaml
+++ b/automations/opti_balancing_counter.yaml
@@ -34,3 +34,31 @@
     - action: counter.increment
       target:
         entity_id: counter.tage_seit_akku100
+
+# -----------------------------------------------------------------------------
+# Counter-Reset bei erreichtem Done-SoC. Bewusst als eigene, TRIGGER-basierte
+# Automation: ein numeric_state-Trigger mit for: haelt zuverlaessig 30 min
+# (im Gegensatz zu for: auf einer numeric_state-CONDITION, das HA nicht
+# belastbar auswertet). 30 min stabil >= Done-SoC = Balancing-Zyklus erledigt
+# -> counter.tage_seit_akku100 = 0 -> sensor.opti_balancing_watchdog faellt auf
+# 'aus'. Loest den semantischen Widerspruch (Watchdog laedt bis 100 / CV-Phase,
+# Reset bereits ab Done-SoC 98.5%) sauber auf: der Watchdog haelt, bis dieser
+# Trigger nach stabilem Stand ueber Done-SoC feuert.
+# -----------------------------------------------------------------------------
+- id: opti_balancing_counter_reset
+  alias: "Opti Balancing: Counter zuruecksetzen bei erreichtem Done-SoC"
+  description: >-
+    Setzt counter.tage_seit_akku100 auf 0, sobald der Akku 30 min stabil ueber
+    dem Done-SoC (input_number.opti_balancing_done_soc) steht. Beendet damit
+    einen faelligen Balancing-Zyklus des Watchdogs.
+  mode: single
+  triggers:
+    - trigger: numeric_state
+      entity_id: sensor.opti_soc
+      above: input_number.opti_balancing_done_soc
+      for:
+        minutes: 30
+  actions:
+    - action: counter.reset
+      target:
+        entity_id: counter.tage_seit_akku100

--- a/automations/opti_balancing_counter.yaml
+++ b/automations/opti_balancing_counter.yaml
@@ -1,0 +1,36 @@
+# =============================================================================
+# opti_balancing_counter.yaml — Taegliches Increment fuer den Balancing-Watchdog
+# =============================================================================
+# Zaehlt counter.tage_seit_akku100 einmal pro Tag um 1 hoch, WENN der Akku an
+# diesem Tag NICHT den Done-SoC (input_number.opti_balancing_done_soc, Default
+# 98.5%) erreicht hat. Der Reset des Counters passiert an anderer Stelle
+# (Cleanup-Block in automations/opti_strategie.yaml, sobald der Akku 30 min
+# stabil ueber dem Done-SoC steht) - beide nutzen dieselbe Done-Schwelle.
+#
+# Kanonisierte Repo-Version der bislang nur live vorhandenen (verwaisten)
+# Increment-Automation. Als Top-Level-Automations-Liste im Format von
+# automations.yaml (siehe README, Abschnitt Strategie-Automation einbinden).
+#
+# Downtime-Randfall: ist HA um 23:59 (ueber Mitternacht) down, wird der Tag
+# NICHT nachgeholt. Harmlos/fail-safe: der Watchdog zaehlt dann eher zu wenig
+# und feuert allenfalls einen Tag spaeter - bei einem 14-Tage-Intervall
+# unkritisch.
+# =============================================================================
+- id: opti_balancing_counter_increment
+  alias: "Opti Balancing: Tage seit Akku 100% täglich hochzählen"
+  description: >-
+    Zaehlt counter.tage_seit_akku100 taeglich um 1 hoch, solange der Akku an
+    diesem Tag nicht den Done-SoC erreicht hat. Speist den Balancing-/Deep-
+    Charge-Watchdog (sensor.opti_balancing_watchdog).
+  mode: single
+  triggers:
+    - trigger: time
+      at: "23:59:00"
+  conditions:
+    - condition: numeric_state
+      entity_id: sensor.opti_soc
+      below: input_number.opti_balancing_done_soc
+  actions:
+    - action: counter.increment
+      target:
+        entity_id: counter.tage_seit_akku100

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -101,18 +101,33 @@
         - sensor.opti_peak_reserve_soc
         - binary_sensor.opti_peak_reserve_aktiv
       id: "Peak-Reserve geändert"
+    # Balancing-/Deep-Charge-Watchdog: sonst bliebe der Modus nach einem
+    # Watchdog-Zustandswechsel (aus/pv/netz) stale.
+    - trigger: state
+      entity_id:
+        - sensor.opti_balancing_watchdog
+      id: "Balancing-Watchdog geändert"
   conditions:
     - condition: state
       entity_id: input_boolean.akku_opti_automatik
       state: "on"
   actions:
-    # CLEANUP (immer, kein has_value-/Toggle-Gate): Counter bei vollem Akku zurücksetzen
-    - alias: "Counter auf 0 setzen bei 100% SoC"
+    # CLEANUP (immer, kein has_value-/Toggle-Gate): Counter zuruecksetzen, wenn der
+    # Akku den Done-SoC erreicht hat. Eine einzige Voll-/Done-Definition:
+    # opti_balancing_done_soc (Default 98.5%). for: 30 min -> erst als "erledigt"
+    # zaehlen, wenn der Akku stabil oben steht (kein kurzer Spike). Bleibt
+    # per-Execution-Cleanup (laeuft bei JEDER Automationsausfuehrung), nicht nur
+    # kantengetriggert. Der Balancing-Watchdog laedt bis 100 (CV-Phase), der
+    # Counter-Reset lehnt bewusst schon bei done_soc ab -> Watchdog feuert nicht
+    # unnoetig, sobald der Akku regulaer ~voll war.
+    - alias: "Counter auf 0 setzen bei erreichtem Done-SoC (30 min stabil)"
       choose:
         - conditions:
             - condition: numeric_state
               entity_id: sensor.opti_soc
-              above: 99
+              above: input_number.opti_balancing_done_soc
+              for:
+                minutes: 30
           sequence:
             - action: counter.reset
               target:
@@ -246,6 +261,41 @@
             - action: input_select.select_option
               data:
                 option: "Akku nur Entladen"
+              target:
+                entity_id: input_select.akkusteuerung_modus
+            - stop: "fertig"
+
+        # ---------------------------------------------------------------------
+        # Balancing-/Deep-Charge-Watchdog (Feature #31): laedt den Akku gezielt
+        # einmalig hoch, wenn er zu lange nicht ~voll war (BMS-Balancing des BYD
+        # HVS). Entscheidung komplett im abgeleiteten sensor.opti_balancing_watchdog
+        # (aus/pv/netz) - restart-durabel, kein Latch. Position bewusst NACH der
+        # Peak-Entlade-Leiter L1/L2 (aktiver Peak schlaegt Balancing) und VOR den
+        # Prognose-Ladebloecken. 'pv' = tagsueber PV-Vollladung, 'netz' = guenstiges/
+        # gratis Netzladen fuers BMS.
+        # ---------------------------------------------------------------------
+        - alias: "Modus 'nur Laden' (Balancing-Watchdog): tagsueber PV-Vollladung fuers BMS-Balancing"
+          conditions:
+            - condition: state
+              entity_id: sensor.opti_balancing_watchdog
+              state: "pv"
+          sequence:
+            - action: input_select.select_option
+              data:
+                option: "Akku nur Laden"
+              target:
+                entity_id: input_select.akkusteuerung_modus
+            - stop: "fertig"
+
+        - alias: "Modus 'Netzladen' (Balancing-Watchdog): guenstiges/gratis Netzladen fuers BMS-Balancing"
+          conditions:
+            - condition: state
+              entity_id: sensor.opti_balancing_watchdog
+              state: "netz"
+          sequence:
+            - action: input_select.select_option
+              data:
+                option: "Akku Netzladen"
               target:
                 entity_id: input_select.akkusteuerung_modus
             - stop: "fertig"

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -112,27 +112,11 @@
       entity_id: input_boolean.akku_opti_automatik
       state: "on"
   actions:
-    # CLEANUP (immer, kein has_value-/Toggle-Gate): Counter zuruecksetzen, wenn der
-    # Akku den Done-SoC erreicht hat. Eine einzige Voll-/Done-Definition:
-    # opti_balancing_done_soc (Default 98.5%). for: 30 min -> erst als "erledigt"
-    # zaehlen, wenn der Akku stabil oben steht (kein kurzer Spike). Bleibt
-    # per-Execution-Cleanup (laeuft bei JEDER Automationsausfuehrung), nicht nur
-    # kantengetriggert. Der Balancing-Watchdog laedt bis 100 (CV-Phase), der
-    # Counter-Reset lehnt bewusst schon bei done_soc ab -> Watchdog feuert nicht
-    # unnoetig, sobald der Akku regulaer ~voll war.
-    - alias: "Counter auf 0 setzen bei erreichtem Done-SoC (30 min stabil)"
-      choose:
-        - conditions:
-            - condition: numeric_state
-              entity_id: sensor.opti_soc
-              above: input_number.opti_balancing_done_soc
-              for:
-                minutes: 30
-          sequence:
-            - action: counter.reset
-              target:
-                entity_id: counter.tage_seit_akku100
-
+    # Hinweis: Der Counter-Reset (counter.tage_seit_akku100) fuers Balancing liegt
+    # bewusst NICHT hier als per-Execution-Cleanup, sondern als eigene, trigger-
+    # basierte Automation in automations/opti_balancing_counter.yaml. Grund: ein
+    # zuverlaessiger 30-min-Halt braucht einen numeric_state-TRIGGER mit for: -
+    # for: auf einer numeric_state-CONDITION ist in HA nicht belastbar.
     - alias: "Zwischen Speicherszenarien wählen"
       choose:
         # OBERSTE PRIORITÄT: Entladesperre <minsoc — vor allen anderen geprüft.

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -203,10 +203,11 @@ Damit greift **kein** Ladeblock mehr, der ein Preisniveau prüft:
 
 ### Harte Garantie gegen jedes Netzladen
 
-Willst du sicherstellen, dass die Steuerung **niemals** aus dem Netz lädt (etwa in der Testphase, bevor die Hardware dranhängt), lässt du zusätzlich diese beiden Toggles bewusst aus:
+Willst du sicherstellen, dass die Steuerung **niemals** aus dem Netz lädt (etwa in der Testphase, bevor die Hardware dranhängt), lässt du diese Toggles bewusst aus:
 
-- `input_boolean.opti_prognose_netzladen` - Gate für beide Netzladen-Zweige, die alten Reserve-Blöcke **und** den Netz-Zweig des Balancing-Watchdogs (`sensor.opti_balancing_watchdog` = `netz`). Ist das Gate aus, bleibt der Watchdog nachts `aus`; seine PV-Vollladung (`pv`, tagsüber) zieht keinen Netzstrom und läuft weiter.
+- `input_boolean.opti_prognose_netzladen` - Gate für die prognosebasierten Netzladen-Zweige und die alten Reserve-Blöcke.
 - `input_boolean.hausakku_aus_netz_laden` - manueller Booster, unabhängig davon: der zieht den Ziel-SoC sonst direkt auf `maxsoc`.
+- `input_boolean.opti_balancing_netzladen` - eigener Schalter für den **Netz-Zweig des Balancing-Watchdogs** (`sensor.opti_balancing_watchdog` = `netz`). **Default aus** - ohne ihn balancet der Watchdog rein per PV (`pv`, tagsüber, zieht keinen Netzstrom). Nur wenn du ihn bewusst anschaltest, darf der Watchdog fürs BMS-Balancing auch nachts günstig/gratis aus dem Netz laden. Bewusst entkoppelt von `opti_prognose_netzladen`, damit du Balancing-Netzladen erlauben kannst, ohne das allgemeine Prognose-Netzladen zu öffnen (und umgekehrt).
 
 ### Vorher gefahrlos durchspielen
 
@@ -380,7 +381,7 @@ des betreffenden Sensors testen — häufig ist der Quell-Sensor noch falsch ben
 | `binary_sensor.opti_winter_charging_allowed` | Saisonales Lade-Gate (Standard: `true`, fail-open) |
 | `sensor.opti_peak_reserve_soc` | Reserve-SoC für kommende Preisspitzen (trigger-basiert, 36h-Horizont) |
 | `binary_sensor.opti_peak_reserve_aktiv` | Gate: Peaks im Wiederauflade-Horizont vorhanden |
-| `sensor.opti_balancing_watchdog` | Balancing-/Deep-Charge-Watchdog (`aus`/`pv`/`netz`): erzwingt einen Voll-Zyklus fürs BMS, wenn `counter.tage_seit_akku100` ≥ `input_number.opti_balancing_intervall_tage` (Default 14; 0 = aus) und SoC < 100 %. Staffelt PV (tagsüber) → Gratis-/Negativ-Netz → bezahltes Netz erst nach `opti_balancing_karenz_tage` und nur ≤ `opti_balancing_max_ct`. Beide `netz`-Zweige respektieren `input_boolean.opti_prognose_netzladen` (PV ungegatet). Rein abgeleitet → restart-durabel |
+| `sensor.opti_balancing_watchdog` | Balancing-/Deep-Charge-Watchdog (`aus`/`pv`/`netz`): erzwingt einen Voll-Zyklus fürs BMS, wenn `counter.tage_seit_akku100` ≥ `input_number.opti_balancing_intervall_tage` (Default 14; 0 = aus) und SoC < 100 %. Staffelt PV (tagsüber) → Gratis-/Negativ-Netz → bezahltes Netz erst nach `opti_balancing_karenz_tage` und nur ≤ `opti_balancing_max_ct`. Beide `netz`-Zweige hängen am eigenen Schalter `input_boolean.opti_balancing_netzladen` (Default aus, PV ungegatet). Rein abgeleitet → restart-durabel |
 
 **Baustein `sensor.opti_house_consumption_60min_w` (`packages/sma_statistik.yaml`):**
 Gleitender 60-Minuten-Mittelwert von `sensor.opti_house_consumption_w` (Legacy-Muster, `state_characteristic: mean`).
@@ -416,7 +417,7 @@ du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
 | **Forecast fehlt** | `opti_forecast_remaining_today_kwh` → `unavailable` | Prognose-Blöcke inaktiv; MinSOC-Schutz und Cleanup laufen weiter | Default → **Akku Dynamisch** (nur wenn `opti_soc` + `opti_battery_capacity_kwh` verfügbar) |
 | **Voller Akku** | SoC > 99 % | **Akku Dynamisch**; Lade-Booster (Legacy) wird deaktiviert | Option „Bei vollem Akku auf Dynamisch" + Cleanup-Block |
 | **Balancing fällig, tagsüber** | `counter.tage_seit_akku100` ≥ `opti_balancing_intervall_tage`, SoC < 100 %, Tag | **Akku nur Laden** | `sensor.opti_balancing_watchdog` = `pv`; steht hinter der Peak-Leiter L1/L2, vor den Prognoseblöcken — siehe [strategie-logik.md](strategie-logik.md#balancing-deep-charge-watchdog) |
-| **Balancing fällig, nachts günstig** | wie oben, Nacht, `opti_prognose_netzladen` = on, Preis gratis/negativ oder (nach Karenz) VERY_CHEAP/CHEAP ≤ `opti_balancing_max_ct` | **Akku Netzladen** | `sensor.opti_balancing_watchdog` = `netz`; Gate `opti_prognose_netzladen` off → `aus` (kein Netzladen); `opti_balancing_max_ct` = 0 lässt den bezahlten Fallback aus (fail-safe) |
+| **Balancing fällig, nachts günstig** | wie oben, Nacht, `opti_balancing_netzladen` = on, Preis gratis/negativ oder (nach Karenz) VERY_CHEAP/CHEAP ≤ `opti_balancing_max_ct` | **Akku Netzladen** | `sensor.opti_balancing_watchdog` = `netz`; eigener Schalter `opti_balancing_netzladen` off → `aus` (kein Netzladen, Default); `opti_balancing_max_ct` = 0 lässt den bezahlten Fallback aus (fail-safe) |
 
 **Fail-safe-Verhalten:** Sind `sensor.opti_soc` oder `sensor.opti_battery_capacity_kwh`
 `unavailable`, setzt die Strategie keinen Modus — der bisherige Modus bleibt aktiv.

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -380,6 +380,7 @@ des betreffenden Sensors testen — häufig ist der Quell-Sensor noch falsch ben
 | `binary_sensor.opti_winter_charging_allowed` | Saisonales Lade-Gate (Standard: `true`, fail-open) |
 | `sensor.opti_peak_reserve_soc` | Reserve-SoC für kommende Preisspitzen (trigger-basiert, 36h-Horizont) |
 | `binary_sensor.opti_peak_reserve_aktiv` | Gate: Peaks im Wiederauflade-Horizont vorhanden |
+| `sensor.opti_balancing_watchdog` | Balancing-/Deep-Charge-Watchdog (`aus`/`pv`/`netz`): erzwingt einen Voll-Zyklus fürs BMS, wenn `counter.tage_seit_akku100` ≥ `input_number.opti_balancing_intervall_tage` (Default 14; 0 = aus) und SoC < 100 %. Staffelt PV (tagsüber) → Gratis-/Negativ-Netz → bezahltes Netz erst nach `opti_balancing_karenz_tage` und nur ≤ `opti_balancing_max_ct`. Rein abgeleitet → restart-durabel |
 
 **Baustein `sensor.opti_house_consumption_60min_w` (`packages/sma_statistik.yaml`):**
 Gleitender 60-Minuten-Mittelwert von `sensor.opti_house_consumption_w` (Legacy-Muster, `state_characteristic: mean`).
@@ -414,6 +415,8 @@ du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
 | **Preis-morgen fehlt** | `opti_price_series`-Attribut `tomorrow` leer / < 4 Gesamtwerte | Preisniveau bleibt **NORMAL** | Fail-safe: `< 4 Preise gesamt → NORMAL`. `sensor.opti_peak_reserve_soc` wird bei < 4 Preisen `unavailable` (Peak-Leiter L1-L4 komplett inaktiv) - bewusst anders als der NORMAL-Fallback des Preisniveaus, siehe [strategie-logik.md](strategie-logik.md#fail-safes-und-bekannte-grenzen) |
 | **Forecast fehlt** | `opti_forecast_remaining_today_kwh` → `unavailable` | Prognose-Blöcke inaktiv; MinSOC-Schutz und Cleanup laufen weiter | Default → **Akku Dynamisch** (nur wenn `opti_soc` + `opti_battery_capacity_kwh` verfügbar) |
 | **Voller Akku** | SoC > 99 % | **Akku Dynamisch**; Lade-Booster (Legacy) wird deaktiviert | Option „Bei vollem Akku auf Dynamisch" + Cleanup-Block |
+| **Balancing fällig, tagsüber** | `counter.tage_seit_akku100` ≥ `opti_balancing_intervall_tage`, SoC < 100 %, Tag | **Akku nur Laden** | `sensor.opti_balancing_watchdog` = `pv`; steht hinter der Peak-Leiter L1/L2, vor den Prognoseblöcken — siehe [strategie-logik.md](strategie-logik.md#balancing-deep-charge-watchdog) |
+| **Balancing fällig, nachts günstig** | wie oben, Nacht, Preis gratis/negativ oder (nach Karenz) VERY_CHEAP/CHEAP ≤ `opti_balancing_max_ct` | **Akku Netzladen** | `sensor.opti_balancing_watchdog` = `netz`; `opti_balancing_max_ct` = 0 lässt den bezahlten Fallback aus (fail-safe) |
 
 **Fail-safe-Verhalten:** Sind `sensor.opti_soc` oder `sensor.opti_battery_capacity_kwh`
 `unavailable`, setzt die Strategie keinen Modus — der bisherige Modus bleibt aktiv.

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -205,7 +205,7 @@ Damit greift **kein** Ladeblock mehr, der ein Preisniveau prüft:
 
 Willst du sicherstellen, dass die Steuerung **niemals** aus dem Netz lädt (etwa in der Testphase, bevor die Hardware dranhängt), lässt du zusätzlich diese beiden Toggles bewusst aus:
 
-- `input_boolean.opti_prognose_netzladen` - Gate für beide Netzladen-Zweige plus die alten Reserve-Blöcke.
+- `input_boolean.opti_prognose_netzladen` - Gate für beide Netzladen-Zweige, die alten Reserve-Blöcke **und** den Netz-Zweig des Balancing-Watchdogs (`sensor.opti_balancing_watchdog` = `netz`). Ist das Gate aus, bleibt der Watchdog nachts `aus`; seine PV-Vollladung (`pv`, tagsüber) zieht keinen Netzstrom und läuft weiter.
 - `input_boolean.hausakku_aus_netz_laden` - manueller Booster, unabhängig davon: der zieht den Ziel-SoC sonst direkt auf `maxsoc`.
 
 ### Vorher gefahrlos durchspielen
@@ -380,7 +380,7 @@ des betreffenden Sensors testen — häufig ist der Quell-Sensor noch falsch ben
 | `binary_sensor.opti_winter_charging_allowed` | Saisonales Lade-Gate (Standard: `true`, fail-open) |
 | `sensor.opti_peak_reserve_soc` | Reserve-SoC für kommende Preisspitzen (trigger-basiert, 36h-Horizont) |
 | `binary_sensor.opti_peak_reserve_aktiv` | Gate: Peaks im Wiederauflade-Horizont vorhanden |
-| `sensor.opti_balancing_watchdog` | Balancing-/Deep-Charge-Watchdog (`aus`/`pv`/`netz`): erzwingt einen Voll-Zyklus fürs BMS, wenn `counter.tage_seit_akku100` ≥ `input_number.opti_balancing_intervall_tage` (Default 14; 0 = aus) und SoC < 100 %. Staffelt PV (tagsüber) → Gratis-/Negativ-Netz → bezahltes Netz erst nach `opti_balancing_karenz_tage` und nur ≤ `opti_balancing_max_ct`. Rein abgeleitet → restart-durabel |
+| `sensor.opti_balancing_watchdog` | Balancing-/Deep-Charge-Watchdog (`aus`/`pv`/`netz`): erzwingt einen Voll-Zyklus fürs BMS, wenn `counter.tage_seit_akku100` ≥ `input_number.opti_balancing_intervall_tage` (Default 14; 0 = aus) und SoC < 100 %. Staffelt PV (tagsüber) → Gratis-/Negativ-Netz → bezahltes Netz erst nach `opti_balancing_karenz_tage` und nur ≤ `opti_balancing_max_ct`. Beide `netz`-Zweige respektieren `input_boolean.opti_prognose_netzladen` (PV ungegatet). Rein abgeleitet → restart-durabel |
 
 **Baustein `sensor.opti_house_consumption_60min_w` (`packages/sma_statistik.yaml`):**
 Gleitender 60-Minuten-Mittelwert von `sensor.opti_house_consumption_w` (Legacy-Muster, `state_characteristic: mean`).
@@ -416,7 +416,7 @@ du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
 | **Forecast fehlt** | `opti_forecast_remaining_today_kwh` → `unavailable` | Prognose-Blöcke inaktiv; MinSOC-Schutz und Cleanup laufen weiter | Default → **Akku Dynamisch** (nur wenn `opti_soc` + `opti_battery_capacity_kwh` verfügbar) |
 | **Voller Akku** | SoC > 99 % | **Akku Dynamisch**; Lade-Booster (Legacy) wird deaktiviert | Option „Bei vollem Akku auf Dynamisch" + Cleanup-Block |
 | **Balancing fällig, tagsüber** | `counter.tage_seit_akku100` ≥ `opti_balancing_intervall_tage`, SoC < 100 %, Tag | **Akku nur Laden** | `sensor.opti_balancing_watchdog` = `pv`; steht hinter der Peak-Leiter L1/L2, vor den Prognoseblöcken — siehe [strategie-logik.md](strategie-logik.md#balancing-deep-charge-watchdog) |
-| **Balancing fällig, nachts günstig** | wie oben, Nacht, Preis gratis/negativ oder (nach Karenz) VERY_CHEAP/CHEAP ≤ `opti_balancing_max_ct` | **Akku Netzladen** | `sensor.opti_balancing_watchdog` = `netz`; `opti_balancing_max_ct` = 0 lässt den bezahlten Fallback aus (fail-safe) |
+| **Balancing fällig, nachts günstig** | wie oben, Nacht, `opti_prognose_netzladen` = on, Preis gratis/negativ oder (nach Karenz) VERY_CHEAP/CHEAP ≤ `opti_balancing_max_ct` | **Akku Netzladen** | `sensor.opti_balancing_watchdog` = `netz`; Gate `opti_prognose_netzladen` off → `aus` (kein Netzladen); `opti_balancing_max_ct` = 0 lässt den bezahlten Fallback aus (fail-safe) |
 
 **Fail-safe-Verhalten:** Sind `sensor.opti_soc` oder `sensor.opti_battery_capacity_kwh`
 `unavailable`, setzt die Strategie keinen Modus — der bisherige Modus bleibt aktiv.

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -316,30 +316,79 @@ Die Regel wartet also nicht ewig auf einen Wert, der nicht mehr existiert.
 
 ### Wechselwirkung mit den alten Ladeblöcken
 
-Die bestehenden SOC-gestuften Ladeblöcke (Optionen 6-10 in der Übersicht unten, siehe [Winter-/Prognose-Ladelogik](#winter-prognose-ladelogik--intent)) stehen weiterhin **hinter** der Negativpreis-/Vorladeregel und **hinter** den Entlade-Stufen der Leiter (L1/L2), aber **vor** deren Halte-Stufen (L3/L4) - Peak-Entladen schlägt Winterladen, günstiges Laden schlägt Halten (Ben-Entscheidung 2026-07-02). Sie kennen die Ladefenster-Wahl **nicht** - sie laden sofort, sobald ihre eigenen SoC-/Preisbedingungen erfüllt sind.
+Die bestehenden SOC-gestuften Ladeblöcke (Optionen 8-12 in der Übersicht unten, siehe [Winter-/Prognose-Ladelogik](#winter-prognose-ladelogik--intent)) stehen weiterhin **hinter** der Negativpreis-/Vorladeregel und **hinter** den Entlade-Stufen der Leiter (L1/L2), aber **vor** deren Halte-Stufen (L3/L4) - Peak-Entladen schlägt Winterladen, günstiges Laden schlägt Halten (Ben-Entscheidung 2026-07-02). Sie kennen die Ladefenster-Wahl **nicht** - sie laden sofort, sobald ihre eigenen SoC-/Preisbedingungen erfüllt sind.
 Das ist bewusst so belassen: Fällt die Peak-Allokation aus (z. B. wegen zu weniger Preise) oder ist ihre Reserve zu knapp bemessen, sorgen die alten Blöcke weiterhin als **Sicherheitsnetz** dafür, dass bei schlechter Prognose überhaupt geladen wird, unabhängig davon, ob gerade das optimale Fenster ist.
+
+---
+
+## Balancing-/Deep-Charge-Watchdog
+
+Ein Lithium-BMS (hier BYD HVS 12.8 kWh) muss den Akku regelmäßig einmal ~voll laden, um die
+Zellen zu balancen und die SoC-Kalibrierung frisch zu halten. Im PV-Alltag - und besonders im
+Sommer-Schonband mit `maxsoc` < 100 - erreicht die dynamische Ziel-SoC-Treppe die 100 % aber
+nie. Der Watchdog erzwingt diesen Voll-Zyklus gezielt, sobald der Akku zu lange nicht mehr
+oben war.
+
+**Zustand rein abgeleitet, kein Latch:** `sensor.opti_balancing_watchdog` berechnet seinen
+Zustand jederzeit neu aus dem Zähler `counter.tage_seit_akku100`, dem SoC und den Helfern -
+damit ist er **restart-durabel** (kein gelatchtes Flag, das ein HA-Neustart verlieren könnte).
+
+**Fälligkeit:** Der Watchdog wird fällig, wenn
+`input_number.opti_balancing_intervall_tage` > 0 **und** SoC < 100 % **und**
+`counter.tage_seit_akku100` ≥ Intervall. Das Ladeziel ist bewusst **100 %** (nicht nur
+`maxsoc`), damit die Zelle in die CV-Phase kommt. `intervall = 0` schaltet den Watchdog
+komplett aus.
+
+**Zähler-Pflege:** Eine eigene Automation (`automations/opti_balancing_counter.yaml`, täglich
+um 23:59) zählt `counter.tage_seit_akku100` um 1 hoch, solange der Akku an dem Tag den
+Done-SoC nicht erreicht hat. Zurückgesetzt wird der Zähler im Cleanup-Block der
+Strategie-Automation, sobald der Akku 30 min stabil über
+`input_number.opti_balancing_done_soc` (Default 98.5 %) steht. Beide nutzen dieselbe
+Done-Schwelle - eine einzige Voll-/Done-Definition.
+
+**Staffelung (Kosten aufsteigend)** - der Zustand entscheidet über den Strategie-Zweig:
+
+| Zustand | Bedingung (fällig vorausgesetzt) | Strategie-Modus |
+|---|---|---|
+| `pv` | tagsüber (`sun.sun` above_horizon) | Akku nur Laden |
+| `netz` | nachts, aktueller Preis < Einspeisevergütung (gratis/negativ) | Akku Netzladen |
+| `netz` | nachts, nach Karenz (`counter` ≥ Intervall + `opti_balancing_karenz_tage`), Preisniveau VERY_CHEAP/CHEAP **und** aktueller Preis ≤ `opti_balancing_max_ct` (> 0) | Akku Netzladen |
+| `aus` | sonst (auf besseres Fenster warten) | — (Kaskade läuft weiter) |
+
+Der PV-Zweig ist im MVP bewusst simpel (ganztags PV-bevorzugt, kein PV > Haus-Gate). Der
+bezahlte Netz-Fallback ist doppelt abgesichert: erst nach der Karenz, nur bei günstigem
+Preisniveau **und** unter einem absoluten Brutto-Deckel. `opti_balancing_max_ct = 0`
+(Erststart-Wert) lässt den bezahlten Fallback komplett aus - fail-safe kein bezahltes
+Netzladen, bis der Deckel bewusst gesetzt wird (empfohlen 25 ct).
+
+**Position in der Kaskade:** Die beiden Watchdog-Zweige stehen **nach** der Peak-Entlade-Leiter
+L1/L2 (ein aktiver Preisspitzen-Peak schlägt das Balancing) und **vor** den Prognose-Ladeblöcken
+(Optionen 6/7 in der Übersicht unten). Fehlt `opti_soc`, ist der Watchdog `aus` (fail-safe).
 
 ---
 
 ## Block-für-Block-Übersicht
 
 Die Automation besteht aus mehreren Aktionsblöcken, die **sequenziell** ausgeführt werden.
-Der wichtigste ist „Zwischen Speicherszenarien wählen" mit 17 Optionen und einem Default-Pfad.
+Der wichtigste ist „Zwischen Speicherszenarien wählen" mit 19 Optionen und einem Default-Pfad.
 
 ---
 
-### Aktionsblock 1 — Counter-Reset bei 100 % SoC
+### Aktionsblock 1 — Counter-Reset bei erreichtem Done-SoC
 
-**Was passiert:** Sobald der Trigger „Akku ist voll" (SoC > 99 %) feuert, wird der Zähler
-`counter.tage_seit_akku100` auf null zurückgesetzt. Dieser Zähler läuft täglich hoch und
-zeigt, wie lange der Akku nicht mehr vollgeladen war — nützlich für Wartungsplanung und
-spätere Automatisierungen, die einen Voll-Zyklus erzwingen können.
+**Was passiert:** Steht der SoC 30 min stabil über `input_number.opti_balancing_done_soc`
+(Default 98.5 %), wird der Zähler `counter.tage_seit_akku100` auf null zurückgesetzt. Dieser
+Zähler läuft täglich hoch (eigene Automation `opti_balancing_counter.yaml`, 23:59) und zeigt,
+wie lange der Akku nicht mehr ~voll war — er speist den
+[Balancing-/Deep-Charge-Watchdog](#balancing-deep-charge-watchdog). Der Block läuft bei
+**jeder** Automationsausführung (per-Execution-Cleanup, kein reiner Kanten-Trigger); die
+`for: 30 min`-Bedingung verhindert, dass ein kurzer SoC-Spike den Zähler fälschlich löscht.
 
 **Modus-Auswirkung:** Keine direkte Modus-Änderung — nur Counter-Reset.
 
 ---
 
-### Aktionsblock 2 — „Zwischen Speicherszenarien wählen" (17 Optionen + Default)
+### Aktionsblock 2 — „Zwischen Speicherszenarien wählen" (19 Optionen + Default)
 
 Dies ist das Herzstück. Die Optionen werden **der Reihe nach** geprüft;
 die erste, deren Bedingungen alle erfüllt sind, wird ausgeführt und die weitere Prüfung
@@ -413,9 +462,10 @@ Reserve ja da. Details zur Leiter (L1-L4) und zum Freigabeband stehen im Abschni
 **[Entlade-Peak-Allokation](#entlade-peak-allokation-reserve-für-die-teuersten-stunden)**.
 
 **Warum vor den alten Ladeblöcken (Ben-Entscheidung 2026-07-02):** L1/L2 stehen jetzt direkt
-nach der Peak-Vorladeregel und damit vor den alten SOC-gestuften Ladeblöcken (Option 6-10):
-Peak-Entladen schlägt Winterladen. Die Halte-Stufen L3/L4 (Option 14/15) bleiben hinter den
-Ladeblöcken stehen — günstiges Laden schlägt Halten.
+nach der Peak-Vorladeregel und damit vor den alten SOC-gestuften Ladeblöcken (Option 8-12):
+Peak-Entladen schlägt Winterladen. Die Halte-Stufen L3/L4 (Option 16/17) bleiben hinter den
+Ladeblöcken stehen — günstiges Laden schlägt Halten. Dazwischen (Option 6/7) sitzt der
+Balancing-Watchdog: er lädt vor den Prognoseblöcken, aber hinter einem aktiven Peak.
 
 ---
 
@@ -433,7 +483,38 @@ VERY_EXPENSIVE-Reserve liegt (Freigabeband +5 %/+3 %, siehe Hauptabschnitt).
 
 ---
 
-#### Option 6 — Laden wenn heute + morgen schlecht, SoC < 20 % (Tag und Nacht)
+#### Option 6 - Balancing-Watchdog: PV-Vollladung (Tag)
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | `sensor.opti_balancing_watchdog` = `pv` (fällig **und** tagsüber) |
+| Preis | irrelevant |
+| Tageszeit | nach Sonnenaufgang bis Sonnenuntergang |
+| Gesetzter Modus | **Akku nur Laden** |
+
+**Warum:** Ist der Watchdog fällig (Akku zu lange nicht ~voll), wird tagsüber PV-bevorzugt bis
+100 % geladen, damit das BMS balancen kann. Details und Staffelung siehe
+**[Balancing-/Deep-Charge-Watchdog](#balancing-deep-charge-watchdog)**.
+
+---
+
+#### Option 7 - Balancing-Watchdog: Netz-Vollladung (Nacht)
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | `sensor.opti_balancing_watchdog` = `netz` (fällig, nachts; gratis/negativer Preis, oder nach Karenz günstig **und** unter dem Preisdeckel) |
+| Preis | gratis/negativ (< Einspeisevergütung) oder VERY_CHEAP/CHEAP ≤ `opti_balancing_max_ct` |
+| Tageszeit | nachts (der PV-Zweig hat tagsüber Vorrang) |
+| Gesetzter Modus | **Akku Netzladen** (braucht `ha-modbus-akku-adapter` >= v1.5.0) |
+
+**Warum:** Reicht die PV nicht (nachts), lädt der Watchdog aus dem Netz - sofort bei gratis/
+negativem Strom, sonst erst nach einer Karenz und nur günstig unter einem absoluten Deckel.
+`opti_balancing_max_ct = 0` (Erststart) lässt den bezahlten Fallback aus. Details siehe
+**[Balancing-/Deep-Charge-Watchdog](#balancing-deep-charge-watchdog)**.
+
+---
+
+#### Option 8 — Laden wenn heute + morgen schlecht, SoC < 20 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -449,7 +530,7 @@ noch besser als kein Puffer. Diese Ausnahmeregelung gilt nur für diese kritisch
 
 ---
 
-#### Option 7 — Laden wenn heute + morgen schlecht, SoC < 75 % (Tag und Nacht)
+#### Option 9 — Laden wenn heute + morgen schlecht, SoC < 75 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -461,12 +542,12 @@ noch besser als kein Puffer. Diese Ausnahmeregelung gilt nur für diese kritisch
 **Warum (Nuance):** Bei moderatem SoC (20–75 %) und zwei schlechten Prognosetagen wird
 bis NORMAL-Preis nachgeladen. Der Grenze zu EXPENSIVE bleibt verschlossen, weil der Akku
 noch nicht kritisch leer ist — es lohnt sich, auf günstigere Stunden zu warten.
-Dieser Block bildet zusammen mit Option 6 eine bewusste Abstufung: je leerer der Akku,
+Dieser Block bildet zusammen mit Option 8 eine bewusste Abstufung: je leerer der Akku,
 desto teureren Strom darf die Automatik akzeptieren.
 
 ---
 
-#### Option 8 — Laden wenn heute + morgen schlecht, Wintermodus, SoC < 80 % (Tag und Nacht)
+#### Option 10 — Laden wenn heute + morgen schlecht, Wintermodus, SoC < 80 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -484,7 +565,7 @@ Sommermodus-Schalter überschrieben werden, wenn ein saisonales Gate gewünscht 
 
 ---
 
-#### Option 9 — Laden wenn heute schlecht, SoC < 15 % (Tag und Nacht)
+#### Option 11 — Laden wenn heute schlecht, SoC < 15 % (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -493,13 +574,13 @@ Sommermodus-Schalter überschrieben werden, wenn ein saisonales Gate gewünscht 
 | Tageszeit | jederzeit |
 | Gesetzter Modus | **Akku nur Laden** |
 
-**Warum:** Ähnlich wie Option 6, aber unabhängig von der Morgen-Prognose. Wenn der Akku
+**Warum:** Ähnlich wie Option 8, aber unabhängig von der Morgen-Prognose. Wenn der Akku
 fast leer ist (< 15 %) und die heutige Bewertung schlecht ist, wird notgeladen — ohne
 Rücksicht auf morgen. Kurzfrist-Schutz.
 
 ---
 
-#### Option 10 — Laden wenn heute schlecht, SoC < 45 %, Strom sehr günstig (Tag und Nacht)
+#### Option 12 — Laden wenn heute schlecht, SoC < 45 %, Strom sehr günstig (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -515,7 +596,7 @@ Stunden rechtfertigen das Netzladen bei diesem SoC-Niveau.
 
 ---
 
-#### Option 11 — Bei 70%-Überschuss laden (nur tagsüber)
+#### Option 13 — Bei 70%-Überschuss laden (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -535,7 +616,7 @@ Entprellung 30 s beidseitig plus Hysterese-Band, wie in der bewährten Opti-2.0-
 
 ---
 
-#### Option 12 — Bei AC-Überschuss laden (nur tagsüber)
+#### Option 14 — Bei AC-Überschuss laden (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -550,7 +631,7 @@ der Netzeinspeisung. Nutzt verfügbare PV-Energie aktiv, bevor sie verschwendet 
 
 ---
 
-#### Option 13 — Bei vollem Akku auf Dynamisch schalten
+#### Option 15 — Bei vollem Akku auf Dynamisch schalten
 
 | Eigenschaft | Wert |
 |---|---|
@@ -565,7 +646,7 @@ einspeisen, bei Verbrauch den Akku nutzen — je nach aktuellem Systemzustand.
 
 ---
 
-#### Option 14 - Peak-Leiter L3: Halten bei EXPENSIVE unter VE-Reserve (Tag und Nacht)
+#### Option 16 - Peak-Leiter L3: Halten bei EXPENSIVE unter VE-Reserve (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -582,7 +663,7 @@ preislich kaum über der aktuellen EXPENSIVE-Stunde, kostet die Entladesperre nu
 
 ---
 
-#### Option 15 - Peak-Leiter L4: Halten bei NORMAL oder billiger unter Gesamt-Reserve (Tag und Nacht)
+#### Option 17 - Peak-Leiter L4: Halten bei NORMAL oder billiger unter Gesamt-Reserve (Tag und Nacht)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -594,11 +675,11 @@ preislich kaum über der aktuellen EXPENSIVE-Stunde, kostet die Entladesperre nu
 **Warum:** Auch bei günstigem Preis wird nicht in die für Peaks reservierte Energie
 entladen, solange der SoC die Gesamt-Reserve noch nicht deutlich übersteigt.
 Trifft keine der vier Leiter-Stufen zu, fällt die Prüfung durch zu den normalen
-Ziel-SoC-Optionen (Option 16/17).
+Ziel-SoC-Optionen (Option 18/19).
 
 ---
 
-#### Option 16 — Dynamisch laden wenn SoC zwischen MinSOC und Ziel-SoC (nur tagsüber)
+#### Option 18 — Dynamisch laden wenn SoC zwischen MinSOC und Ziel-SoC (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -615,7 +696,7 @@ erklärt. Das **−3 %-Band** (H) verhindert Modus-Pendeln direkt an der Ziel-Ka
 
 ---
 
-#### Option 17 — Nur Entladen wenn SoC über Ziel-SoC
+#### Option 19 — Nur Entladen wenn SoC über Ziel-SoC
 
 | Eigenschaft | Wert |
 |---|---|
@@ -633,7 +714,7 @@ Ziel-SoC-Hysterese dafür, dass der Modus an der Grenze nicht flattert.
 
 #### Default — Akku Dynamisch
 
-Trifft keine der 17 Optionen zu (z. B. nachts ohne Ladegrund, Preis zu hoch),
+Trifft keine der 19 Optionen zu (z. B. nachts ohne Ladegrund, Preis zu hoch),
 wird der Modus auf **Akku Dynamisch** gesetzt. Der Adapter entscheidet dann
 situationsabhängig, ob leicht geladen oder entladen wird — ein sicherer Mittelweg.
 
@@ -658,8 +739,8 @@ putzt den Zustand automatisch auf — er läuft immer (kein Toggle-Gate).
 
 | Modus | Typische Situation |
 |---|---|
-| **Akku nur Laden** | SoC unter MinSOC (Notfall); schlechte Prognose + günstiger Strom; Wintermodus aktiv; Akku fast leer bei Schlechtwetter; Peak-Leiter L3/L4 (halten) |
-| **Akku Netzladen** | Negativpreis-Laderegel oder Peak-Vorladeregel aktiv — erzwungenes dynamisches Netzladen (BatChaMinW = `opti_charge_power_w`); braucht `ha-modbus-akku-adapter` >= v1.5.0 |
+| **Akku nur Laden** | SoC unter MinSOC (Notfall); schlechte Prognose + günstiger Strom; Wintermodus aktiv; Akku fast leer bei Schlechtwetter; Peak-Leiter L3/L4 (halten); Balancing-Watchdog PV-Vollladung (tagsüber) |
+| **Akku Netzladen** | Negativpreis-Laderegel, Peak-Vorladeregel oder Balancing-Watchdog (nachts) aktiv — erzwungenes dynamisches Netzladen (BatChaMinW = `opti_charge_power_w`); braucht `ha-modbus-akku-adapter` >= v1.5.0 |
 | **Akku Dynamisch** | PV-Überschuss tagsüber; Akku zwischen MinSOC und Ziel-SoC; voller Akku; kein klarer Lade-/Entladegrund (Default) |
 | **Akku nur Entladen** | SoC über intelligentem Ziel-SoC (`sensor.opti_target_soc`); Peak-Leiter L1/L2 (entladen) |
 
@@ -686,3 +767,4 @@ Steuer-Automation parallel aktiv lassen.
 | **Midrank-Perzentil** | `sensor.opti_price_level` zählt Preis-Gleichstände seit dem Fix nur noch halb (statt sie wie ein `select('le')` komplett auf die teure Seite zu zählen) - flache Preistage landen dadurch bei NORMAL statt fälschlich bei VERY_EXPENSIVE. Dieselbe Klassifikation nutzt auch `sensor.opti_peak_reserve_soc` |
 | **`sensor.opti_peak_reserve_soc`** | Reserve-SoC für kommende Preisspitzen im Wiederauflade-Horizont (36h); steuert die Peak-Leiter L1-L4. Siehe [Entlade-Peak-Allokation](#entlade-peak-allokation-reserve-für-die-teuersten-stunden) |
 | **`binary_sensor.opti_winter_charging_allowed`** | Fail-open Gate für Winterladeblöcke (Standard: `true`); kann mit eigenem Sommermodus-Sensor überschrieben werden |
+| **`sensor.opti_balancing_watchdog`** | Balancing-/Deep-Charge-Watchdog (`aus`/`pv`/`netz`): erzwingt einen Voll-Zyklus, wenn der Akku zu lange nicht ~voll war (BMS-Balancing). Rein abgeleitet aus `counter.tage_seit_akku100`, SoC und den `opti_balancing_*`-Helfern → restart-durabel. Siehe [Balancing-/Deep-Charge-Watchdog](#balancing-deep-charge-watchdog) |

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -354,13 +354,16 @@ nach stabilem Stand über Done-SoC feuert und `counter = 0` setzt → Watchdog `
 | Zustand | Bedingung (fällig vorausgesetzt) | Strategie-Modus |
 |---|---|---|
 | `pv` | tagsüber (`sun.sun` above_horizon) | Akku nur Laden |
-| `netz` | nachts, **`opti_prognose_netzladen` = on**, aktueller Preis < Einspeisevergütung (gratis/negativ) | Akku Netzladen |
-| `netz` | nachts, **`opti_prognose_netzladen` = on**, nach Karenz (`counter` ≥ Intervall + `opti_balancing_karenz_tage`), Preisniveau VERY_CHEAP/CHEAP **und** aktueller Preis ≤ `opti_balancing_max_ct` (> 0) | Akku Netzladen |
+| `netz` | nachts, **`opti_balancing_netzladen` = on**, aktueller Preis < Einspeisevergütung (gratis/negativ) | Akku Netzladen |
+| `netz` | nachts, **`opti_balancing_netzladen` = on**, nach Karenz (`counter` ≥ Intervall + `opti_balancing_karenz_tage`), Preisniveau VERY_CHEAP/CHEAP **und** aktueller Preis ≤ `opti_balancing_max_ct` (> 0) | Akku Netzladen |
 | `aus` | sonst (auf besseres Fenster warten) | — (Kaskade läuft weiter) |
 
-**Netzlade-Gate:** Beide `netz`-Zweige respektieren `input_boolean.opti_prognose_netzladen` -
-ist das Gate aus, bleibt der Watchdog nachts `aus` (**harte Garantie gegen jedes Netzladen**,
-siehe [canonical-layer.md](canonical-layer.md#harte-garantie-gegen-jedes-netzladen)). Der
+**Netzlade-Schalter:** Beide `netz`-Zweige hängen am **eigenen** Schalter
+`input_boolean.opti_balancing_netzladen` (**Default aus**) - ist er aus, bleibt der Watchdog
+nachts `aus` und balancet rein per PV. Bewusst **entkoppelt** von `opti_prognose_netzladen`:
+so lässt sich Balancing-Netzladen erlauben, ohne das allgemeine Prognose-Netzladen zu öffnen
+(die **harte Netzlade-Garantie** bleibt darüber erhalten, siehe
+[canonical-layer.md](canonical-layer.md#harte-garantie-gegen-jedes-netzladen)). Der
 `pv`-Zweig ist **ungegatet** - PV-Vollladung zieht keinen Netzstrom.
 
 Der PV-Zweig ist im MVP bewusst simpel (ganztags PV-bevorzugt, kein PV > Haus-Gate). Der
@@ -502,16 +505,16 @@ VERY_EXPENSIVE-Reserve liegt (Freigabeband +5 %/+3 %, siehe Hauptabschnitt).
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | `sensor.opti_balancing_watchdog` = `netz` (fällig, nachts, `opti_prognose_netzladen` = on; gratis/negativer Preis, oder nach Karenz günstig **und** unter dem Preisdeckel) |
+| Bedingung | `sensor.opti_balancing_watchdog` = `netz` (fällig, nachts, `opti_balancing_netzladen` = on; gratis/negativer Preis, oder nach Karenz günstig **und** unter dem Preisdeckel) |
 | Preis | gratis/negativ (< Einspeisevergütung) oder VERY_CHEAP/CHEAP ≤ `opti_balancing_max_ct` |
 | Tageszeit | nachts (der PV-Zweig hat tagsüber Vorrang) |
-| Gate | `input_boolean.opti_prognose_netzladen` muss `on` sein (im Sensor gegated) |
+| Schalter | `input_boolean.opti_balancing_netzladen` muss `on` sein (im Sensor gegated, Default aus) |
 | Gesetzter Modus | **Akku Netzladen** (braucht `ha-modbus-akku-adapter` >= v1.5.0) |
 
 **Warum:** Reicht die PV nicht (nachts), lädt der Watchdog aus dem Netz - sofort bei gratis/
 negativem Strom, sonst erst nach einer Karenz und nur günstig unter einem absoluten Deckel.
-Beide `netz`-Fälle respektieren das Netzlade-Gate `opti_prognose_netzladen` (harte Garantie
-gegen jedes Netzladen); der `pv`-Zweig bleibt ungegatet.
+Beide `netz`-Fälle hängen am eigenen Wartungs-Schalter `opti_balancing_netzladen` (Default
+aus, entkoppelt von `opti_prognose_netzladen`); der `pv`-Zweig bleibt ungegatet.
 `opti_balancing_max_ct = 0` (Erststart) lässt den bezahlten Fallback aus. Details siehe
 **[Balancing-/Deep-Charge-Watchdog](#balancing-deep-charge-watchdog)**.
 

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -339,21 +339,29 @@ damit ist er **restart-durabel** (kein gelatchtes Flag, das ein HA-Neustart verl
 `maxsoc`), damit die Zelle in die CV-Phase kommt. `intervall = 0` schaltet den Watchdog
 komplett aus.
 
-**Zähler-Pflege:** Eine eigene Automation (`automations/opti_balancing_counter.yaml`, täglich
-um 23:59) zählt `counter.tage_seit_akku100` um 1 hoch, solange der Akku an dem Tag den
-Done-SoC nicht erreicht hat. Zurückgesetzt wird der Zähler im Cleanup-Block der
-Strategie-Automation, sobald der Akku 30 min stabil über
-`input_number.opti_balancing_done_soc` (Default 98.5 %) steht. Beide nutzen dieselbe
-Done-Schwelle - eine einzige Voll-/Done-Definition.
+**Zähler-Pflege (zwei Automationen in `automations/opti_balancing_counter.yaml`):**
+`opti_balancing_counter_increment` zählt `counter.tage_seit_akku100` täglich um 23:59 um 1
+hoch, solange der Akku an dem Tag den Done-SoC nicht erreicht hat.
+`opti_balancing_counter_reset` setzt den Zähler auf 0, sobald der Akku **30 min stabil** über
+`input_number.opti_balancing_done_soc` (Default 98.5 %) steht. Der Reset ist bewusst ein
+numeric_state-**Trigger** mit `for: 30 min` (nicht eine numeric_state-Condition mit `for:` -
+letzteres wertet HA nicht belastbar aus). Beide nutzen dieselbe Done-Schwelle - eine einzige
+Voll-/Done-Definition. Damit hält der Watchdog (Ladeziel 100 %/CV-Phase), bis der Reset-Trigger
+nach stabilem Stand über Done-SoC feuert und `counter = 0` setzt → Watchdog `aus`.
 
 **Staffelung (Kosten aufsteigend)** - der Zustand entscheidet über den Strategie-Zweig:
 
 | Zustand | Bedingung (fällig vorausgesetzt) | Strategie-Modus |
 |---|---|---|
 | `pv` | tagsüber (`sun.sun` above_horizon) | Akku nur Laden |
-| `netz` | nachts, aktueller Preis < Einspeisevergütung (gratis/negativ) | Akku Netzladen |
-| `netz` | nachts, nach Karenz (`counter` ≥ Intervall + `opti_balancing_karenz_tage`), Preisniveau VERY_CHEAP/CHEAP **und** aktueller Preis ≤ `opti_balancing_max_ct` (> 0) | Akku Netzladen |
+| `netz` | nachts, **`opti_prognose_netzladen` = on**, aktueller Preis < Einspeisevergütung (gratis/negativ) | Akku Netzladen |
+| `netz` | nachts, **`opti_prognose_netzladen` = on**, nach Karenz (`counter` ≥ Intervall + `opti_balancing_karenz_tage`), Preisniveau VERY_CHEAP/CHEAP **und** aktueller Preis ≤ `opti_balancing_max_ct` (> 0) | Akku Netzladen |
 | `aus` | sonst (auf besseres Fenster warten) | — (Kaskade läuft weiter) |
+
+**Netzlade-Gate:** Beide `netz`-Zweige respektieren `input_boolean.opti_prognose_netzladen` -
+ist das Gate aus, bleibt der Watchdog nachts `aus` (**harte Garantie gegen jedes Netzladen**,
+siehe [canonical-layer.md](canonical-layer.md#harte-garantie-gegen-jedes-netzladen)). Der
+`pv`-Zweig ist **ungegatet** - PV-Vollladung zieht keinen Netzstrom.
 
 Der PV-Zweig ist im MVP bewusst simpel (ganztags PV-bevorzugt, kein PV > Haus-Gate). Der
 bezahlte Netz-Fallback ist doppelt abgesichert: erst nach der Karenz, nur bei günstigem
@@ -372,23 +380,15 @@ L1/L2 (ein aktiver Preisspitzen-Peak schlägt das Balancing) und **vor** den Pro
 Die Automation besteht aus mehreren Aktionsblöcken, die **sequenziell** ausgeführt werden.
 Der wichtigste ist „Zwischen Speicherszenarien wählen" mit 19 Optionen und einem Default-Pfad.
 
----
-
-### Aktionsblock 1 — Counter-Reset bei erreichtem Done-SoC
-
-**Was passiert:** Steht der SoC 30 min stabil über `input_number.opti_balancing_done_soc`
-(Default 98.5 %), wird der Zähler `counter.tage_seit_akku100` auf null zurückgesetzt. Dieser
-Zähler läuft täglich hoch (eigene Automation `opti_balancing_counter.yaml`, 23:59) und zeigt,
-wie lange der Akku nicht mehr ~voll war — er speist den
-[Balancing-/Deep-Charge-Watchdog](#balancing-deep-charge-watchdog). Der Block läuft bei
-**jeder** Automationsausführung (per-Execution-Cleanup, kein reiner Kanten-Trigger); die
-`for: 30 min`-Bedingung verhindert, dass ein kurzer SoC-Spike den Zähler fälschlich löscht.
-
-**Modus-Auswirkung:** Keine direkte Modus-Änderung — nur Counter-Reset.
+> **Hinweis — Counter-Pflege ausgelagert:** Der Zähler `counter.tage_seit_akku100` (Increment
+> täglich, Reset bei 30 min stabil über Done-SoC) liegt **nicht** in dieser Automation, sondern
+> als zwei eigene, trigger-basierte Automationen in `automations/opti_balancing_counter.yaml` -
+> ein zuverlässiger 30-min-Halt braucht einen numeric_state-**Trigger** mit `for:`, nicht eine
+> gleichnamige Condition. Details siehe [Balancing-/Deep-Charge-Watchdog](#balancing-deep-charge-watchdog).
 
 ---
 
-### Aktionsblock 2 — „Zwischen Speicherszenarien wählen" (19 Optionen + Default)
+### Aktionsblock 1 — „Zwischen Speicherszenarien wählen" (19 Optionen + Default)
 
 Dies ist das Herzstück. Die Optionen werden **der Reihe nach** geprüft;
 die erste, deren Bedingungen alle erfüllt sind, wird ausgeführt und die weitere Prüfung
@@ -502,13 +502,16 @@ VERY_EXPENSIVE-Reserve liegt (Freigabeband +5 %/+3 %, siehe Hauptabschnitt).
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | `sensor.opti_balancing_watchdog` = `netz` (fällig, nachts; gratis/negativer Preis, oder nach Karenz günstig **und** unter dem Preisdeckel) |
+| Bedingung | `sensor.opti_balancing_watchdog` = `netz` (fällig, nachts, `opti_prognose_netzladen` = on; gratis/negativer Preis, oder nach Karenz günstig **und** unter dem Preisdeckel) |
 | Preis | gratis/negativ (< Einspeisevergütung) oder VERY_CHEAP/CHEAP ≤ `opti_balancing_max_ct` |
 | Tageszeit | nachts (der PV-Zweig hat tagsüber Vorrang) |
+| Gate | `input_boolean.opti_prognose_netzladen` muss `on` sein (im Sensor gegated) |
 | Gesetzter Modus | **Akku Netzladen** (braucht `ha-modbus-akku-adapter` >= v1.5.0) |
 
 **Warum:** Reicht die PV nicht (nachts), lädt der Watchdog aus dem Netz - sofort bei gratis/
 negativem Strom, sonst erst nach einer Karenz und nur günstig unter einem absoluten Deckel.
+Beide `netz`-Fälle respektieren das Netzlade-Gate `opti_prognose_netzladen` (harte Garantie
+gegen jedes Netzladen); der `pv`-Zweig bleibt ungegatet.
 `opti_balancing_max_ct = 0` (Erststart) lässt den bezahlten Fallback aus. Details siehe
 **[Balancing-/Deep-Charge-Watchdog](#balancing-deep-charge-watchdog)**.
 
@@ -723,7 +726,7 @@ verfügbar sind — Fail-safe bei unavailable Quellen.
 
 ---
 
-### Aktionsblock 3 — Cleanup: Netzladen-Booster deaktivieren bei vollem Akku
+### Aktionsblock 2 — Cleanup: Netzladen-Booster deaktivieren bei vollem Akku
 
 **Was passiert:** Wenn SoC > 99 % und der manuelle Netzlade-Booster
 (`input_boolean.hausakku_aus_netz_laden`) aktiv ist, wird dieser automatisch deaktiviert.
@@ -746,7 +749,7 @@ putzt den Zustand automatisch auf — er läuft immer (kein Toggle-Gate).
 
 **Modus-Contract (Single-Writer-Regel):**
 Die Strategie-Automation schreibt primär `input_select.akkusteuerung_modus`. Im
-Cleanup-Block (Aktionsblock 3) werden zusätzlich `input_boolean.hausakku_aus_netz_laden`
+Cleanup-Block (Aktionsblock 2) werden zusätzlich `input_boolean.hausakku_aus_netz_laden`
 und `input_number.ladepreis` gesetzt. Was der Modus am Wechselrichter/Speicher auslöst,
 entscheidet allein der Hardware-Adapter (Blueprint im Repo `ha-modbus-akku-adapter`).
 Nur eine Automation darf gleichzeitig via Modbus schreiben — keine zweite

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -621,11 +621,15 @@ template:
           {% set eeg = states('input_number.opti_einspeiseverguetung_ct')|float(0) %}
           {% set price = states('sensor.opti_price_level') %}
           {% set day = is_state('sun.sun','above_horizon') %}
+          {% set prog = states('input_boolean.opti_prognose_netzladen') == 'on' %}
           {% set faellig = intervall > 0 and soc >= 0 and soc < 100 and counter >= intervall %}
+          {# 'netz' respektiert das Netzlade-Gate opti_prognose_netzladen (harte
+             Garantie gegen jedes Netzladen, docs/canonical-layer.md #26). 'pv'
+             bleibt ungegatet - PV-Vollladung zieht keinen Netzstrom. #}
           {% if not faellig %}aus
           {%- elif day %}pv
-          {%- elif hv_cur and cur < eeg %}netz
-          {%- elif counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct %}netz
+          {%- elif prog and hv_cur and cur < eeg %}netz
+          {%- elif prog and counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct %}netz
           {%- else %}aus{% endif %}
         attributes:
           grund: >
@@ -639,14 +643,16 @@ template:
             {% set eeg = states('input_number.opti_einspeiseverguetung_ct')|float(0) %}
             {% set price = states('sensor.opti_price_level') %}
             {% set day = is_state('sun.sun','above_horizon') %}
+            {% set prog = states('input_boolean.opti_prognose_netzladen') == 'on' %}
             {% set faellig = intervall > 0 and soc >= 0 and soc < 100 and counter >= intervall %}
             {% if intervall <= 0 %}Watchdog aus (Intervall 0)
             {%- elif soc < 0 %}opti_soc fehlt
             {%- elif soc >= 100 %}Akku voll (soc>=100)
             {%- elif not faellig %}nicht faellig ({{counter}}/{{intervall}} Tage)
             {%- elif day %}PV-Vollladung (tag, {{counter}} Tage seit voll)
-            {%- elif hv_cur and cur < eeg %}Gratis-Netz ({{cur}}ct < EEG {{eeg}}ct)
-            {%- elif counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct %}Bezahltes Netz ({{cur}}ct <= Deckel {{maxct}}ct, nach Karenz)
+            {%- elif prog and hv_cur and cur < eeg %}Gratis-Netz ({{cur}}ct < EEG {{eeg}}ct)
+            {%- elif prog and counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct %}Bezahltes Netz ({{cur}}ct <= Deckel {{maxct}}ct, nach Karenz)
+            {%- elif not prog and (hv_cur and cur < eeg or counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct) %}Netz-Balancing gesperrt (opti_prognose_netzladen aus)
             {%- else %}warte auf besseres Fenster{% endif %}
           soc: "{{ states('sensor.opti_soc') }}"
           tage_seit_voll: "{{ states('counter.tage_seit_akku100') }}"

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -621,15 +621,17 @@ template:
           {% set eeg = states('input_number.opti_einspeiseverguetung_ct')|float(0) %}
           {% set price = states('sensor.opti_price_level') %}
           {% set day = is_state('sun.sun','above_horizon') %}
-          {% set prog = states('input_boolean.opti_prognose_netzladen') == 'on' %}
+          {% set bal_netz = states('input_boolean.opti_balancing_netzladen') == 'on' %}
           {% set faellig = intervall > 0 and soc >= 0 and soc < 100 and counter >= intervall %}
-          {# 'netz' respektiert das Netzlade-Gate opti_prognose_netzladen (harte
-             Garantie gegen jedes Netzladen, docs/canonical-layer.md #26). 'pv'
-             bleibt ungegatet - PV-Vollladung zieht keinen Netzstrom. #}
+          {# 'netz' hat einen EIGENEN Schalter opti_balancing_netzladen (Default aus),
+             entkoppelt vom allgemeinen opti_prognose_netzladen. So bleibt die harte
+             Netzlade-Garantie (docs/canonical-layer.md #26) erhalten: Balancing zieht
+             nur Netzstrom, wenn dieser Wartungs-Schalter bewusst an ist. 'pv' bleibt
+             ungegatet - PV-Vollladung zieht keinen Netzstrom. #}
           {% if not faellig %}aus
           {%- elif day %}pv
-          {%- elif prog and hv_cur and cur < eeg %}netz
-          {%- elif prog and counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct %}netz
+          {%- elif bal_netz and hv_cur and cur < eeg %}netz
+          {%- elif bal_netz and counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct %}netz
           {%- else %}aus{% endif %}
         attributes:
           grund: >
@@ -643,16 +645,16 @@ template:
             {% set eeg = states('input_number.opti_einspeiseverguetung_ct')|float(0) %}
             {% set price = states('sensor.opti_price_level') %}
             {% set day = is_state('sun.sun','above_horizon') %}
-            {% set prog = states('input_boolean.opti_prognose_netzladen') == 'on' %}
+            {% set bal_netz = states('input_boolean.opti_balancing_netzladen') == 'on' %}
             {% set faellig = intervall > 0 and soc >= 0 and soc < 100 and counter >= intervall %}
             {% if intervall <= 0 %}Watchdog aus (Intervall 0)
             {%- elif soc < 0 %}opti_soc fehlt
             {%- elif soc >= 100 %}Akku voll (soc>=100)
             {%- elif not faellig %}nicht faellig ({{counter}}/{{intervall}} Tage)
             {%- elif day %}PV-Vollladung (tag, {{counter}} Tage seit voll)
-            {%- elif prog and hv_cur and cur < eeg %}Gratis-Netz ({{cur}}ct < EEG {{eeg}}ct)
-            {%- elif prog and counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct %}Bezahltes Netz ({{cur}}ct <= Deckel {{maxct}}ct, nach Karenz)
-            {%- elif not prog and (hv_cur and cur < eeg or counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct) %}Netz-Balancing gesperrt (opti_prognose_netzladen aus)
+            {%- elif bal_netz and hv_cur and cur < eeg %}Gratis-Netz ({{cur}}ct < EEG {{eeg}}ct)
+            {%- elif bal_netz and counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct %}Bezahltes Netz ({{cur}}ct <= Deckel {{maxct}}ct, nach Karenz)
+            {%- elif not bal_netz and (hv_cur and cur < eeg or counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct) %}Netz-Balancing gesperrt (opti_balancing_netzladen aus)
             {%- else %}warte auf besseres Fenster{% endif %}
           soc: "{{ states('sensor.opti_soc') }}"
           tage_seit_voll: "{{ states('counter.tage_seit_akku100') }}"

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -589,6 +589,70 @@ template:
           {% endif %}
 
       # -----------------------------------------------------------------------
+      # 7a. Balancing-/Deep-Charge-Watchdog (Feature #31) — READ-ONLY-Signal.
+      #    Feuert, wenn der Akku zu lange nicht ~voll war (counter
+      #    tage_seit_akku100 >= Intervall), damit das BMS des BYD HVS balancen/
+      #    kalibrieren kann. Ladeziel bewusst bis 100% (nicht nur bis maxsoc),
+      #    damit die Zelle in die CV-Phase kommt - deshalb greift der Watchdog
+      #    besonders im Sommer-Schonband (maxsoc<100), wo die Ziel-SoC-Treppe
+      #    100% nie erreicht. Rein abgeleitet -> restart-durabel (kein Latch).
+      #    State: 'aus' | 'pv' | 'netz'. Staffelung (Kosten aufsteigend):
+      #      1. tagsueber          -> 'pv'   (ganztags PV-bevorzugt, bewusst
+      #                                       simpel, kein PV>Haus-Gate im MVP)
+      #      2. Gratis-/Negativpreis (cur < EEG) -> 'netz'   (sofort, keine Karenz)
+      #      3. bezahlter Fallback -> 'netz'  (erst nach Karenz, nur VERY_CHEAP/
+      #                                       CHEAP UND cur <= absoluter Deckel,
+      #                                       Deckel 0 = aus = fail-safe)
+      #      sonst -> 'aus' (auf besseres Fenster warten).
+      #    Fail-safe: fehlt opti_soc (float(-1)) -> faellig false -> 'aus'.
+      #    Intervall 0 = Watchdog global aus.
+      # -----------------------------------------------------------------------
+      - unique_id: opti_balancing_watchdog
+        name: "Opti Balancing Watchdog"
+        icon: mdi:battery-heart-variant
+        state: >
+          {% set soc = states('sensor.opti_soc')|float(-1) %}
+          {% set counter = states('counter.tage_seit_akku100')|int(0) %}
+          {% set intervall = states('input_number.opti_balancing_intervall_tage')|int(0) %}
+          {% set karenz = states('input_number.opti_balancing_karenz_tage')|int(0) %}
+          {% set maxct = states('input_number.opti_balancing_max_ct')|float(0) %}
+          {% set cur = states('sensor.opti_price_current_ct_kwh')|float(0) %}
+          {% set hv_cur = has_value('sensor.opti_price_current_ct_kwh') %}
+          {% set eeg = states('input_number.opti_einspeiseverguetung_ct')|float(0) %}
+          {% set price = states('sensor.opti_price_level') %}
+          {% set day = is_state('sun.sun','above_horizon') %}
+          {% set faellig = intervall > 0 and soc >= 0 and soc < 100 and counter >= intervall %}
+          {% if not faellig %}aus
+          {%- elif day %}pv
+          {%- elif hv_cur and cur < eeg %}netz
+          {%- elif counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct %}netz
+          {%- else %}aus{% endif %}
+        attributes:
+          grund: >
+            {% set soc = states('sensor.opti_soc')|float(-1) %}
+            {% set counter = states('counter.tage_seit_akku100')|int(0) %}
+            {% set intervall = states('input_number.opti_balancing_intervall_tage')|int(0) %}
+            {% set karenz = states('input_number.opti_balancing_karenz_tage')|int(0) %}
+            {% set maxct = states('input_number.opti_balancing_max_ct')|float(0) %}
+            {% set cur = states('sensor.opti_price_current_ct_kwh')|float(0) %}
+            {% set hv_cur = has_value('sensor.opti_price_current_ct_kwh') %}
+            {% set eeg = states('input_number.opti_einspeiseverguetung_ct')|float(0) %}
+            {% set price = states('sensor.opti_price_level') %}
+            {% set day = is_state('sun.sun','above_horizon') %}
+            {% set faellig = intervall > 0 and soc >= 0 and soc < 100 and counter >= intervall %}
+            {% if intervall <= 0 %}Watchdog aus (Intervall 0)
+            {%- elif soc < 0 %}opti_soc fehlt
+            {%- elif soc >= 100 %}Akku voll (soc>=100)
+            {%- elif not faellig %}nicht faellig ({{counter}}/{{intervall}} Tage)
+            {%- elif day %}PV-Vollladung (tag, {{counter}} Tage seit voll)
+            {%- elif hv_cur and cur < eeg %}Gratis-Netz ({{cur}}ct < EEG {{eeg}}ct)
+            {%- elif counter >= intervall + karenz and hv_cur and price in ['VERY_CHEAP','CHEAP'] and maxct > 0 and cur <= maxct %}Bezahltes Netz ({{cur}}ct <= Deckel {{maxct}}ct, nach Karenz)
+            {%- else %}warte auf besseres Fenster{% endif %}
+          soc: "{{ states('sensor.opti_soc') }}"
+          tage_seit_voll: "{{ states('counter.tage_seit_akku100') }}"
+          intervall_tage: "{{ states('input_number.opti_balancing_intervall_tage') }}"
+
+      # -----------------------------------------------------------------------
       # 8. Strategie-Vorschau (Soll-Modus, READ-ONLY) — spiegelt die Entscheidungs-
       #    kette aus automations/opti_strategie.yaml, OHNE zu steuern. Vergleich
       #    Soll (state) vs Ist (input_select.akkusteuerung_modus, Attribut ist_modus).
@@ -638,6 +702,8 @@ template:
           {%- elif prog and aktiv and hv_cur and soc >= 0 and soc < ges_res - stopband and avg is not none and (avg - cur) >= spread and fenster %}Akku Netzladen
           {%- elif aktiv and soc >= 0 and price == 'VERY_EXPENSIVE' %}Akku nur Entladen
           {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and soc > ve_res + band %}Akku nur Entladen
+          {%- elif is_state('sensor.opti_balancing_watchdog','pv') %}Akku nur Laden
+          {%- elif is_state('sensor.opti_balancing_watchdog','netz') %}Akku Netzladen
           {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}Akku nur Laden
           {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}Akku nur Laden
           {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}Akku nur Laden
@@ -690,6 +756,8 @@ template:
             {%- elif prog and aktiv and hv_cur and soc >= 0 and soc < ges_res - stopband and avg is not none and (avg - cur) >= spread and fenster %}Peak-Vorladen (Spread {{(avg - cur)|round(1)}}ct, bis {{ges_res}}%)
             {%- elif aktiv and soc >= 0 and price == 'VERY_EXPENSIVE' %}Peak-Leiter L1 (VE entladen)
             {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and soc > ve_res + band %}Peak-Leiter L2 (EXP entladen, ueber VE-Reserve {{ve_res}}%)
+            {%- elif is_state('sensor.opti_balancing_watchdog','pv') %}Balancing-Watchdog (PV-Vollladung)
+            {%- elif is_state('sensor.opti_balancing_watchdog','netz') %}Balancing-Watchdog (Netz-Vollladung)
             {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}SOC<20 Prognose (heute+morgen schlecht)
             {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}SOC<75 Prognose (Preis bis NORMAL)
             {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}SOC<80 Wintermodus

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -331,6 +331,17 @@ input_boolean:
     # Gate für die PV-/AC-Überschussblöcke (Akku Dynamisch). Default an.
     icon: mdi:solar-power
 
+  opti_balancing_netzladen:
+    name: "Opti Balancing darf ans Netz"
+    # Eigener Schalter für den Balancing-/Deep-Charge-Watchdog (Feature #31):
+    # erlaubt dem Watchdog, den Akku fürs BMS-Balancing auch AUS DEM NETZ
+    # hochzuladen (Gratis-/Negativpreis + bezahlter Fallback unter Deckel).
+    # Bewusst entkoppelt von opti_prognose_netzladen, damit die harte
+    # Netzlade-Garantie (#26) erhalten bleibt. Default AUS (fail-safe): ohne
+    # diesen Schalter balancet der Watchdog rein per PV. PV-Balancing läuft
+    # unabhängig davon immer, solange das Intervall > 0 ist.
+    icon: mdi:battery-heart-variant
+
 counter:
   tage_seit_akku100:
     name: "Tage seit Akku 100%"

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -244,6 +244,60 @@ input_number:
     mode: box
     icon: mdi:hand-back-right-outline
 
+  # --- Balancing-/Deep-Charge-Watchdog (Feature #31) ---
+  # Laedt den Akku gezielt einmalig auf ~100%, wenn er zu lange nicht mehr voll
+  # war, damit das BMS balancen/kalibrieren kann. Rein abgeleitet ueber
+  # sensor.opti_balancing_watchdog (kein gelatchtes Flag -> restart-durabel).
+  opti_balancing_intervall_tage:
+    name: "Opti Balancing Intervall"
+    # Tage ohne Voll-/Done-Ladung, ab denen der Watchdog faellig wird.
+    # Dokumentierter Startwert 14; 0 = Watchdog komplett aus (Erststart-Wert
+    # ohne initial = Minimum 0 = fail-safe aus). Nach Anlegen auf 14 setzen.
+    min: 0
+    max: 60
+    step: 1
+    unit_of_measurement: "Tage"
+    mode: box
+    icon: mdi:calendar-refresh
+
+  opti_balancing_karenz_tage:
+    name: "Opti Balancing Karenz"
+    # Zusaetzliche Karenz-Tage nach Faelligkeit, bevor der bezahlte Netz-
+    # Fallback (guenstiges Netzladen) erlaubt wird. Startwert 3.
+    min: 0
+    max: 14
+    step: 1
+    unit_of_measurement: "Tage"
+    mode: box
+    icon: mdi:timer-sand
+
+  opti_balancing_max_ct:
+    name: "Opti Balancing Preisdeckel"
+    # Absoluter Brutto-Preisdeckel (ct/kWh) fuers bezahlte Balancing-Netzladen.
+    # Erststart 0 = fail-safe = KEIN bezahltes Netzladen (nur PV + Gratis-/
+    # Negativ-Netz). Nach Anlegen auf 25 setzen; 0 laesst den bezahlten
+    # Netz-Fallback aus.
+    min: 0
+    max: 50
+    step: 0.5
+    unit_of_measurement: ct/kWh
+    mode: box
+    icon: mdi:cash-lock
+
+  opti_balancing_done_soc:
+    name: "Opti Balancing Done-SoC"
+    # Schwelle (%), ab der ein Balancing-Zyklus als erledigt gilt: der Counter
+    # tage_seit_akku100 wird ab hier (30 min stabil) zurueckgesetzt, das
+    # taegliche Increment zaehlt nur unterhalb weiter. HIER ist 0 NICHT
+    # fail-safe, daher expliziter initial-Wert.
+    initial: 98.5
+    min: 90
+    max: 100
+    step: 0.5
+    unit_of_measurement: "%"
+    mode: box
+    icon: mdi:battery-heart-variant
+
 input_boolean:
   akku_opti_automatik:
     name: "Akku Opti-Automatik"

--- a/tests/test_strategie_paritaet.py
+++ b/tests/test_strategie_paritaet.py
@@ -1,14 +1,14 @@
 """Paritaets-Test: echte Steuer-Automation vs. Spiegel-Sensor.
 
 Die Steuerung lebt in automations/opti_strategie.yaml (action-Alias
-"Zwischen Speicherszenarien waehlen": choose-Kette mit 17 Optionen + default).
+"Zwischen Speicherszenarien waehlen": choose-Kette mit 19 Optionen + default).
 Ihr Spiegel ist der Vorschau-Sensor opti_strategie_vorschau in
 packages/opti_derived.yaml (state-if/elif-Kette + grund-Attribut). Der
 YAML-Kommentar verlangt manuelle Spiegelung ("MUSS mitgespiegelt werden") -
 ohne diesen Test laesst eine Aenderung an der Automation alle Tests gruen,
 obwohl die Steuerung von der Vorschau abweicht.
 
-Der Test baut fuer JEDE der 17 choose-Optionen + den Default eine Fixture
+Der Test baut fuer JEDE der 19 choose-Optionen + den Default eine Fixture
 (FakeHass-Zustand), die genau diesen Zweig trifft, und prueft:
   (i)   Automation-choose-Kette (eigener Evaluator) -> getroffener Zweig-Index
         + gesetzter Modus.
@@ -16,7 +16,7 @@ Der Test baut fuer JEDE der 17 choose-Optionen + den Default eine Fixture
   Assert: Modus identisch UND der getroffene Zweig ist der beabsichtigte
   (Index der choose-Option == Position des grund-Labels).
 Ein Struktur-Assert koppelt die Zahl der choose-Optionen an die Zahl der vom
-Test abgedeckten Zweige: wer eine 18. Option ergaenzt, ohne den Test zu
+Test abgedeckten Zweige: wer eine 20. Option ergaenzt, ohne den Test zu
 erweitern, bricht hier hart.
 
 Bewusst ignoriert: Trigger und die Top-Level-condition der Automation
@@ -24,7 +24,7 @@ Bewusst ignoriert: Trigger und die Top-Level-condition der Automation
 Booster-Aus). Fuer die Paritaet zaehlt ausschliesslich die Modus-Wahl in der
 choose-Kette der Action "Zwischen Speicherszenarien waehlen".
 
-Bekannte, GEWOLLTE Aequivalenz (kein Fail): die Vorschau-L3 (Zweig 13) laesst
+Bekannte, GEWOLLTE Aequivalenz (kein Fail): die Vorschau-L3 (Zweig 15) laesst
 die Bedingung 'soc <= ve_res + band' weg, die in der Automation-L3 explizit
 steht. Das ist aequivalent, weil fuer soc > ve_res + band bei EXPENSIVE bereits
 der davorstehende L2-Zweig (Index 4) in BEIDEN Seiten entladen haette; die
@@ -131,52 +131,58 @@ BRANCHES = [
      {**LEITER_BASE, "sensor.opti_soc": "85", "sensor.opti_price_level": "EXPENSIVE",
       "_attrs": reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0)},
      "Akku nur Entladen", "Peak-Leiter L2"),
-    (5, "soc20_prognose",
+    (5, "balancing_watchdog_pv",
+     {"sensor.opti_balancing_watchdog": "pv"},
+     "Akku nur Laden", "Balancing-Watchdog (PV"),
+    (6, "balancing_watchdog_netz",
+     {"sensor.opti_balancing_watchdog": "netz"},
+     "Akku Netzladen", "Balancing-Watchdog (Netz"),
+    (7, "soc20_prognose",
      {"sensor.opti_soc": "18", "sensor.opti_forecast_score": "1",
       "sensor.opti_forecast_score_tomorrow": "1", "sensor.opti_price_level": "NORMAL"},
      "Akku nur Laden", "SOC<20"),
-    (6, "soc75_prognose",
+    (8, "soc75_prognose",
      {"sensor.opti_soc": "50", "sensor.opti_forecast_score": "1",
       "sensor.opti_forecast_score_tomorrow": "1", "sensor.opti_price_level": "NORMAL"},
      "Akku nur Laden", "SOC<75"),
-    (7, "soc80_wintermodus",
+    (9, "soc80_wintermodus",
      {"sensor.opti_soc": "78", "sensor.opti_forecast_score": "1",
       "sensor.opti_forecast_score_tomorrow": "1", "sensor.opti_price_level": "EXPENSIVE"},
      "Akku nur Laden", "SOC<80 Wintermodus"),
-    (8, "soc15_notfall",
+    (10, "soc15_notfall",
      {"sensor.opti_soc": "12", "sensor.opti_forecast_score": "1",
       "sensor.opti_price_level": "NORMAL"},
      "Akku nur Laden", "SOC<15 Notfall"),
-    (9, "soc45_sehr_guenstig",
+    (11, "soc45_sehr_guenstig",
      {"sensor.opti_soc": "30", "sensor.opti_forecast_score": "1",
       "sensor.opti_price_level": "CHEAP"},
      "Akku nur Laden", "SOC<45"),
-    (10, "ueberschuss_70",
+    (12, "ueberschuss_70",
      {"sun.sun": "above_horizon", "sensor.opti_soc": "70", "sensor.opti_target_soc": "50",
       "binary_sensor.opti_ueberschuss_70_aktiv": "on"},
      "Akku Dynamisch", "70% Ueberschuss"),
-    (11, "ueberschuss_ac",
+    (13, "ueberschuss_ac",
      {"sun.sun": "above_horizon", "sensor.opti_soc": "70", "sensor.opti_target_soc": "50",
       "binary_sensor.opti_ueberschuss_ac_aktiv": "on"},
      "Akku Dynamisch", "AC Ueberschuss"),
-    (12, "akku_voll",
+    (14, "akku_voll",
      {"sensor.opti_soc": "100"},
      "Akku Dynamisch", "Akku voll"),
-    (13, "leiter_l3_halten",
+    (15, "leiter_l3_halten",
      {**LEITER_BASE, "sensor.opti_soc": "31", "sensor.opti_price_level": "EXPENSIVE",
       "input_boolean.opti_prognose_netzladen": "off",
       "input_number.opti_halte_spread_ct": "3",
       "_attrs": reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0, ve_avg=55.0)},
      "Akku nur Laden", "Peak-Leiter L3"),
-    (14, "leiter_l4_halten",
+    (16, "leiter_l4_halten",
      {**LEITER_BASE, "sensor.opti_soc": "40", "sensor.opti_price_level": "NORMAL",
       "input_boolean.opti_prognose_netzladen": "off",
       "_attrs": reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0)},
      "Akku nur Laden", "Peak-Leiter L4"),
-    (15, "dyn_bis_ziel",
+    (17, "dyn_bis_ziel",
      {"sun.sun": "above_horizon", "sensor.opti_soc": "40", "sensor.opti_target_soc": "60"},
      "Akku Dynamisch", "dyn bis Ziel"),
-    (16, "ueber_ziel_soc",
+    (18, "ueber_ziel_soc",
      {"sensor.opti_soc": "70", "sensor.opti_target_soc": "60"},
      "Akku nur Entladen", "ueber Ziel-SoC"),
 ]

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -382,7 +382,9 @@ WD_BASIS = {
     "input_number.opti_einspeiseverguetung_ct": "8",
     "sensor.opti_price_current_ct_kwh": "30",
     "sensor.opti_price_level": "NORMAL",
-    "input_boolean.opti_prognose_netzladen": "on",
+    # Eigener Wartungs-Schalter fuers Balancing-Netzladen (entkoppelt von
+    # opti_prognose_netzladen). Default aus; hier an, damit die netz-Faelle greifen.
+    "input_boolean.opti_balancing_netzladen": "on",
     "sun.sun": "below_horizon",
 }
 
@@ -484,28 +486,38 @@ def test_watchdog_intervall_null_global_aus():
                        "sun.sun": "above_horizon"}) == "aus"
 
 
-# Netzlade-Gate: 'netz' respektiert input_boolean.opti_prognose_netzladen.
-def test_watchdog_netz_respektiert_prognose_gate():
-    # Gratis-Netz (cur 3 < EEG 8) waere 'netz', aber prog off -> 'aus'
-    # (harte Garantie gegen jedes Netzladen).
+# Netzlade-Gate: 'netz' respektiert den EIGENEN Schalter opti_balancing_netzladen
+# (entkoppelt von opti_prognose_netzladen). Default aus -> Balancing rein per PV.
+def test_watchdog_netz_respektiert_balancing_schalter():
+    # Gratis-Netz (cur 3 < EEG 8) waere 'netz', aber Schalter aus -> 'aus'
+    # (harte Netzlade-Garantie bleibt erhalten).
     fall = {"sun.sun": "below_horizon", "sensor.opti_price_current_ct_kwh": "3"}
-    assert watchdog(**{**fall, "input_boolean.opti_prognose_netzladen": "off"}) == "aus"
-    # Gegentest: prog on -> 'netz'.
-    assert watchdog(**{**fall, "input_boolean.opti_prognose_netzladen": "on"}) == "netz"
+    assert watchdog(**{**fall, "input_boolean.opti_balancing_netzladen": "off"}) == "aus"
+    # Gegentest: Schalter an -> 'netz'.
+    assert watchdog(**{**fall, "input_boolean.opti_balancing_netzladen": "on"}) == "netz"
 
 
-def test_watchdog_bezahltes_netz_respektiert_prognose_gate():
-    # Auch der bezahlte Fallback ist gegated.
+def test_watchdog_bezahltes_netz_respektiert_balancing_schalter():
+    # Auch der bezahlte Fallback haengt am eigenen Schalter.
     fall = {"sun.sun": "below_horizon", "counter.tage_seit_akku100": "17",
             "sensor.opti_price_level": "CHEAP", "sensor.opti_price_current_ct_kwh": "20"}
-    assert watchdog(**{**fall, "input_boolean.opti_prognose_netzladen": "off"}) == "aus"
-    assert watchdog(**{**fall, "input_boolean.opti_prognose_netzladen": "on"}) == "netz"
+    assert watchdog(**{**fall, "input_boolean.opti_balancing_netzladen": "off"}) == "aus"
+    assert watchdog(**{**fall, "input_boolean.opti_balancing_netzladen": "on"}) == "netz"
 
 
-def test_watchdog_pv_ungegatet_von_prognose():
-    # 'pv' zieht keinen Netzstrom -> vom Netzlade-Gate unberuehrt.
+def test_watchdog_netz_unabhaengig_von_prognose_gate():
+    # Der Balancing-Netzschalter ist ENTKOPPELT von opti_prognose_netzladen:
+    # Balancing darf ans Netz, auch wenn die allgemeine Prognose-Netzladung aus ist.
+    fall = {"sun.sun": "below_horizon", "sensor.opti_price_current_ct_kwh": "3",
+            "input_boolean.opti_balancing_netzladen": "on",
+            "input_boolean.opti_prognose_netzladen": "off"}
+    assert watchdog(**fall) == "netz"
+
+
+def test_watchdog_pv_ungegatet_vom_netzschalter():
+    # 'pv' zieht keinen Netzstrom -> vom Netzlade-Schalter unberuehrt.
     assert watchdog(**{"sun.sun": "above_horizon",
-                       "input_boolean.opti_prognose_netzladen": "off"}) == "pv"
+                       "input_boolean.opti_balancing_netzladen": "off"}) == "pv"
 
 
 # Vorschau-Mapping direkt: pv -> nur Laden, netz -> Netzladen.

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -371,6 +371,7 @@ def test_ueberschuss_binary_unavailable_ist_aus():
 # ihn dann in die Vorschau (wie live: Sensor -> Strategie).
 
 # Basis fuer den Watchdog-Sensor: faellig (Intervall 14, counter 14, soc 40<100).
+# prog='on': das Netzlade-Gate ist offen, damit die 'netz'-Zweige greifen koennen.
 WD_BASIS = {
     "sensor.opti_soc": "40",
     "counter.tage_seit_akku100": "14",
@@ -381,6 +382,7 @@ WD_BASIS = {
     "input_number.opti_einspeiseverguetung_ct": "8",
     "sensor.opti_price_current_ct_kwh": "30",
     "sensor.opti_price_level": "NORMAL",
+    "input_boolean.opti_prognose_netzladen": "on",
     "sun.sun": "below_horizon",
 }
 
@@ -480,6 +482,30 @@ def test_watchdog_maxct_null_kein_bezahltes_netz():
 def test_watchdog_intervall_null_global_aus():
     assert watchdog(**{"input_number.opti_balancing_intervall_tage": "0",
                        "sun.sun": "above_horizon"}) == "aus"
+
+
+# Netzlade-Gate: 'netz' respektiert input_boolean.opti_prognose_netzladen.
+def test_watchdog_netz_respektiert_prognose_gate():
+    # Gratis-Netz (cur 3 < EEG 8) waere 'netz', aber prog off -> 'aus'
+    # (harte Garantie gegen jedes Netzladen).
+    fall = {"sun.sun": "below_horizon", "sensor.opti_price_current_ct_kwh": "3"}
+    assert watchdog(**{**fall, "input_boolean.opti_prognose_netzladen": "off"}) == "aus"
+    # Gegentest: prog on -> 'netz'.
+    assert watchdog(**{**fall, "input_boolean.opti_prognose_netzladen": "on"}) == "netz"
+
+
+def test_watchdog_bezahltes_netz_respektiert_prognose_gate():
+    # Auch der bezahlte Fallback ist gegated.
+    fall = {"sun.sun": "below_horizon", "counter.tage_seit_akku100": "17",
+            "sensor.opti_price_level": "CHEAP", "sensor.opti_price_current_ct_kwh": "20"}
+    assert watchdog(**{**fall, "input_boolean.opti_prognose_netzladen": "off"}) == "aus"
+    assert watchdog(**{**fall, "input_boolean.opti_prognose_netzladen": "on"}) == "netz"
+
+
+def test_watchdog_pv_ungegatet_von_prognose():
+    # 'pv' zieht keinen Netzstrom -> vom Netzlade-Gate unberuehrt.
+    assert watchdog(**{"sun.sun": "above_horizon",
+                       "input_boolean.opti_prognose_netzladen": "off"}) == "pv"
 
 
 # Vorschau-Mapping direkt: pv -> nur Laden, netz -> Netzladen.

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -24,6 +24,8 @@ BASIS = {
     "input_boolean.opti_pv_ueberschuss_ladung": "on",
     "input_select.akkusteuerung_modus": "Akku Dynamisch",
     "sun.sun": "below_horizon",
+    # Balancing-Watchdog default aus (feuert nur, wenn Fixture ihn setzt).
+    "sensor.opti_balancing_watchdog": "aus",
 }
 
 
@@ -360,3 +362,129 @@ def test_ueberschuss_binary_unavailable_ist_aus():
     g = grund(**{**UEBERSCHUSS_TAG,
                  "binary_sensor.opti_ueberschuss_70_aktiv": "unavailable"})
     assert "Ueberschuss" not in g
+
+
+# --- Feature #31: Balancing-/Deep-Charge-Watchdog ---
+# Zwei Ebenen: (1) der abgeleitete sensor.opti_balancing_watchdog (aus/pv/netz)
+# aus den Rohwerten, (2) die Vorschau-Kaskade, die diesen State auf einen Modus
+# abbildet. Die End-to-End-Faelle rechnen zuerst den Watchdog-State und speisen
+# ihn dann in die Vorschau (wie live: Sensor -> Strategie).
+
+# Basis fuer den Watchdog-Sensor: faellig (Intervall 14, counter 14, soc 40<100).
+WD_BASIS = {
+    "sensor.opti_soc": "40",
+    "counter.tage_seit_akku100": "14",
+    "input_number.opti_balancing_intervall_tage": "14",
+    "input_number.opti_balancing_karenz_tage": "3",
+    "input_number.opti_balancing_max_ct": "25",
+    "input_number.opti_balancing_done_soc": "98.5",
+    "input_number.opti_einspeiseverguetung_ct": "8",
+    "sensor.opti_price_current_ct_kwh": "30",
+    "sensor.opti_price_level": "NORMAL",
+    "sun.sun": "below_horizon",
+}
+
+
+def watchdog(**overrides):
+    states = dict(WD_BASIS)
+    states.update(overrides)
+    hass = FakeHass(states=states)
+    cfg = load_yaml(REPO / "packages" / "opti_derived.yaml")
+    entity = find_template_entity(cfg, "sensor", "opti_balancing_watchdog")
+    return render(hass, entity["state"])
+
+
+def vorschau_e2e(**overrides):
+    """End-to-End: Watchdog-State berechnen und in die Vorschau einspeisen."""
+    wd = watchdog(**overrides)
+    return vorschau(**{**overrides, "sensor.opti_balancing_watchdog": wd})
+
+
+# (a) faellig + Tag -> PV -> Vorschau "Akku nur Laden"
+def test_watchdog_tag_pv():
+    assert watchdog(**{"sun.sun": "above_horizon"}) == "pv"
+    assert vorschau_e2e(**{"sun.sun": "above_horizon"}) == "Akku nur Laden"
+
+
+# (b) faellig + Nacht + cur < eeg -> Gratis-Netz -> "Akku Netzladen"
+def test_watchdog_gratis_netz():
+    fall = {"sun.sun": "below_horizon", "sensor.opti_price_current_ct_kwh": "3"}
+    assert watchdog(**fall) == "netz"
+    assert vorschau_e2e(**fall) == "Akku Netzladen"
+
+
+# (c) faellig + Nacht + nach Karenz + CHEAP + cur <= maxct -> bezahltes Netz
+def test_watchdog_bezahltes_netz_nach_karenz():
+    fall = {"sun.sun": "below_horizon", "counter.tage_seit_akku100": "17",
+            "sensor.opti_price_level": "CHEAP",
+            "sensor.opti_price_current_ct_kwh": "20"}
+    assert watchdog(**fall) == "netz"
+    assert vorschau_e2e(**fall) == "Akku Netzladen"
+
+
+# (d) faellig + Nacht + CHEAP + cur > maxct -> faellt durch (kein Netzladen)
+def test_watchdog_ueber_deckel_faellt_durch():
+    fall = {"sun.sun": "below_horizon", "counter.tage_seit_akku100": "17",
+            "sensor.opti_price_level": "CHEAP",
+            "sensor.opti_price_current_ct_kwh": "30"}  # > maxct 25
+    assert watchdog(**fall) == "aus"
+
+
+# (e) faellig + Nacht + vor Karenz -> kein bezahltes Netzladen
+def test_watchdog_vor_karenz_kein_bezahltes_netz():
+    # counter 14 = faellig, aber < intervall+karenz (17) -> CHEAP-Fallback aus.
+    fall = {"sun.sun": "below_horizon", "counter.tage_seit_akku100": "14",
+            "sensor.opti_price_level": "CHEAP",
+            "sensor.opti_price_current_ct_kwh": "20"}
+    assert watchdog(**fall) == "aus"
+
+
+# (f) counter < intervall -> Watchdog aus
+def test_watchdog_nicht_faellig():
+    assert watchdog(**{"counter.tage_seit_akku100": "13",
+                       "sun.sun": "above_horizon"}) == "aus"
+
+
+# (g) soc >= 100 -> Watchdog aus (auch bei Tag/faelligem Counter)
+def test_watchdog_akku_voll_aus():
+    assert watchdog(**{"sensor.opti_soc": "100",
+                       "sun.sun": "above_horizon"}) == "aus"
+
+
+# (h) L1/L2-Peak schlaegt den Watchdog (Watchdog steht in der Kaskade dahinter)
+def test_watchdog_peak_hat_vorrang():
+    # Watchdog waere 'netz' (Nacht, cur<eeg), aber ein aktiver VERY_EXPENSIVE-Peak
+    # (L1) steht davor -> "Akku nur Entladen".
+    fall = {"sun.sun": "below_horizon", "sensor.opti_price_current_ct_kwh": "3",
+            "sensor.opti_soc": "85", "sensor.opti_price_level": "VERY_EXPENSIVE",
+            "binary_sensor.opti_peak_reserve_aktiv": "on",
+            "sensor.opti_peak_reserve_soc": "45",
+            "_attrs": reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0)}
+    assert watchdog(**{k: v for k, v in fall.items() if k != "_attrs"}) == "netz"
+    out = vorschau(**{**fall, "sensor.opti_balancing_watchdog": "netz"})
+    assert out == "Akku nur Entladen"
+
+
+# (i) maxct = 0 -> kein bezahltes Netzladen (fail-safe Erststart)
+def test_watchdog_maxct_null_kein_bezahltes_netz():
+    # cur 20 >= EEG 8, damit NICHT der Gratis-Netz-Zweig greift und wirklich der
+    # bezahlte Fallback getestet wird: maxct 0 -> kein Netzladen.
+    fall = {"sun.sun": "below_horizon", "counter.tage_seit_akku100": "17",
+            "sensor.opti_price_level": "CHEAP",
+            "sensor.opti_price_current_ct_kwh": "20",
+            "input_number.opti_balancing_max_ct": "0"}
+    assert watchdog(**fall) == "aus"
+
+
+# Intervall 0 -> Watchdog global aus (auch bei faelligem Counter)
+def test_watchdog_intervall_null_global_aus():
+    assert watchdog(**{"input_number.opti_balancing_intervall_tage": "0",
+                       "sun.sun": "above_horizon"}) == "aus"
+
+
+# Vorschau-Mapping direkt: pv -> nur Laden, netz -> Netzladen.
+def test_watchdog_vorschau_mapping():
+    assert vorschau(**{"sensor.opti_balancing_watchdog": "pv"}) == "Akku nur Laden"
+    assert vorschau(**{"sensor.opti_balancing_watchdog": "netz"}) == "Akku Netzladen"
+    assert "Balancing-Watchdog (PV" in grund(**{"sensor.opti_balancing_watchdog": "pv"})
+    assert "Balancing-Watchdog (Netz" in grund(**{"sensor.opti_balancing_watchdog": "netz"})


### PR DESCRIPTION
Schließt #31. Saison-übergreifender Watchdog, der den Akku (BYD HVS) gezielt einmalig hochlädt, wenn er zu lange nicht ~voll war - damit das BMS balancen/kalibrieren kann. Greift v.a. bei `maxsoc < 100` (Sommer-Schonband), wo die Ziel-SoC-Treppe 100% nie erreicht.

## Design
- **Rein abgeleiteter `sensor.opti_balancing_watchdog`** (`aus`/`pv`/`netz`) - kein gelatchtes Flag, restart-durabel. Fälligkeit = `intervall>0 AND soc<100 AND counter>=intervall`.
- **Zwei dünne Kaskaden-Zweige** (nach Peak-Leiter L2, vor den Prognose-Ladeblöcken), identisch in Vorschau (`opti_derived.yaml`) und Steuer-Automation (`opti_strategie.yaml`). Aktiver Preis-Peak schlägt den Watchdog.
- **Lade-Staffelung (Kosten aufsteigend):** tagsüber PV-Vollladung → Gratis-/Negativpreis-Netz → bezahlter Netz-Fallback (erst nach Karenz, nur `VERY_CHEAP`/`CHEAP` UND unter absolutem ct-Deckel).
- **Netz-Balancing respektiert `opti_prognose_netzladen`** - die harte Netzlade-Garantie aus #26 bleibt gültig. PV-Balancing läuft immer.
- **Zähler-Pflege** in `opti_balancing_counter.yaml`: tägliches Increment (23:59, wenn `soc < done_soc`) + Reset über einen `numeric_state`-Trigger mit `for: 30min` (zuverlässiger als `for:` auf einer Condition).

## Neue Helper (Erststart fail-safe)
| Helper | Startwert | |
|---|---|---|
| `opti_balancing_intervall_tage` | 14 (0 = aus) | Tage bis fällig |
| `opti_balancing_karenz_tage` | 3 | Karenz vor bezahltem Netz |
| `opti_balancing_max_ct` | 25 (0 = kein bezahltes Netz) | absoluter Preisdeckel |
| `opti_balancing_done_soc` | 98.5 (`initial`) | Done-/Reset-Schwelle |

## Tests & Review
- **164 passed, 2 skipped** (+16). Paritäts-Suite grün (19==19), jinja2-Parse-Check sauber.
- Design mit Fable + Codex gebrainstormt; Implementierung von Codex reviewt. Drei Findings gefixt: Netz-Gate (`prog`), robuster Trigger-Reset statt `for:`-Condition, Test für die Gate-Sperre.

## ⚠️ Deploy-Hinweis
Beim Ausrollen die **verwaiste Live-Increment-Automation `1757419369851`** durch `automations/opti_balancing_counter.yaml` ersetzen (bringt jetzt Increment **und** Reset), sonst zählt der Counter doppelt, sobald der Helper existiert. Erststart-Werte setzen: `intervall` 14, `karenz` 3, `max_ct` 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)