### PR TITLE
feat: KI-Analyse-Schicht Phase 1 (Tagesreport + Anomalie-Alert)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Verzeichnis kopieren:
 | `sma_helpers.yaml` | alle `input_select`/`input_number`/`input_boolean`/`counter` (Modus, Sollwerte, SoC-Grenzen …) |
 | `sma_templates.yaml` | **optional** — nur für Sollkurve-/Abregelungs-Anzeige (Legacy), enthält Platzhalter-Entity-IDs: ersetzen oder ganz weglassen |
 | `sma_statistik.yaml` | gleitende Mittelwerte (Verbrauch, Batterielast) |
+| `opti_ki_analyse.yaml` | **optional** — täglicher KI-Tagesreport per `ai_task.generate_data`, rein lesend; Details siehe [docs/canonical-layer.md](docs/canonical-layer.md#ki-analyse-schicht-optional-phase-1) |
 
 **4. Home Assistant neu starten** → Helfer, Templates, Statistik & Modbus sind da.
 

--- a/automations/opti_ki_analyse.yaml
+++ b/automations/opti_ki_analyse.yaml
@@ -171,3 +171,35 @@
           data:
             title: "🔋🤖 Akku-Tagesreport ({{ now().strftime('%d.%m.') }})"
             message: "{{ analyse.data.zusammenfassung }}"
+
+- id: "opti_ki_watchdog"
+  alias: "KI | Opti Analyse-Watchdog"
+  description: >-
+    Deterministischer Watchdog gegen stilles Sterben der KI-Analyse: meldet,
+    wenn der letzte erfolgreiche Lauf aelter als 3 Tage ist. Laeuft maximal
+    einmal taeglich, beruehrt den Regelkreis nicht. Beim Deploy wird
+    opti_ki_last_success einmalig auf den Aktivierungszeitpunkt gesetzt
+    (Karenz fuer den ersten Lauf, siehe Spec-Grenzfaelle).
+  mode: single
+  triggers:
+    - trigger: time
+      at: "22:00:00"
+  conditions:
+    - condition: template
+      value_template: >-
+        {{ (now().timestamp() - as_timestamp(states('input_datetime.opti_ki_last_success'), 0)) > 259200 }}
+  actions:
+    - action: notify.notify
+      data:
+        title: "🤖⚠️ KI-Analyse ohne Erfolg"
+        message: >-
+          Die Opti-KI-Analyse hatte seit
+          {{ ((now().timestamp() - as_timestamp(states('input_datetime.opti_ki_last_success'), 0)) / 86400) | round(1) }}
+          Tagen keinen erfolgreichen Lauf. OpenAI-Integration/API-Key pruefen.
+    - action: persistent_notification.create
+      data:
+        notification_id: opti_ki_watchdog
+        title: "KI-Analyse ohne Erfolg"
+        message: >-
+          Letzter Erfolg: {{ states('input_datetime.opti_ki_last_success') }}.
+          Automation "KI | Opti Tagesanalyse" und OpenAI-Integration pruefen.

--- a/automations/opti_ki_analyse.yaml
+++ b/automations/opti_ki_analyse.yaml
@@ -130,12 +130,13 @@
               boolean:
           auffaelligkeiten:
             description: >-
-              Liste von Objekten {code, schweregrad, beobachtung};
-              schweregrad ist info, warnung oder kritisch; leere Liste wenn
-              nichts auffaellig
+              Eine Zeile pro Auffaelligkeit im Format
+              '- [schweregrad] code: beobachtung' (schweregrad: info, warnung
+              oder kritisch); leerer String wenn nichts auffaellig
             required: true
             selector:
-              object:
+              text:
+                multiline: true
 
     - alias: "Bei Fehler still enden"
       condition: template

--- a/automations/opti_ki_analyse.yaml
+++ b/automations/opti_ki_analyse.yaml
@@ -1,0 +1,175 @@
+# =============================================================================
+# opti_ki_analyse.yaml - Automationen der KI-Analyse-Schicht (Phase 1).
+# Analyse taeglich 21:00, Watchdog 22:00. Rein lesend/berichtend.
+# Live-Abweichung (dokumentiert): notify.notify wird live durch den echten
+# Mobile-App-Service ersetzt (kein Geraetename im oeffentlichen Repo).
+# =============================================================================
+- id: "opti_ki_analyse_taeglich"
+  alias: "KI | Opti Tagesanalyse"
+  description: >-
+    Sammelt die deterministischen Tageskennzahlen, laesst ai_task einen
+    Tagesreport mit Anomalie-Einschaetzung erzeugen und verteilt das Ergebnis
+    (Event fuer den Dashboard-Sensor, Notification je nach Toggle/meldenswert).
+    Fehler enden still - der Watchdog meldet nach 3 Tagen ohne Erfolg.
+  mode: single
+  triggers:
+    - trigger: time
+      at: "21:00:00"
+  actions:
+    - alias: "Versuch stempeln"
+      action: input_datetime.set_datetime
+      target:
+        entity_id: input_datetime.opti_ki_last_attempt
+      data:
+        datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
+
+    - alias: "Tagesdaten einsammeln"
+      variables:
+        nv: "nicht verfuegbar"
+        datenpaket: >-
+          {% set nv = 'nicht verfuegbar' %}
+          {% macro num(eid, digits=1) -%}
+            {{ (states(eid) | float(0) | round(digits)) if has_value(eid) else ('"' ~ nv ~ '"') }}
+          {%- endmacro %}
+          {% set byd_da = has_value('sensor.byd_zellspreizung_ruhe') %}
+          {
+            "datum": "{{ now().strftime('%Y-%m-%d') }}",
+            "modi": {
+              "nur_laden":    {"stunden": {{ num('sensor.opti_ki_dauer_nur_laden', 2) }},    "starts": {{ num('sensor.opti_ki_starts_nur_laden', 0) }}},
+              "netzladen":    {"stunden": {{ num('sensor.opti_ki_dauer_netzladen', 2) }},    "starts": {{ num('sensor.opti_ki_starts_netzladen', 0) }}},
+              "nur_entladen": {"stunden": {{ num('sensor.opti_ki_dauer_nur_entladen', 2) }}, "starts": {{ num('sensor.opti_ki_starts_nur_entladen', 0) }}},
+              "dynamisch":    {"stunden": {{ num('sensor.opti_ki_dauer_dynamisch', 2) }},    "starts": {{ num('sensor.opti_ki_starts_dynamisch', 0) }}}
+            },
+            "akku": {
+              "soc_min": {{ num('sensor.opti_ki_soc_min_24h') }},
+              "soc_max": {{ num('sensor.opti_ki_soc_max_24h') }},
+              "geladen_kwh": {{ num('sensor.opti_ki_akku_ladung_heute') }},
+              "entladen_kwh": {{ num('sensor.opti_ki_akku_entladung_heute') }}
+            },
+            "tag": {
+              "preisspanne_ct": {{ num('sensor.opti_price_spread_today_ct') }},
+              "netzbezug_kwh": {{ num('sensor.opti_grid_import_today_kwh') }},
+              "pv_ist_kwh": {{ num('sensor.opti_pv_yield_today_kwh') }},
+              "pv_prognose_kwh": {{ num('sensor.opti_forecast_today_kwh', 0) }},
+              "score_heute": {{ num('sensor.opti_forecast_score', 0) }},
+              "score_morgen": {{ num('sensor.opti_forecast_score_tomorrow', 0) }}
+            },
+            "jetzt": {
+              "modus": "{{ states('input_select.akkusteuerung_modus') }}",
+              "vorschau": "{{ states('sensor.opti_strategie_vorschau') }}",
+              "grund_code": "{{ state_attr('sensor.opti_strategie_vorschau', 'grund') }}",
+              "ziel_soc": {{ num('sensor.opti_target_soc', 0) }}
+            },
+            "parameter": {
+              "forecast_optimismus": {{ num('input_number.opti_forecast_optimismus', 0) }},
+              "peak_min_aufschlag_ct": {{ num('input_number.opti_peak_min_aufschlag_ct') }},
+              "halte_spread_ct": {{ num('input_number.opti_halte_spread_ct') }},
+              "minsoc": {{ num('input_number.minsoc', 0) }},
+              "maxsoc": {{ num('input_number.maxsoc', 0) }}
+            },
+            "datenqualitaet": {
+              "preis_unavailable_min": {{ ((states('sensor.opti_ki_preis_unavailable_h') | float(0)) * 60) | round(0) }},
+              "forecast_unavailable_min": {{ ((states('sensor.opti_ki_forecast_unavailable_h') | float(0)) * 60) | round(0) }}
+            },
+            "byd": {
+              "verfuegbar": {{ byd_da | lower }},
+              "ruhe_spreizung_mv": {{ num('sensor.byd_zellspreizung_ruhe', 0) }},
+              "ruhe_spreizung_max_24h_mv": {{ num('sensor.opti_ki_ruhe_spreizung_max_24h', 0) }},
+              "temp_spreizung_k": {{ num('sensor.byd_temperatur_spreizung', 0) }},
+              "soh_prozent": {{ num('sensor.byd_soh', 0) }},
+              "balancing_dauer_h": {{ num('sensor.opti_ki_balancing_dauer_h', 2) }}
+            }
+          }
+
+    - alias: "KI-Analyse erzeugen"
+      action: ai_task.generate_data
+      continue_on_error: true
+      response_variable: analyse
+      data:
+        entity_id: ai_task.openai_ai_task
+        task_name: "Opti Tagesanalyse"
+        instructions: >-
+          Du bist die taegliche Analyse-Schicht einer deterministischen
+          Hausakku-Steuerung (BYD-LFP-Akku, PV, Boersenpreise). Du bekommst
+          die Tageskennzahlen als JSON. Erzeuge einen kompakten Tagesreport.
+
+          SO ENTSCHEIDET DIE STEUERUNG (Prioritaetsleiter, erster Treffer
+          gewinnt; der grund_code benennt den aktiven Zweig): 1. MinSOC-Schutz
+          -> nur Laden. 2. Negativpreis-Laden -> Netzladen. 3. Peak-Vorladen
+          -> Netzladen. 4. Peak-Leiter L1/L2 (sehr teure Stunden) -> nur
+          Entladen. 5. Balancing-Watchdog -> Vollladung. 6. Prognose-Zweige
+          (Score unter 3) -> nur Laden. 7. PV-Ueberschuss -> Dynamisch.
+          8. Akku voll -> Dynamisch. 9. Peak-Leiter L3/L4 (halten) -> nur
+          Laden. 10. Unter Ziel-SoC tags -> Dynamisch. 11. Ueber Ziel-SoC ->
+          nur Entladen (preisunabhaengig, Ziel-SoC enthaelt die
+          Wirtschaftlichkeit). 12. Default -> Dynamisch.
+
+          REGELN: Nutze nur die gelieferten Zahlen, ergaenze keine Fakten.
+          unavailable-Minuten sind Datenluecken, kein Anlagenverhalten -
+          Kennzahlen mit "nicht verfuegbar" nicht bewerten. Formuliere
+          Korrelation nie als Kausalitaet. Keine Handlungsempfehlungen und
+          keine Parameter-Vorschlaege. Zahlen mit Einheiten. Viele Starts bei
+          kleiner Verweildauer je Modus deuten auf Flattern. Zum byd-Block:
+          LFP-Zellspreizung ist nur der Ruhe-Wert vergleichbar; SoH-Aenderungen
+          von Tag zu Tag sind Rauschen; deterministische Alarme existieren
+          separat, du bewertest nur Trends. meldenswert = true nur bei echten
+          Auffaelligkeiten (Flattern, Datenluecken ueber 30 min, SoC-Band
+          verletzt MinSOC/MaxSOC, ungewoehnliche Ruhe-Spreizung).
+
+          DATEN: {{ datenpaket }}
+        structure:
+          zusammenfassung:
+            description: "Tagesreport, max. ca. 500 Zeichen, notification-tauglich, Deutsch"
+            required: true
+            selector:
+              text:
+          meldenswert:
+            description: "true nur bei echten Auffaelligkeiten"
+            required: true
+            selector:
+              boolean:
+          auffaelligkeiten:
+            description: >-
+              Liste von Objekten {code, schweregrad, beobachtung};
+              schweregrad ist info, warnung oder kritisch; leere Liste wenn
+              nichts auffaellig
+            required: true
+            selector:
+              object:
+
+    - alias: "Bei Fehler still enden"
+      condition: template
+      value_template: >-
+        {{ analyse is defined and analyse.data is defined
+           and analyse.data.zusammenfassung is defined }}
+
+    - alias: "Erfolg stempeln"
+      action: input_datetime.set_datetime
+      target:
+        entity_id: input_datetime.opti_ki_last_success
+      data:
+        datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
+
+    - alias: "Ergebnis an Dashboard-Sensor"
+      action: event.fire
+      data:
+        event_type: opti_ki_analyse_fertig
+        event_data:
+          zusammenfassung: "{{ analyse.data.zusammenfassung }}"
+          auffaelligkeiten: "{{ analyse.data.auffaelligkeiten }}"
+          meldenswert: "{{ analyse.data.meldenswert | default(false) | bool }}"
+
+    - alias: "Notification je nach Toggle/meldenswert"
+      if:
+        - condition: or
+          conditions:
+            - condition: state
+              entity_id: input_boolean.opti_ki_tagesreport_immer
+              state: "on"
+            - condition: template
+              value_template: "{{ analyse.data.meldenswert | default(false) | bool }}"
+      then:
+        - action: notify.notify
+          data:
+            title: "🔋🤖 Akku-Tagesreport ({{ now().strftime('%d.%m.') }})"
+            message: "{{ analyse.data.zusammenfassung }}"

--- a/automations/opti_ki_analyse.yaml
+++ b/automations/opti_ki_analyse.yaml
@@ -151,13 +151,11 @@
         datetime: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
 
     - alias: "Ergebnis an Dashboard-Sensor"
-      action: event.fire
-      data:
-        event_type: opti_ki_analyse_fertig
-        event_data:
-          zusammenfassung: "{{ analyse.data.zusammenfassung }}"
-          auffaelligkeiten: "{{ analyse.data.auffaelligkeiten }}"
-          meldenswert: "{{ analyse.data.meldenswert | default(false) | bool }}"
+      event: opti_ki_analyse_fertig
+      event_data:
+        zusammenfassung: "{{ analyse.data.zusammenfassung }}"
+        auffaelligkeiten: "{{ analyse.data.auffaelligkeiten }}"
+        meldenswert: "{{ analyse.data.meldenswert | default(false) | bool }}"
 
     - alias: "Notification je nach Toggle/meldenswert"
       if:

--- a/automations/opti_ki_analyse.yaml
+++ b/automations/opti_ki_analyse.yaml
@@ -55,9 +55,9 @@
               "score_morgen": {{ num('sensor.opti_forecast_score_tomorrow', 0) }}
             },
             "jetzt": {
-              "modus": "{{ states('input_select.akkusteuerung_modus') }}",
-              "vorschau": "{{ states('sensor.opti_strategie_vorschau') }}",
-              "grund_code": "{{ state_attr('sensor.opti_strategie_vorschau', 'grund') }}",
+              "modus": {{ states('input_select.akkusteuerung_modus') | tojson }},
+              "vorschau": {{ states('sensor.opti_strategie_vorschau') | tojson }},
+              "grund_code": {{ (state_attr('sensor.opti_strategie_vorschau', 'grund') or '') | tojson }},
               "ziel_soc": {{ num('sensor.opti_target_soc', 0) }}
             },
             "parameter": {
@@ -155,7 +155,7 @@
       event: opti_ki_analyse_fertig
       event_data:
         zusammenfassung: "{{ analyse.data.zusammenfassung }}"
-        auffaelligkeiten: "{{ analyse.data.auffaelligkeiten }}"
+        auffaelligkeiten: "{{ analyse.data.auffaelligkeiten | default('') }}"
         meldenswert: "{{ analyse.data.meldenswert | default(false) | bool }}"
 
     - alias: "Notification je nach Toggle/meldenswert"

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -403,6 +403,16 @@ du beeinflusst sie ausschließlich über dein Mapping und die Helfer-Werte.
 
 ---
 
+## KI-Analyse-Schicht (optional, Phase 1)
+
+`packages/opti_ki_analyse.yaml` + `automations/opti_ki_analyse.yaml` erzeugen einen täglichen KI-Tagesreport (21:00) über `ai_task.generate_data`.
+Die Schicht liest ausschließlich - der Regelkreis funktioniert ohne sie vollständig.
+Datenzugriff läuft über die optionalen Mapping-Einträge (Abschnitt 12 der Example-Datei); fehlende Quellen werden im Report als "nicht verfügbar" markiert.
+Ein deterministischer Watchdog (22:00) meldet, wenn die Analyse 3 Tage keinen Erfolg hatte.
+Details: `docs/superpowers/specs/2026-07-10-ki-analyse-schicht-design.md` (lokal).
+
+---
+
 ## Testfälle — Erwartetes Verhalten
 
 | Szenario | Relevante Eingaben | Erwarteter Modus | Hinweise |

--- a/opti_mapping.example.yaml
+++ b/opti_mapping.example.yaml
@@ -237,3 +237,52 @@ template:
         # state: "{{ states('sensor.DEIN_BATT_POWER') | float(0) }}"
         # Falls Quelle positiv = entladen (Laden ist negativ) → Vorzeichen drehen:
         # state: "{{ states('sensor.DEIN_BATT_POWER') | float(0) * -1 }}"
+
+      # -----------------------------------------------------------------------
+      # 14. OPTIONAL - Kennzahlen fuer die KI-Analyse-Schicht (Phase 1).
+      # Alle Eintraege optional: Block weglassen oder Quelle leer lassen ->
+      # Sensor bleibt unavailable, der Tagesreport markiert die Kennzahl als
+      # "nicht verfuegbar". KEINE Steuerungsfunktion.
+      # -----------------------------------------------------------------------
+
+      # Kumulierte Batterie-Ladung (kWh, monoton steigend, z. B. WR-Total)
+      - unique_id: opti_mapping_battery_charge_total
+        name: "Opti Battery Charge Total kWh"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total_increasing
+        availability: "{{ has_value('sensor.DEIN_AKKU_LADUNG_TOTAL') }}"
+        state: "{{ states('sensor.DEIN_AKKU_LADUNG_TOTAL') | float(0) }}"
+
+      # Kumulierte Batterie-Entladung (kWh, monoton steigend)
+      - unique_id: opti_mapping_battery_discharge_total
+        name: "Opti Battery Discharge Total kWh"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: total_increasing
+        availability: "{{ has_value('sensor.DEIN_AKKU_ENTLADUNG_TOTAL') }}"
+        state: "{{ states('sensor.DEIN_AKKU_ENTLADUNG_TOTAL') | float(0) }}"
+
+      # Preisspanne heute (ct/kWh, max - min des Tages)
+      - unique_id: opti_mapping_price_spread_today
+        name: "Opti Price Spread Today ct"
+        unit_of_measurement: "ct/kWh"
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEINE_PREISSPANNE_HEUTE') }}"
+        state: "{{ states('sensor.DEINE_PREISSPANNE_HEUTE') | float(0) }}"
+
+      # Netzbezug heute (kWh)
+      - unique_id: opti_mapping_grid_import_today
+        name: "Opti Grid Import Today kWh"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        availability: "{{ has_value('sensor.DEIN_NETZBEZUG_HEUTE') }}"
+        state: "{{ states('sensor.DEIN_NETZBEZUG_HEUTE') | float(0) }}"
+
+      # PV-Ertrag heute (kWh, Ist-Erzeugung fuer Forecast-vs-Ist)
+      - unique_id: opti_mapping_pv_yield_today
+        name: "Opti PV Yield Today kWh"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        availability: "{{ has_value('sensor.DEIN_PV_ERTRAG_HEUTE') }}"
+        state: "{{ states('sensor.DEIN_PV_ERTRAG_HEUTE') | float(0) }}"

--- a/packages/opti_ki_analyse.yaml
+++ b/packages/opti_ki_analyse.yaml
@@ -1,0 +1,174 @@
+# =============================================================================
+# opti_ki_analyse.yaml - KI-Analyse-Schicht Phase 1 (Tagesreport + Anomalie)
+# -----------------------------------------------------------------------------
+# Deterministischer Unterbau fuer den taeglichen KI-Report (21:00, siehe
+# automations/opti_ki_analyse.yaml). Die KI liest ausschliesslich - nichts in
+# dieser Datei schreibt in die Steuerung. Ausfall der KI = kein Report.
+# Spec: docs/superpowers/specs/2026-07-10-ki-analyse-schicht-design.md
+# =============================================================================
+
+input_boolean:
+  opti_ki_tagesreport_immer:
+    name: "Opti KI Tagesreport immer senden"
+    icon: mdi:message-text-clock
+
+input_datetime:
+  opti_ki_last_attempt:
+    name: "Opti KI letzter Versuch"
+    has_date: true
+    has_time: true
+  opti_ki_last_success:
+    name: "Opti KI letzter Erfolg"
+    has_date: true
+    has_time: true
+
+sensor:
+  # ---- Modus-Verweildauern und Einschaltzahlen (heute) ---------------------
+  - platform: history_stats
+    name: "Opti KI Dauer Nur Laden"
+    unique_id: opti_ki_dauer_nur_laden
+    entity_id: input_select.akkusteuerung_modus
+    state: "Akku nur Laden"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: "Opti KI Starts Nur Laden"
+    unique_id: opti_ki_starts_nur_laden
+    entity_id: input_select.akkusteuerung_modus
+    state: "Akku nur Laden"
+    type: count
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: "Opti KI Dauer Netzladen"
+    unique_id: opti_ki_dauer_netzladen
+    entity_id: input_select.akkusteuerung_modus
+    state: "Akku Netzladen"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: "Opti KI Starts Netzladen"
+    unique_id: opti_ki_starts_netzladen
+    entity_id: input_select.akkusteuerung_modus
+    state: "Akku Netzladen"
+    type: count
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: "Opti KI Dauer Nur Entladen"
+    unique_id: opti_ki_dauer_nur_entladen
+    entity_id: input_select.akkusteuerung_modus
+    state: "Akku nur Entladen"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: "Opti KI Starts Nur Entladen"
+    unique_id: opti_ki_starts_nur_entladen
+    entity_id: input_select.akkusteuerung_modus
+    state: "Akku nur Entladen"
+    type: count
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: "Opti KI Dauer Dynamisch"
+    unique_id: opti_ki_dauer_dynamisch
+    entity_id: input_select.akkusteuerung_modus
+    state: "Akku Dynamisch"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: "Opti KI Starts Dynamisch"
+    unique_id: opti_ki_starts_dynamisch
+    entity_id: input_select.akkusteuerung_modus
+    state: "Akku Dynamisch"
+    type: count
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+
+  # ---- Datenqualitaet: unavailable-Zeiten der Kernquellen (heute) ----------
+  - platform: history_stats
+    name: "Opti KI Preis Unavailable H"
+    unique_id: opti_ki_preis_unavailable_h
+    entity_id: sensor.opti_price_current_ct_kwh
+    state:
+      - "unavailable"
+      - "unknown"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+  - platform: history_stats
+    name: "Opti KI Forecast Unavailable H"
+    unique_id: opti_ki_forecast_unavailable_h
+    entity_id: sensor.opti_forecast_score
+    state:
+      - "unavailable"
+      - "unknown"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+
+  # ---- BYD-Gesundheit: Balancing-Dauer heute (optional, s. Spec-Delta) -----
+  - platform: history_stats
+    name: "Opti KI Balancing Dauer H"
+    unique_id: opti_ki_balancing_dauer_h
+    entity_id: binary_sensor.byd_balancing_aktiv
+    state: "on"
+    type: time
+    start: "{{ today_at() }}"
+    end: "{{ now() }}"
+
+  # ---- SoC-Band und Ruhe-Spreizung (24h rollierend, bewusst akzeptiert) ----
+  - platform: statistics
+    name: "Opti KI SoC Min 24h"
+    unique_id: opti_ki_soc_min_24h
+    entity_id: sensor.opti_soc
+    state_characteristic: value_min
+    max_age:
+      hours: 24
+    sampling_size: 3000
+  - platform: statistics
+    name: "Opti KI SoC Max 24h"
+    unique_id: opti_ki_soc_max_24h
+    entity_id: sensor.opti_soc
+    state_characteristic: value_max
+    max_age:
+      hours: 24
+    sampling_size: 3000
+  - platform: statistics
+    name: "Opti KI Ruhe Spreizung Max 24h"
+    unique_id: opti_ki_ruhe_spreizung_max_24h
+    entity_id: sensor.byd_zellspreizung_ruhe
+    state_characteristic: value_max
+    max_age:
+      hours: 24
+    sampling_size: 3000
+
+# ---- Akku-Ladung/Entladung heute (aus kumulierten Mapping-Totals) ----------
+utility_meter:
+  opti_ki_akku_ladung_heute:
+    name: "Opti KI Akku Ladung Heute"
+    source: sensor.opti_battery_charge_total_kwh
+    cycle: daily
+  opti_ki_akku_entladung_heute:
+    name: "Opti KI Akku Entladung Heute"
+    source: sensor.opti_battery_discharge_total_kwh
+    cycle: daily
+
+# ---- Ergebnis-Sensor: gefuellt vom Analyse-Event ---------------------------
+template:
+  - triggers:
+      - trigger: event
+        event_type: opti_ki_analyse_fertig
+    sensor:
+      - unique_id: opti_ki_analyse
+        name: "Opti KI Analyse"
+        icon: mdi:robot-outline
+        state: "{{ 'auffaellig' if trigger.event.data.meldenswert else 'ok' }}"
+        attributes:
+          zusammenfassung: "{{ trigger.event.data.zusammenfassung }}"
+          auffaelligkeiten: "{{ trigger.event.data.auffaelligkeiten }}"
+          generiert: "{{ now().isoformat() }}"

--- a/tests/ha_harness.py
+++ b/tests/ha_harness.py
@@ -73,10 +73,21 @@ def _as_local(value):
     return value.astimezone(TZ) if isinstance(value, dt.datetime) else value
 
 
+def _as_timestamp(value, default=None):
+    try:
+        parsed = dt.datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return default
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=TZ)
+    return parsed.timestamp()
+
+
 def _setup(env, hass):
     env.globals.update(
         states=hass.states, state_attr=hass.state_attr, has_value=hass.has_value,
         is_state=hass.is_state, now=hass.now, today_at=hass.today_at,
+        as_timestamp=_as_timestamp,
         timedelta=dt.timedelta, min=min, max=max,
         this=types.SimpleNamespace(attributes=hass.this_attributes,
                                    state=hass.this_state),

--- a/tests/test_ki_analyse.py
+++ b/tests/test_ki_analyse.py
@@ -114,3 +114,19 @@ def test_datenpaket_markiert_fehlende_quellen():
     ergebnis = json.loads(render(hass, _datenpaket_template()))
     assert ergebnis["tag"]["preisspanne_ct"] == "nicht verfuegbar"
     assert ergebnis["byd"]["verfuegbar"] is False
+
+
+def _watchdog_condition():
+    cfg = load_yaml(KI_AUTOMATIONS)
+    auto = next(a for a in cfg if a["id"] == "opti_ki_watchdog")
+    return auto["conditions"][0]["value_template"]
+
+
+def test_watchdog_meldet_nach_drei_tagen():
+    import datetime as dt
+    from .ha_harness import TZ
+    now = dt.datetime(2026, 7, 15, 22, 0, tzinfo=TZ)
+    alt = FakeHass(states={"input_datetime.opti_ki_last_success": "2026-07-11 21:00:00"}, now=now)
+    frisch = FakeHass(states={"input_datetime.opti_ki_last_success": "2026-07-14 21:00:00"}, now=now)
+    assert render(alt, _watchdog_condition()) == "True"
+    assert render(frisch, _watchdog_condition()) == "False"

--- a/tests/test_ki_analyse.py
+++ b/tests/test_ki_analyse.py
@@ -44,3 +44,73 @@ def _parse_fails(env, template_str):
         return False
     except jinja2.TemplateSyntaxError:
         return True
+
+
+def _analyse_automation():
+    cfg = load_yaml(KI_AUTOMATIONS)
+    return next(a for a in cfg if a["id"] == "opti_ki_analyse_taeglich")
+
+
+def _datenpaket_template():
+    auto = _analyse_automation()
+    schritt = next(a for a in auto["actions"] if "variables" in a)
+    return schritt["variables"]["datenpaket"]
+
+
+STATES_VOLL = {
+    "input_select.akkusteuerung_modus": "Akku Dynamisch",
+    "sensor.opti_strategie_vorschau": "Akku Dynamisch",
+    "sensor.opti_ki_dauer_nur_laden": "1.5",
+    "sensor.opti_ki_starts_nur_laden": "2",
+    "sensor.opti_ki_dauer_netzladen": "0.0",
+    "sensor.opti_ki_starts_netzladen": "0",
+    "sensor.opti_ki_dauer_nur_entladen": "6.25",
+    "sensor.opti_ki_starts_nur_entladen": "3",
+    "sensor.opti_ki_dauer_dynamisch": "13.0",
+    "sensor.opti_ki_starts_dynamisch": "4",
+    "sensor.opti_ki_preis_unavailable_h": "0.1",
+    "sensor.opti_ki_forecast_unavailable_h": "0.0",
+    "sensor.opti_ki_soc_min_24h": "38.0",
+    "sensor.opti_ki_soc_max_24h": "92.0",
+    "sensor.opti_ki_akku_ladung_heute": "9.8",
+    "sensor.opti_ki_akku_entladung_heute": "7.2",
+    "sensor.opti_price_spread_today_ct": "21.4",
+    "sensor.opti_grid_import_today_kwh": "3.1",
+    "sensor.opti_pv_yield_today_kwh": "118.0",
+    "sensor.opti_forecast_today_kwh": "127.0",
+    "sensor.opti_forecast_score": "9",
+    "sensor.opti_forecast_score_tomorrow": "10",
+    "sensor.opti_target_soc": "50",
+    "input_number.opti_forecast_optimismus": "40",
+    "input_number.opti_peak_min_aufschlag_ct": "5",
+    "input_number.opti_halte_spread_ct": "5",
+    "input_number.minsoc": "10",
+    "input_number.maxsoc": "95",
+    "sensor.byd_zellspreizung_ruhe": "2",
+    "sensor.opti_ki_ruhe_spreizung_max_24h": "4",
+    "sensor.byd_temperatur_spreizung": "3",
+    "sensor.byd_soh": "96",
+    "sensor.opti_ki_balancing_dauer_h": "1.2",
+}
+
+
+def test_datenpaket_rendert_valides_json():
+    hass = FakeHass(states=STATES_VOLL,
+                    attrs={"sensor.opti_strategie_vorschau": {"grund": "Default (Nacht/keine Aktion)"}})
+    ergebnis = json.loads(render(hass, _datenpaket_template()))
+    assert ergebnis["modi"]["nur_entladen"]["stunden"] == 6.25
+    assert ergebnis["modi"]["nur_entladen"]["starts"] == 3
+    assert ergebnis["datenqualitaet"]["preis_unavailable_min"] == 6
+    assert ergebnis["akku"]["soc_min"] == 38.0
+    assert ergebnis["byd"]["ruhe_spreizung_max_24h_mv"] == 4
+
+
+def test_datenpaket_markiert_fehlende_quellen():
+    ohne_optionales = {k: v for k, v in STATES_VOLL.items()
+                       if not k.startswith(("sensor.opti_price_spread", "sensor.opti_grid_import",
+                                            "sensor.opti_pv_yield", "sensor.byd_"))}
+    hass = FakeHass(states=ohne_optionales,
+                    attrs={"sensor.opti_strategie_vorschau": {"grund": "Default (Nacht/keine Aktion)"}})
+    ergebnis = json.loads(render(hass, _datenpaket_template()))
+    assert ergebnis["tag"]["preisspanne_ct"] == "nicht verfuegbar"
+    assert ergebnis["byd"]["verfuegbar"] is False

--- a/tests/test_ki_analyse.py
+++ b/tests/test_ki_analyse.py
@@ -1,9 +1,7 @@
 """Tests fuer das KI-Analyse-Paket (Phase 1)."""
 import json
-import pathlib
 
 import jinja2
-import yaml
 
 from .ha_harness import REPO, FakeHass, load_yaml, render
 

--- a/tests/test_ki_analyse.py
+++ b/tests/test_ki_analyse.py
@@ -1,0 +1,46 @@
+"""Tests fuer das KI-Analyse-Paket (Phase 1)."""
+import json
+import pathlib
+
+import jinja2
+import yaml
+
+from .ha_harness import REPO, FakeHass, load_yaml, render
+
+KI_PACKAGE = REPO / "packages" / "opti_ki_analyse.yaml"
+KI_AUTOMATIONS = REPO / "automations" / "opti_ki_analyse.yaml"
+
+
+def _walk_templates(node, path=""):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            yield from _walk_templates(v, f"{path}.{k}")
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            yield from _walk_templates(v, f"{path}[{i}]")
+    elif isinstance(node, str) and ("{{" in node or "{%" in node):
+        yield path, node
+
+
+def test_ki_package_jinja_parst():
+    cfg = load_yaml(KI_PACKAGE)
+    env = jinja2.Environment()
+    fehler = [p for p, t in _walk_templates(cfg)
+              if _parse_fails(env, t)]
+    assert fehler == []
+
+
+def test_mapping_example_jinja_parst():
+    cfg = load_yaml(REPO / "opti_mapping.example.yaml")
+    env = jinja2.Environment()
+    fehler = [p for p, t in _walk_templates(cfg)
+              if _parse_fails(env, t)]
+    assert fehler == []
+
+
+def _parse_fails(env, template_str):
+    try:
+        env.parse(template_str)
+        return False
+    except jinja2.TemplateSyntaxError:
+        return True


### PR DESCRIPTION
## Was

KI-Schicht ÜBER dem deterministischen Regelkreis: täglich 21:00 sammelt eine Automation die Tageskennzahlen (Modus-Verweildauern/Starts, SoC-Band, Akku-Ladung/Entladung, Preisspanne/Netzbezug/PV-Ist, Datenqualität, optionaler BYD-Gesundheitsblock) und lässt ai_task.generate_data einen kompakten Tagesreport mit Anomalie-Einschätzung erzeugen. Ergebnis geht als Event an einen Dashboard-Sensor und je nach Toggle/meldenswert als Notification.

## Design-Invariante

Die KI liest ausschließlich. Die Automation schreibt nur last_attempt/last_success, das Ergebnis-Event und notify - kein Pfad in die Steuerung. KI-Fehler = stilles Ende (continue_on_error + Guard-Condition); ein deterministischer Watchdog (22:00) meldet nach 3 Tagen ohne Erfolg.

## Bestandteile

- `opti_mapping.example.yaml`: 5 neue OPTIONALE Canonical-Einträge (Batterie-Totals, Preisspanne, Netzbezug, PV-Ist) - fehlende Quelle = Kennzahl "nicht verfuegbar" im Report
- `packages/opti_ki_analyse.yaml`: Helfer, history_stats/statistics/utility_meter-Hilfssensoren, trigger-basierter Ergebnis-Sensor
- `automations/opti_ki_analyse.yaml`: Analyse-Automation (Datenpaket-JSON, Prompt mit Prioritätsleiter-Semantik, festes Schema) + Watchdog
- Tests: Jinja-Parse (inkl. erstmals der öffentlichen Example-Datei), Datenpaket-Rendering (valides JSON, Fehlend-Markierung), Watchdog-Bedingung (TZ-korrekt)

## Live-Status

Bereits deployed und E2E-verifiziert (Happy Path mit echtem Report, Fehlerpfad, Watchdog-Bedingung, Toggle-Logik). Erkenntnisse aus dem Live-Test sind eingeflossen: object-Selector in der ai_task-structure bricht die OpenAI-Integration (500) -> auffaelligkeiten als multiline-Text (Spec-Delta dokumentiert); Event via klassischer event:-Syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvRkGrujQQEoSJJgMR8QNy