### PR TITLE
fix: Anti-Flatter-Hysterese am Ziel-SoC-Entladezweig

### DIFF
--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -661,13 +661,18 @@
         # Modus-Set-Zweig: nur Entladen wenn SOC über Ziel-SoC.
         - alias: "Modus 'nur Entladen': SOC über Ziel-SoC"
           conditions:
-            # Band H=3 %: nur Entladen erst wenn soc > target + H (Template, da Offset).
+            # Band H=3 %: rein bei soc > target + 3. Asymmetrische Hysterese gegen
+            # Ziel-SoC-Flattern: ist der Modus schon 'Akku nur Entladen', bleibt er
+            # bis soc <= target (Offset 0) drin. Sonst flippt er mittags im
+            # Minutentakt Entladen<->Dynamisch, weil das Entladen selbst den SoC
+            # wieder unter die Kante zieht und PV ihn sofort erneut drueber drueckt.
             - condition: template
               value_template: >-
+                {% set off = 0 if is_state('input_select.akkusteuerung_modus', 'Akku nur Entladen') else 3 %}
                 {{ has_value('sensor.opti_soc')
                    and has_value('sensor.opti_battery_capacity_kwh')
                    and has_value('sensor.opti_target_soc')
-                   and (states('sensor.opti_soc') | float) > (states('sensor.opti_target_soc') | float + 3) }}
+                   and (states('sensor.opti_soc') | float) > (states('sensor.opti_target_soc') | float + off) }}
           sequence:
             - action: input_select.select_option
               data:

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -723,7 +723,12 @@ template:
           {%- elif aktiv and hv_cur and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Akku nur Laden
           {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Akku nur Laden
           {%- elif soc > minsoc and soc < target - H and day %}Akku Dynamisch
-          {%- elif soc > target + H %}Akku nur Entladen
+          {# Asymmetrische Hysterese gegen Ziel-SoC-Flattern (v.a. mittags, wenn
+             PV den SoC ueber die Schwelle drueckt): rein bei target+H, drin
+             bleiben bis target. Ohne das flippt der Modus im Minutentakt
+             Entladen<->Dynamisch, weil das Entladen selbst den SoC wieder
+             unter die Kante zieht. #}
+          {%- elif soc > target + (0 if is_state('input_select.akkusteuerung_modus','Akku nur Entladen') else H) %}Akku nur Entladen
           {%- elif soc >= 0 %}Akku Dynamisch
           {%- else %}unbekannt{% endif %}
         attributes:
@@ -777,7 +782,7 @@ template:
             {%- elif aktiv and hv_cur and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Peak-Leiter L3 (halten fuer VE, Reserve {{ve_res}}%, Spread {{(ve_avg - cur)|round(1)}}ct)
             {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Peak-Leiter L4 (halten fuer Peaks, Reserve {{ges_res}}%)
             {%- elif soc > minsoc and soc < target - H and day %}dyn bis Ziel (tag)
-            {%- elif soc > target + H %}ueber Ziel-SoC
+            {%- elif soc > target + (0 if is_state('input_select.akkusteuerung_modus','Akku nur Entladen') else H) %}ueber Ziel-SoC
             {%- elif soc >= 0 %}Default (Nacht/keine Aktion)
             {%- else %}opti_soc fehlt{% endif %}
           ist_modus: "{{ states('input_select.akkusteuerung_modus') }}"

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -275,6 +275,27 @@ def test_l4_normal_mit_genug_reserve_normalbetrieb():
                                      _attrs=LEITER_ATTRS)
 
 
+# --- Ziel-SoC-Anti-Flatter: asymmetrische Hysterese am "ueber Ziel"-Zweig ---
+def test_ueber_ziel_hysterese_deadband():
+    # soc 61 knapp ueber Ziel 60, Modus NICHT 'nur Entladen':
+    # Eintrittsschwelle target+3=63 noch nicht erreicht -> kein Entladen.
+    assert vorschau(**{"sensor.opti_soc": "61"}) == "Akku Dynamisch"
+
+
+def test_ueber_ziel_hysterese_sticky():
+    # Gleicher SoC 61, aber Modus schon 'Akku nur Entladen': Offset 0 ->
+    # bleibt entladen bis target erreicht ist (verhindert Minutentakt-Flattern).
+    assert vorschau(**{"sensor.opti_soc": "61",
+                       "input_select.akkusteuerung_modus": "Akku nur Entladen"}) == "Akku nur Entladen"
+
+
+def test_ueber_ziel_eintritt_unveraendert():
+    # Eintrittsschwelle unveraendert: soc 64 > 60+3 -> Entladen, egal welcher Modus.
+    assert vorschau(**{"sensor.opti_soc": "64"}) == "Akku nur Entladen"
+    assert vorschau(**{"sensor.opti_soc": "64",
+                       "input_select.akkusteuerung_modus": "Akku nur Entladen"}) == "Akku nur Entladen"
+
+
 def test_leiter_inaktiv_ohne_gate():
     out = grund(**{**LEITER, "sensor.opti_price_level": "EXPENSIVE",
                    "sensor.opti_soc": "31",


### PR DESCRIPTION
Behebt das Modus-Flappen (Entladen<->Dynamisch im Minutentakt), das v.a. mittags auftrat.

## Ursache
Der Zweig `soc > target + 3 -> Akku nur Entladen` hatte nur **eine** Schwelle. Das Entladen zieht den SoC selbst unter `target+3`, PV drückt ihn sofort wieder drüber -> Oszillation an der Kante (live gemessen: ~40 Moduswechsel zwischen 10:50-13:20).

## Fix
Asymmetrische, modus-sticky Hysterese (Muster wie `band = 5/3` bei der Peak-Leiter):
- **Eintritt** unverändert bei `soc > target + 3`
- **Drin bleiben** bis `soc <= target` (Offset 0), solange der Modus schon `Akku nur Entladen` ist

Damit muss der SoC ein volles 3%-Band durchlaufen, bevor neu geschaltet wird -> das schnelle Kanten-Zittern verschwindet. Gespiegelt in Vorschau (`state` + `grund`) und Steuer-Automation.

## Tests & Review
- **170 pytest passed** (+3: Deadband, Sticky, Eintritt), Paritäts-Suite grün.
- Codex-Review: Logik an allen 3 Stellen konsistent; benigner Randfall benannt (Sticky-Offset keyt auf Modus-State, nicht -Grund -> nach einem Peak entlädt es die letzten 0-3% bis `target`, was dem Zweck des Zweigs entspricht; reintroduziert **nicht** das schnelle Flappen).

## Deploy
Bereits live (2026-07-08, template.reload + automation.reload, kein Neustart). opti_strategie.yaml live hand-gemergt (Package-Format), opti_derived.yaml aus dem Branch. Backups: `*.bak_20260708_hysterese`.

## Bekannter Rest
Eine langsame ~3%-Restschwingung bleibt möglich, wenn PV den SoC mittags aktiv über `target` lädt - viel seltener/langsamer, benigne. Falls störend: nächster Schritt wäre ein PV-Überschuss-Guard (kein Entladen-über-Ziel bei aktiver PV-Ladung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)