### PR TITLE
Dashboard-Template (portabel) + Canonical-Sensor opti_grid_import_w

### DIFF
--- a/dashboard-template/README.md
+++ b/dashboard-template/README.md
@@ -114,7 +114,7 @@ Das Template hat eine einzige View "Übersicht" mit folgenden Abschnitten (von o
 ## Ergänzte Karten
 
 - **Energiefluss-Diagramm** (`custom:power-flow-card-plus`), Abschnitt "⚡ Energiefluss (Live-Diagramm)": neu empfohlen, nicht aus einem bestehenden Dashboard 1:1 kopiert. Die Karte ist auf die kanonischen opti-Sensoren gemappt.
-  - PV: `sensor.opti_pv_power_w`, Haus: `sensor.opti_house_consumption_w`, Netzbezug: `sensor.opti_grid_import_w`, Einspeisung: `sensor.opti_grid_export_w`, Batterie: `sensor.opti_battery_power_w` mit SoC `sensor.opti_soc`.
+  - PV: `sensor.opti_pv_generation_w` (PV GESAMT - nicht `opti_pv_power_w`, das ist nur der AC-Ausgang des Hybrid-WR und lässt bei Mehr-WR-Anlagen die Bilanz im Flussdiagramm nicht aufgehen), Haus: `sensor.opti_house_consumption_w`, Netzbezug: `sensor.opti_grid_import_w`, Einspeisung: `sensor.opti_grid_export_w`, Batterie: `sensor.opti_battery_power_w` mit SoC `sensor.opti_soc`.
   - **Netzbezug**: `sensor.opti_grid_import_w` ist der optionale, symmetrisch zu `opti_grid_export_w` ergänzte Canonical-Sensor (siehe `docs/canonical-layer.md`, Sensor 6b). Fehlt er auf der Zielinstanz, im Mapping die Bezugsquelle nachtragen oder den grid-consumption-Eintrag entfernen.
   - **Batterie-Vorzeichen**: opti nutzt "positiv = laden". `power-flow-card-plus` erwartet standardmäßig "positiv = entladen (zum Haus)". Deshalb steht `invert_state: true` in der Batterie-Konfiguration. Beim Nachbau prüfen, ob die Flussrichtung stimmt, und `invert_state` sonst umstellen.
 

--- a/dashboard-template/README.md
+++ b/dashboard-template/README.md
@@ -1,0 +1,130 @@
+# Dashboard-Template: Opti-Akkusteuerung Übersicht
+
+Portables Lovelace-Dashboard als Steuerzentrale für die opti-Strategie-Schicht dieses Repos.
+Die Datei `uebersicht.json` enthält eine abstrahierte Kopie der Live-Ansicht "Übersicht" (View-Pfad `uebersicht`) aus dem Dashboard `opti-akkusteuerung`.
+Sie ist so aufgebaut, dass eine andere HA-Instanz sie mit minimalem Aufwand nachbauen kann.
+
+Weil die Zielinstanz die opti-Schicht dieses Repos bereits fährt (Shadow-Betrieb), sind fast alle Karten direkt auf die kanonischen `sensor.opti_*`-Sensoren und die opti-Helfer gemappt.
+Diese Karten brauchen beim Nachbau keinen Platzhalter und funktionieren sofort.
+Nur echte hardwarespezifische Sensoren (Zell-/BMS-Werte) und ein fehlender Kanonik-Sensor (Netzbezug) sind als `__ROLLE__`-Platzhalter markiert.
+
+## Quelle und Auswahl
+
+- Basis: Dashboard `opti-akkusteuerung`, View "Übersicht" (`type: sections`, `max_columns: 3`), rein lesend per `ha_config_get_dashboard` extrahiert.
+- Alle Karten dieser View wurden 1:1 übernommen (Struktur, Layout, Templates), abgesehen von den unten dokumentierten Abstraktionen und Auslassungen.
+- Eine Fremd-Karte wurde neu ergänzt (siehe "Ergänzte Karten"): ein Live-Energiefluss-Diagramm, weil die Zielinstanz `power-flow-card-plus` bereits installiert hat und ein Flussdiagramm der Kern einer Steuerzentrale ist.
+
+## Nachbau (Kurzfassung)
+
+1. Fehlende HACS-Karten installieren (Tabelle unten).
+2. `uebersicht.json` als neues Dashboard oder neue View anlegen (nicht die vorhandene Übersicht der Zielinstanz überschreiben).
+3. Die Platzhalter `__ROLLE__` durch echte Entitäten der Zielinstanz ersetzen oder die betroffenen Karten/Abschnitte entfernen.
+4. Beim Energiefluss-Diagramm die Vorzeichen-Hinweise beachten (Batterie-Invertierung, Netzbezug-Sensor).
+
+## Rollen-Tabelle: Platzhalter
+
+Nur diese Rollen sind im Template als `__ROLLE__` offen.
+Alles andere ist bereits fest auf kanonische opti-Entitäten verdrahtet (siehe nächste Tabelle).
+
+| Platzhalter | Bedeutung | Einheit / Vorzeichenkonvention | Bens Original-Entität (Referenz) | Hinweis für die Zielinstanz |
+|---|---|---|---|---|
+| `__NETZ_BEZUG_W__` | Netzbezug (Import aus dem Netz) | W, positiv = Bezug aus dem Netz | (kein kanonischer Sensor vorhanden) | Der Canonical-Layer liefert nur `sensor.opti_grid_export_w` (Einspeisung). Für das Flussdiagramm wird zusätzlich der Import benötigt. Huawei stellt dafür meist einen signierten Zähler oder einen eigenen Consumption-Sensor bereit. |
+| `__ZELL_SPREIZUNG_MV__` | Zellspannungs-Spreizung (max - min) | mV, positiv | `sensor.byd_zellspreizung` | Zell-Level-Wert eines externen BMS-Auslesers. Auf Huawei LUNA2000 in der Regel nicht vorhanden. Abschnitt "Akku-Gesundheit" sonst entfernen. |
+| `__ZELL_SPANNUNG_MIN_V__` | niedrigste Zellspannung | V | `sensor.byd_zellspannung_min` | wie oben |
+| `__ZELL_SPANNUNG_MAX_V__` | höchste Zellspannung | V | `sensor.byd_zellspannung_max` | wie oben |
+| `__ZELL_SPANNUNG_AVG_V__` | mittlere Zellspannung | V | `sensor.byd_zellspannung_avg` | wie oben |
+| `__BATT_SOH__` | State of Health der Batterie | % | `sensor.byd_soh` | Falls die Zielbatterie einen SoH-Sensor liefert, hier eintragen, sonst Kachel entfernen. |
+| `__BMS_BALANCING_AKTIV__` | BMS meldet aktives Zell-Balancing | binary (on/off) | `binary_sensor.byd_balancing_aktiv` | Zell-Level, meist nur mit externem BMS-Ausleser. Sonst Kachel entfernen. |
+| `__BMS_SOC__` | SoC laut BMS (zum Vergleich mit WR-SoC) | % | `sensor.byd_soc` | Optionaler Zweit-SoC. Sonst Kachel entfernen. |
+
+## Rollen-Tabelle: fest verdrahtete kanonische opti-Entitäten
+
+Diese Entitäten stehen unverändert im Template, weil die Zielinstanz die opti-Schicht bereits fährt.
+Die Vorzeichen-/Einheiten-Konventionen stammen aus `docs/canonical-layer.md` dieses Repos.
+
+| Entität im Template | Bedeutung | Einheit / Vorzeichenkonvention |
+|---|---|---|
+| `sensor.opti_soc` | Akku-SoC | %, 0 bis 100 |
+| `sensor.opti_battery_power_w` | Batterieleistung | W, **positiv = laden**, negativ = entladen |
+| `sensor.opti_pv_power_w` | PV-AC-Leistung | W, immer >= 0 |
+| `sensor.opti_house_consumption_w` | Hausverbrauch | W, >= 0 |
+| `sensor.opti_grid_export_w` | Einspeisung ins Netz | W, **positiv = Einspeisung**, immer >= 0 |
+| `sensor.opti_battery_temp` | Akku-Temperatur | °C |
+| `sensor.opti_battery_capacity_kwh` | nutzbare Kapazität | kWh |
+| `sensor.opti_target_soc` | intelligenter Ziel-SoC | % |
+| `sensor.opti_price_current_ct_kwh` | aktueller Strompreis | ct/kWh |
+| `sensor.opti_price_level` | Preisniveau-Enum | VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE / VERY_EXPENSIVE |
+| `sensor.opti_mindestentladepreis_ct_kwh` | Mindestentladepreis | ct/kWh |
+| `sensor.opti_forecast_score` / `_score_tomorrow` | PV-Fit-Score heute / morgen | 0 bis 10 |
+| `sensor.opti_forecast_effective_remaining_kwh` | effektive Rest-Prognose | kWh, Attribute `p10_kwh`, `median_kwh`, `alpha` |
+| `sensor.opti_forecast_tomorrow_kwh` | Prognose morgen | kWh, Attribut `estimate10` (P10) |
+| `sensor.opti_peak_reserve_soc` | Reserve-SoC für Preisspitzen | % |
+| `binary_sensor.opti_peak_reserve_aktiv` | Peak-Reserve-Gate | on/off |
+| `binary_sensor.opti_winter_charging_allowed` | saisonales Lade-Gate | on/off (fail-open) |
+| `sensor.opti_strategie_vorschau` | Vorschau-Modus der Strategie | Text, Attribut `grund` |
+| `sensor.opti_balancing_watchdog` | Balancing-/Deep-Charge-Watchdog | `aus` / `pv` / `netz`, Attribut `grund` |
+| `sensor.opti_ki_analyse` | KI-Tagesreport-Status | `ok` / `auffaellig` / …, Attribut `zusammenfassung` |
+| `counter.tage_seit_akku100` | Tage seit letzter 100%-Ladung | Ganzzahl |
+| `input_select.akkusteuerung_modus` | manueller/aktueller Modus | Auswahl |
+| `input_boolean.akku_opti_automatik` | Master-Schalter Automatik | on/off |
+| `input_boolean.opti_prognose_netzladen` | Gate Prognose-Netzladen | on/off |
+| `input_boolean.opti_pv_ueberschuss_ladung` | Gate PV-Überschussladen | on/off |
+| `input_boolean.hausakku_aus_netz_laden` | manueller Netzlade-Booster | on/off |
+| `input_boolean.opti_balancing_netzladen` | Gate Balancing-Netzladen | on/off (Default aus) |
+| `input_boolean.opti_ki_tagesreport_immer` | KI-Report immer senden | on/off |
+| `input_number.minsoc` / `input_number.maxsoc` | SoC-Grenzen | % |
+| `input_number.opti_forecast_optimismus` | Forecast-Optimismus α | %, 0 bis 100 |
+| `input_number.opti_balancing_intervall_tage` / `_karenz_tage` / `_max_ct` / `_done_soc` | Balancing-Parameter | Tage / Tage / ct/kWh / % |
+| `input_datetime.opti_ki_last_success` | letzter KI-Erfolg | Zeitstempel |
+| `script.ki_opti_warum_erklaerung` | KI-Warum-Erklärung auslösen | Skript |
+
+## HACS- und Theme-Abhängigkeiten
+
+Auf der Zielinstanz laut Vorgabe bereits vorhanden: `mushroom`, `power-flow-card-plus`, `trash-card`.
+`trash-card` wird von diesem Template nicht verwendet.
+
+| Karte im Template | HACS-Typname | Repo | Version (Bens Stand) | Status Zielinstanz |
+|---|---|---|---|---|
+| Mushroom-Template-/Select-Card | `custom:mushroom-template-card`, `custom:mushroom-select-card` | `piitaya/lovelace-mushroom` | v5.1.1 | vorhanden |
+| Power Flow Card Plus | `custom:power-flow-card-plus` | `flixlix/power-flow-card-plus` | v0.3.7 | vorhanden |
+| card-mod (CSS in `card_mod:`) | (Ressource, kein Kartentyp) | `thomasloven/lovelace-card-mod` | v4.2.1 | **nachinstallieren** |
+| Bar Card | `custom:bar-card` | `custom-cards/bar-card` | 3.2.0 | **nachinstallieren** |
+| ApexCharts Card | `custom:apexcharts-card` | `RomRider/apexcharts-card` | v2.2.3 | **nachinstallieren** |
+
+Ohne `card-mod` rendern die Mushroom-Karten trotzdem, nur der Zeilenumbruch im `secondary`-Text greift nicht.
+Der `card_mod`-Block kann dann alternativ entfernt werden.
+
+## Views und Abschnitte
+
+Das Template hat eine einzige View "Übersicht" mit folgenden Abschnitten (von oben nach unten):
+
+- **⚡ Energiefluss (Live-Diagramm)**: ergänzte `power-flow-card-plus`, siehe "Ergänzte Karten".
+- **🔋 Status jetzt**: aktueller Modus, Strategie-Vorschau mit Begründung, SoC-Gauge, Batterieleistung, Button für die KI-Warum-Erklärung.
+- **⚡ Energiefluss (Kacheln)**: die ursprünglichen Kachel-Werte (PV, Haus, Einspeisung, Batterie, Temp, Kapazität). Bewusst zusätzlich zum Diagramm behalten, weil die Kacheln exakte Zahlen zeigen.
+- **🧠 Strategie-Intelligenz**: Ziel-SoC, Preis, Preisniveau, Mindestentladepreis, Prognose-Scores, Peak-Reserve, Winter-Gate.
+- **🔮 Prognose-Sicherheit**: P10/Median-Bänder heute und morgen, α-Regler.
+- **🩺 Balancing-Watchdog**: Watchdog-Status, Tage-seit-100%-Balken, Balancing-Parameter.
+- **🤖 KI-Tagesanalyse**: Report-Status, Sende-Schalter, letzter Erfolg.
+- **🔬 Akku-Gesundheit (BMS, optional)**: nur Platzhalter, siehe unten. Abschnitt bei fehlenden Zell-Sensoren komplett löschen.
+- **🎛️ Steuerung & Regler**: Master-Automatik, Modus-Auswahl, Netzlade-/Überschuss-Schalter, MinSOC/MaxSOC.
+- **📈 Verlauf (24 h)**: ApexCharts für Preis/SoC und Leistung (kanonisch), plus ein optionaler Zellspannungs-Chart (Platzhalter).
+
+## Ergänzte Karten
+
+- **Energiefluss-Diagramm** (`custom:power-flow-card-plus`), Abschnitt "⚡ Energiefluss (Live-Diagramm)": neu empfohlen, nicht aus einem bestehenden Dashboard 1:1 kopiert. Die Karte ist auf die kanonischen opti-Sensoren gemappt.
+  - PV: `sensor.opti_pv_power_w`, Haus: `sensor.opti_house_consumption_w`, Einspeisung: `sensor.opti_grid_export_w`, Batterie: `sensor.opti_battery_power_w` mit SoC `sensor.opti_soc`.
+  - **Netzbezug** ist als `__NETZ_BEZUG_W__` offen, weil der Canonical-Layer keinen Import-Sensor hat.
+  - **Batterie-Vorzeichen**: opti nutzt "positiv = laden". `power-flow-card-plus` erwartet standardmäßig "positiv = entladen (zum Haus)". Deshalb steht `invert_state: true` in der Batterie-Konfiguration. Beim Nachbau prüfen, ob die Flussrichtung stimmt, und `invert_state` sonst umstellen.
+
+## Bewusst ausgelassen
+
+- **Personenbezogene Karten**: In dieser Übersicht-View gab es keine (keine Personen-Tracker, Kalender, Kameras, Anwesenheit). Es musste nichts entfernt werden.
+- **Zelltemperatur über 5 Module** (`custom:mushroom-template-card` mit `sensor.byd_modul_1..5_temp_min/max`): ausgelassen, stark BYD-spezifisch (fünf Einzelmodule eines externen BMS-Auslesers).
+- **Per-Modul-Balkenkarte** "Module: min. Zellspannung" (`custom:bar-card` mit `sensor.byd_modul_1..5_zellspannung_min`): ausgelassen, gleiche BYD-Modul-Spezifik.
+- Beide Karten lassen sich auf einer Instanz mit vergleichbaren Modul-Sensoren aus Bens Live-Config wieder ergänzen. Für die Huawei-Zielinstanz sind sie nicht sinnvoll portierbar.
+
+## Privacy-Hinweise
+
+- Keine internen IP-Adressen, Tokens, Secrets oder lokalen Pfade im Template.
+- Die einzigen konkreten Fremd-Entitäten sind Bens `byd_*`-Sensornamen, ausschließlich als dokumentierte Original-Referenz in der Rollen-Tabelle. Im Template selbst stehen dafür nur Platzhalter.
+- Screenshots wurden nicht beigelegt: ein Rendern hätte Service-Calls oder das Screenshot-Beta am Live-System erfordert, und die Aufgabe war strikt read-only.

--- a/dashboard-template/README.md
+++ b/dashboard-template/README.md
@@ -6,7 +6,7 @@ Sie ist so aufgebaut, dass eine andere HA-Instanz sie mit minimalem Aufwand nach
 
 Weil die Zielinstanz die opti-Schicht dieses Repos bereits fährt (Shadow-Betrieb), sind fast alle Karten direkt auf die kanonischen `sensor.opti_*`-Sensoren und die opti-Helfer gemappt.
 Diese Karten brauchen beim Nachbau keinen Platzhalter und funktionieren sofort.
-Nur echte hardwarespezifische Sensoren (Zell-/BMS-Werte) und ein fehlender Kanonik-Sensor (Netzbezug) sind als `__ROLLE__`-Platzhalter markiert.
+Nur echte hardwarespezifische Sensoren (Zell-/BMS-Werte) sind als `__ROLLE__`-Platzhalter markiert.
 
 ## Quelle und Auswahl
 
@@ -28,7 +28,6 @@ Alles andere ist bereits fest auf kanonische opti-Entitäten verdrahtet (siehe n
 
 | Platzhalter | Bedeutung | Einheit / Vorzeichenkonvention | Bens Original-Entität (Referenz) | Hinweis für die Zielinstanz |
 |---|---|---|---|---|
-| `__NETZ_BEZUG_W__` | Netzbezug (Import aus dem Netz) | W, positiv = Bezug aus dem Netz | (kein kanonischer Sensor vorhanden) | Der Canonical-Layer liefert nur `sensor.opti_grid_export_w` (Einspeisung). Für das Flussdiagramm wird zusätzlich der Import benötigt. Huawei stellt dafür meist einen signierten Zähler oder einen eigenen Consumption-Sensor bereit. |
 | `__ZELL_SPREIZUNG_MV__` | Zellspannungs-Spreizung (max - min) | mV, positiv | `sensor.byd_zellspreizung` | Zell-Level-Wert eines externen BMS-Auslesers. Auf Huawei LUNA2000 in der Regel nicht vorhanden. Abschnitt "Akku-Gesundheit" sonst entfernen. |
 | `__ZELL_SPANNUNG_MIN_V__` | niedrigste Zellspannung | V | `sensor.byd_zellspannung_min` | wie oben |
 | `__ZELL_SPANNUNG_MAX_V__` | höchste Zellspannung | V | `sensor.byd_zellspannung_max` | wie oben |
@@ -49,6 +48,7 @@ Die Vorzeichen-/Einheiten-Konventionen stammen aus `docs/canonical-layer.md` die
 | `sensor.opti_pv_power_w` | PV-AC-Leistung | W, immer >= 0 |
 | `sensor.opti_house_consumption_w` | Hausverbrauch | W, >= 0 |
 | `sensor.opti_grid_export_w` | Einspeisung ins Netz | W, **positiv = Einspeisung**, immer >= 0 |
+| `sensor.opti_grid_import_w` | Netzbezug (Import) | W, **positiv = Bezug**, immer >= 0 (optionaler Anzeige-Sensor, siehe `docs/canonical-layer.md`) |
 | `sensor.opti_battery_temp` | Akku-Temperatur | °C |
 | `sensor.opti_battery_capacity_kwh` | nutzbare Kapazität | kWh |
 | `sensor.opti_target_soc` | intelligenter Ziel-SoC | % |
@@ -114,8 +114,8 @@ Das Template hat eine einzige View "Übersicht" mit folgenden Abschnitten (von o
 ## Ergänzte Karten
 
 - **Energiefluss-Diagramm** (`custom:power-flow-card-plus`), Abschnitt "⚡ Energiefluss (Live-Diagramm)": neu empfohlen, nicht aus einem bestehenden Dashboard 1:1 kopiert. Die Karte ist auf die kanonischen opti-Sensoren gemappt.
-  - PV: `sensor.opti_pv_power_w`, Haus: `sensor.opti_house_consumption_w`, Einspeisung: `sensor.opti_grid_export_w`, Batterie: `sensor.opti_battery_power_w` mit SoC `sensor.opti_soc`.
-  - **Netzbezug** ist als `__NETZ_BEZUG_W__` offen, weil der Canonical-Layer keinen Import-Sensor hat.
+  - PV: `sensor.opti_pv_power_w`, Haus: `sensor.opti_house_consumption_w`, Netzbezug: `sensor.opti_grid_import_w`, Einspeisung: `sensor.opti_grid_export_w`, Batterie: `sensor.opti_battery_power_w` mit SoC `sensor.opti_soc`.
+  - **Netzbezug**: `sensor.opti_grid_import_w` ist der optionale, symmetrisch zu `opti_grid_export_w` ergänzte Canonical-Sensor (siehe `docs/canonical-layer.md`, Sensor 6b). Fehlt er auf der Zielinstanz, im Mapping die Bezugsquelle nachtragen oder den grid-consumption-Eintrag entfernen.
   - **Batterie-Vorzeichen**: opti nutzt "positiv = laden". `power-flow-card-plus` erwartet standardmäßig "positiv = entladen (zum Haus)". Deshalb steht `invert_state: true` in der Batterie-Konfiguration. Beim Nachbau prüfen, ob die Flussrichtung stimmt, und `invert_state` sonst umstellen.
 
 ## Bewusst ausgelassen

--- a/dashboard-template/README.md
+++ b/dashboard-template/README.md
@@ -88,8 +88,10 @@ Auf der Zielinstanz laut Vorgabe bereits vorhanden: `mushroom`, `power-flow-card
 | Mushroom-Template-/Select-Card | `custom:mushroom-template-card`, `custom:mushroom-select-card` | `piitaya/lovelace-mushroom` | v5.1.1 | vorhanden |
 | Power Flow Card Plus | `custom:power-flow-card-plus` | `flixlix/power-flow-card-plus` | v0.3.7 | vorhanden |
 | card-mod (CSS in `card_mod:`) | (Ressource, kein Kartentyp) | `thomasloven/lovelace-card-mod` | v4.2.1 | **nachinstallieren** |
-| Bar Card | `custom:bar-card` | `custom-cards/bar-card` | 3.2.0 | **nachinstallieren** |
 | ApexCharts Card | `custom:apexcharts-card` | `RomRider/apexcharts-card` | v2.2.3 | **nachinstallieren** |
+
+Die frühere Bar Card (`custom-cards/bar-card`) ist unmaintained und aus dem HACS-Default-Index entfernt.
+Der "Tage seit 100%"-Balken ist deshalb eine native `tile`-Karte mit `bar-gauge`-Feature (min 0 / max 14); dabei entfallen die Severity-Farbschwellen der alten Karte.
 
 Ohne `card-mod` rendern die Mushroom-Karten trotzdem, nur der Zeilenumbruch im `secondary`-Text greift nicht.
 Der `card_mod`-Block kann dann alternativ entfernt werden.
@@ -120,7 +122,7 @@ Das Template hat eine einzige View "Übersicht" mit folgenden Abschnitten (von o
 
 - **Personenbezogene Karten**: In dieser Übersicht-View gab es keine (keine Personen-Tracker, Kalender, Kameras, Anwesenheit). Es musste nichts entfernt werden.
 - **Zelltemperatur über 5 Module** (`custom:mushroom-template-card` mit `sensor.byd_modul_1..5_temp_min/max`): ausgelassen, stark BYD-spezifisch (fünf Einzelmodule eines externen BMS-Auslesers).
-- **Per-Modul-Balkenkarte** "Module: min. Zellspannung" (`custom:bar-card` mit `sensor.byd_modul_1..5_zellspannung_min`): ausgelassen, gleiche BYD-Modul-Spezifik.
+- **Per-Modul-Balkenkarte** "Module: min. Zellspannung" (`sensor.byd_modul_1..5_zellspannung_min`, in Bens Live-Config inzwischen fünf native `tile`-Karten mit `bar-gauge` statt der früheren `custom:bar-card`): ausgelassen, gleiche BYD-Modul-Spezifik.
 - Beide Karten lassen sich auf einer Instanz mit vergleichbaren Modul-Sensoren aus Bens Live-Config wieder ergänzen. Für die Huawei-Zielinstanz sind sie nicht sinnvoll portierbar.
 
 ## Privacy-Hinweise

--- a/dashboard-template/uebersicht.json
+++ b/dashboard-template/uebersicht.json
@@ -265,32 +265,15 @@
               }
             },
             {
-              "type": "custom:bar-card",
+              "type": "tile",
               "entity": "counter.tage_seit_akku100",
               "name": "Tage seit 100%",
               "icon": "mdi:calendar-refresh",
-              "max": 14,
-              "positions": {
-                "icon": "outside",
-                "indicator": "outside",
-                "name": "inside",
-                "value": "inside"
-              },
-              "severity": [
+              "features": [
                 {
-                  "color": "#4caf50",
-                  "from": 0,
-                  "to": 9
-                },
-                {
-                  "color": "#ff9800",
-                  "from": 10,
-                  "to": 13
-                },
-                {
-                  "color": "#f44336",
-                  "from": 14,
-                  "to": 60
+                  "type": "bar-gauge",
+                  "min": 0,
+                  "max": 14
                 }
               ]
             },

--- a/dashboard-template/uebersicht.json
+++ b/dashboard-template/uebersicht.json
@@ -1,0 +1,613 @@
+{
+  "views": [
+    {
+      "title": "Übersicht",
+      "path": "uebersicht",
+      "type": "sections",
+      "max_columns": 3,
+      "icon": "mdi:battery-heart-variant",
+      "sections": [
+        {
+          "title": "⚡ Energiefluss (Live-Diagramm)",
+          "cards": [
+            {
+              "type": "custom:power-flow-card-plus",
+              "clickable_entities": true,
+              "entities": {
+                "grid": {
+                  "entity": {
+                    "consumption": "__NETZ_BEZUG_W__",
+                    "production": "sensor.opti_grid_export_w"
+                  }
+                },
+                "solar": {
+                  "entity": "sensor.opti_pv_power_w"
+                },
+                "battery": {
+                  "entity": "sensor.opti_battery_power_w",
+                  "state_of_charge": "sensor.opti_soc",
+                  "invert_state": true
+                },
+                "home": {
+                  "entity": "sensor.opti_house_consumption_w"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "title": "🔋 Status jetzt",
+          "cards": [
+            {
+              "type": "custom:mushroom-template-card",
+              "primary": "{{ states('input_select.akkusteuerung_modus') }}",
+              "secondary": "Strategie will: {{ states('sensor.opti_strategie_vorschau') }}",
+              "icon": "mdi:battery-charging-medium",
+              "icon_color": "{% set m = states('input_select.akkusteuerung_modus') %}{% if 'Entladen' in m %}orange{% elif 'Netzladen' in m %}red{% elif 'Laden' in m %}green{% elif m == 'Akku Pause' %}grey{% else %}blue{% endif %}",
+              "entity": "input_select.akkusteuerung_modus",
+              "tap_action": {
+                "action": "more-info"
+              },
+              "card_mod": {
+                "style": "ha-tile-info span { white-space: normal !important; text-overflow: clip !important; overflow: visible !important; }"
+              }
+            },
+            {
+              "type": "gauge",
+              "entity": "sensor.opti_soc",
+              "name": "Akku-SoC",
+              "unit": "%",
+              "min": 0,
+              "max": 100,
+              "needle": true,
+              "severity": {
+                "green": 50,
+                "yellow": 20,
+                "red": 0
+              }
+            },
+            {
+              "type": "tile",
+              "entity": "sensor.opti_battery_power_w",
+              "name": "Batterieleistung",
+              "icon": "mdi:home-battery"
+            },
+            {
+              "type": "custom:mushroom-template-card",
+              "primary": "Strategie-Vorschau: {{ states('sensor.opti_strategie_vorschau') }}",
+              "secondary": "{{ state_attr('sensor.opti_strategie_vorschau','grund') }}",
+              "icon": "mdi:eye-check",
+              "icon_color": "blue",
+              "entity": "sensor.opti_strategie_vorschau",
+              "tap_action": {
+                "action": "more-info"
+              },
+              "card_mod": {
+                "style": "ha-tile-info span { white-space: normal !important; text-overflow: clip !important; overflow: visible !important; }"
+              }
+            },
+            {
+              "type": "button",
+              "entity": "script.ki_opti_warum_erklaerung",
+              "name": "Warum? (KI-Erklärung)",
+              "icon": "mdi:head-question",
+              "show_state": false,
+              "tap_action": {
+                "action": "toggle"
+              }
+            }
+          ]
+        },
+        {
+          "title": "⚡ Energiefluss (Kacheln)",
+          "cards": [
+            {
+              "type": "tile",
+              "entity": "sensor.opti_pv_power_w",
+              "name": "PV",
+              "icon": "mdi:solar-power"
+            },
+            {
+              "type": "tile",
+              "entity": "sensor.opti_house_consumption_w",
+              "name": "Hausverbrauch",
+              "icon": "mdi:home-lightning-bolt"
+            },
+            {
+              "type": "tile",
+              "entity": "sensor.opti_grid_export_w",
+              "name": "Einspeisung",
+              "icon": "mdi:transmission-tower-export"
+            },
+            {
+              "type": "tile",
+              "entity": "sensor.opti_battery_power_w",
+              "name": "Batterie",
+              "icon": "mdi:home-battery"
+            },
+            {
+              "type": "tile",
+              "entity": "sensor.opti_battery_temp",
+              "name": "Akku-Temp",
+              "icon": "mdi:thermometer"
+            },
+            {
+              "type": "tile",
+              "entity": "sensor.opti_battery_capacity_kwh",
+              "name": "Kapazität",
+              "icon": "mdi:battery-high"
+            }
+          ]
+        },
+        {
+          "title": "🧠 Strategie-Intelligenz",
+          "cards": [
+            {
+              "type": "tile",
+              "entity": "sensor.opti_target_soc",
+              "name": "Ziel-SoC",
+              "icon": "mdi:target"
+            },
+            {
+              "type": "tile",
+              "entity": "sensor.opti_price_current_ct_kwh",
+              "name": "Preis jetzt",
+              "icon": "mdi:cash"
+            },
+            {
+              "type": "custom:mushroom-template-card",
+              "primary": "Preisniveau",
+              "secondary": "{{ states('sensor.opti_price_level') }}",
+              "icon": "mdi:cash-clock",
+              "icon_color": "{% set p = states('sensor.opti_price_level') %}{% if p in ['VERY_CHEAP','CHEAP'] %}green{% elif p == 'NORMAL' %}blue{% elif p == 'EXPENSIVE' %}orange{% else %}red{% endif %}",
+              "entity": "sensor.opti_price_level",
+              "card_mod": {
+                "style": "ha-tile-info span { white-space: normal !important; text-overflow: clip !important; overflow: visible !important; }"
+              }
+            },
+            {
+              "type": "tile",
+              "entity": "sensor.opti_mindestentladepreis_ct_kwh",
+              "name": "Mind.-Entladepreis",
+              "icon": "mdi:cash-minus"
+            },
+            {
+              "type": "tile",
+              "entity": "sensor.opti_forecast_score",
+              "name": "Prognose heute",
+              "icon": "mdi:weather-sunny"
+            },
+            {
+              "type": "tile",
+              "entity": "sensor.opti_forecast_score_tomorrow",
+              "name": "Prognose morgen",
+              "icon": "mdi:weather-partly-cloudy"
+            },
+            {
+              "type": "tile",
+              "entity": "sensor.opti_peak_reserve_soc",
+              "name": "Peak-Reserve SoC",
+              "icon": "mdi:chart-timeline-variant"
+            },
+            {
+              "type": "tile",
+              "entity": "binary_sensor.opti_peak_reserve_aktiv",
+              "name": "Peak-Reserve aktiv",
+              "icon": "mdi:flash-alert"
+            },
+            {
+              "type": "tile",
+              "entity": "binary_sensor.opti_winter_charging_allowed",
+              "name": "Winterladen frei",
+              "icon": "mdi:snowflake"
+            }
+          ]
+        },
+        {
+          "title": "🔮 Prognose-Sicherheit",
+          "cards": [
+            {
+              "type": "custom:mushroom-template-card",
+              "primary": "Heute: {{ state_attr('sensor.opti_forecast_effective_remaining_kwh','p10_kwh')|round(0)|int }} - {{ state_attr('sensor.opti_forecast_effective_remaining_kwh','median_kwh')|round(0)|int }} kWh",
+              "secondary": "Effektiv {{ states('sensor.opti_forecast_effective_remaining_kwh')|round(0)|int }} kWh (α {{ (state_attr('sensor.opti_forecast_effective_remaining_kwh','alpha')|float(0)*100)|round(0)|int }}%) · Score {{ states('sensor.opti_forecast_score') }}",
+              "icon": "mdi:cloud-percent",
+              "icon_color": "{% set p = state_attr('sensor.opti_forecast_effective_remaining_kwh','p10_kwh')|float(0) %}{% set m = state_attr('sensor.opti_forecast_effective_remaining_kwh','median_kwh')|float(1) %}{% set r = (p/m) if m>0 else 0 %}{% if r < 0.3 %}red{% elif r < 0.6 %}orange{% else %}green{% endif %}",
+              "entity": "sensor.opti_forecast_effective_remaining_kwh",
+              "tap_action": {
+                "action": "more-info"
+              },
+              "card_mod": {
+                "style": "ha-tile-info span { white-space: normal !important; text-overflow: clip !important; overflow: visible !important; }"
+              }
+            },
+            {
+              "type": "custom:mushroom-template-card",
+              "primary": "Morgen: {{ state_attr('sensor.opti_forecast_tomorrow_kwh','estimate10')|round(0)|int }} - {{ states('sensor.opti_forecast_tomorrow_kwh')|round(0)|int }} kWh",
+              "secondary": "Sicherheit {% set p = state_attr('sensor.opti_forecast_tomorrow_kwh','estimate10')|float(0) %}{% set m = states('sensor.opti_forecast_tomorrow_kwh')|float(1) %}{{ ((p/m*100) if m>0 else 0)|round(0)|int }}% · Score morgen {{ states('sensor.opti_forecast_score_tomorrow') }}",
+              "icon": "mdi:weather-partly-cloudy",
+              "icon_color": "{% set p = state_attr('sensor.opti_forecast_tomorrow_kwh','estimate10')|float(0) %}{% set m = states('sensor.opti_forecast_tomorrow_kwh')|float(1) %}{% set r = (p/m) if m>0 else 0 %}{% if r < 0.3 %}red{% elif r < 0.6 %}orange{% else %}green{% endif %}",
+              "entity": "sensor.opti_forecast_tomorrow_kwh",
+              "tap_action": {
+                "action": "more-info"
+              },
+              "card_mod": {
+                "style": "ha-tile-info span { white-space: normal !important; text-overflow: clip !important; overflow: visible !important; }"
+              }
+            },
+            {
+              "type": "tile",
+              "entity": "input_number.opti_forecast_optimismus",
+              "name": "Forecast-Optimismus (α %)",
+              "icon": "mdi:weather-sunny",
+              "features": [
+                {
+                  "type": "numeric-input"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "🩺 Balancing-Watchdog",
+          "cards": [
+            {
+              "type": "custom:mushroom-template-card",
+              "primary": "Watchdog: {{ states('sensor.opti_balancing_watchdog') | upper }}",
+              "secondary": "{{ state_attr('sensor.opti_balancing_watchdog','grund') }}",
+              "icon": "mdi:battery-heart-variant",
+              "icon_color": "{% set s = states('sensor.opti_balancing_watchdog') %}{% if s == 'pv' %}green{% elif s == 'netz' %}orange{% else %}grey{% endif %}",
+              "entity": "sensor.opti_balancing_watchdog",
+              "tap_action": {
+                "action": "more-info"
+              },
+              "card_mod": {
+                "style": "ha-tile-info span { white-space: normal !important; text-overflow: clip !important; overflow: visible !important; }"
+              }
+            },
+            {
+              "type": "custom:bar-card",
+              "entity": "counter.tage_seit_akku100",
+              "name": "Tage seit 100%",
+              "icon": "mdi:calendar-refresh",
+              "max": 14,
+              "positions": {
+                "icon": "outside",
+                "indicator": "outside",
+                "name": "inside",
+                "value": "inside"
+              },
+              "severity": [
+                {
+                  "color": "#4caf50",
+                  "from": 0,
+                  "to": 9
+                },
+                {
+                  "color": "#ff9800",
+                  "from": 10,
+                  "to": 13
+                },
+                {
+                  "color": "#f44336",
+                  "from": 14,
+                  "to": 60
+                }
+              ]
+            },
+            {
+              "type": "tile",
+              "entity": "input_boolean.opti_balancing_netzladen",
+              "name": "Balancing darf ans Netz",
+              "icon": "mdi:transmission-tower",
+              "features": [
+                {
+                  "type": "toggle"
+                }
+              ]
+            },
+            {
+              "type": "tile",
+              "entity": "input_number.opti_balancing_intervall_tage",
+              "name": "Intervall (Tage)",
+              "features": [
+                {
+                  "type": "numeric-input"
+                }
+              ]
+            },
+            {
+              "type": "tile",
+              "entity": "input_number.opti_balancing_karenz_tage",
+              "name": "Karenz (Tage)",
+              "features": [
+                {
+                  "type": "numeric-input"
+                }
+              ]
+            },
+            {
+              "type": "tile",
+              "entity": "input_number.opti_balancing_max_ct",
+              "name": "Preisdeckel ct/kWh",
+              "features": [
+                {
+                  "type": "numeric-input"
+                }
+              ]
+            },
+            {
+              "type": "tile",
+              "entity": "input_number.opti_balancing_done_soc",
+              "name": "Done-SoC %",
+              "features": [
+                {
+                  "type": "numeric-input"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "🤖 KI-Tagesanalyse",
+          "cards": [
+            {
+              "type": "custom:mushroom-template-card",
+              "primary": "Report: {{ states('sensor.opti_ki_analyse') }}",
+              "secondary": "{{ state_attr('sensor.opti_ki_analyse','zusammenfassung') }}",
+              "icon": "mdi:robot-outline",
+              "icon_color": "{% set s = states('sensor.opti_ki_analyse') %}{% if s == 'auffaellig' %}orange{% elif s == 'ok' %}green{% else %}grey{% endif %}",
+              "entity": "sensor.opti_ki_analyse",
+              "tap_action": {
+                "action": "more-info"
+              },
+              "multiline_secondary": true,
+              "card_mod": {
+                "style": "ha-tile-info span { white-space: normal !important; text-overflow: clip !important; overflow: visible !important; }"
+              }
+            },
+            {
+              "type": "tile",
+              "entity": "input_boolean.opti_ki_tagesreport_immer",
+              "name": "Report immer senden",
+              "icon": "mdi:message-text-clock",
+              "features": [
+                {
+                  "type": "toggle"
+                }
+              ]
+            },
+            {
+              "type": "tile",
+              "entity": "input_datetime.opti_ki_last_success",
+              "name": "Letzter Erfolg",
+              "icon": "mdi:check-circle-outline"
+            }
+          ]
+        },
+        {
+          "title": "🔬 Akku-Gesundheit (BMS, optional)",
+          "cards": [
+            {
+              "type": "custom:mushroom-template-card",
+              "primary": "Zellspreizung: {{ states('__ZELL_SPREIZUNG_MV__') }} mV",
+              "secondary": "min {{ states('__ZELL_SPANNUNG_MIN_V__') }} V · max {{ states('__ZELL_SPANNUNG_MAX_V__') }} V · avg {{ states('__ZELL_SPANNUNG_AVG_V__') }} V",
+              "icon": "mdi:arrow-expand-vertical",
+              "icon_color": "{% set s = states('__ZELL_SPREIZUNG_MV__')|float(-1) %}{% if s < 0 %}grey{% elif s < 30 %}green{% elif s < 60 %}orange{% else %}red{% endif %}",
+              "entity": "__ZELL_SPREIZUNG_MV__",
+              "tap_action": {
+                "action": "more-info"
+              },
+              "card_mod": {
+                "style": "ha-tile-info span { white-space: normal !important; text-overflow: clip !important; overflow: visible !important; }"
+              }
+            },
+            {
+              "type": "tile",
+              "entity": "__BATT_SOH__",
+              "name": "State of Health",
+              "icon": "mdi:battery-heart-variant"
+            },
+            {
+              "type": "tile",
+              "entity": "__BMS_BALANCING_AKTIV__",
+              "name": "Balancing aktiv (BMS)",
+              "icon": "mdi:scale-balance"
+            },
+            {
+              "type": "tile",
+              "entity": "__BMS_SOC__",
+              "name": "SoC laut BMS",
+              "icon": "mdi:battery-medium"
+            }
+          ]
+        },
+        {
+          "title": "🎛️ Steuerung & Regler",
+          "cards": [
+            {
+              "type": "tile",
+              "entity": "input_boolean.akku_opti_automatik",
+              "name": "Opti-Automatik (Master)",
+              "icon": "mdi:robot",
+              "features": [
+                {
+                  "type": "toggle"
+                }
+              ]
+            },
+            {
+              "type": "custom:mushroom-select-card",
+              "entity": "input_select.akkusteuerung_modus",
+              "name": "Modus manuell",
+              "icon": "mdi:tune-variant"
+            },
+            {
+              "type": "tile",
+              "entity": "input_boolean.opti_prognose_netzladen",
+              "name": "Prognose-Netzladen",
+              "icon": "mdi:transmission-tower-import",
+              "features": [
+                {
+                  "type": "toggle"
+                }
+              ]
+            },
+            {
+              "type": "tile",
+              "entity": "input_boolean.opti_pv_ueberschuss_ladung",
+              "name": "PV-Überschussladen",
+              "icon": "mdi:solar-power",
+              "features": [
+                {
+                  "type": "toggle"
+                }
+              ]
+            },
+            {
+              "type": "tile",
+              "entity": "input_boolean.hausakku_aus_netz_laden",
+              "name": "Manuell Netzladen",
+              "icon": "mdi:transmission-tower",
+              "features": [
+                {
+                  "type": "toggle"
+                }
+              ]
+            },
+            {
+              "type": "tile",
+              "entity": "input_number.minsoc",
+              "name": "MinSOC %",
+              "features": [
+                {
+                  "type": "numeric-input"
+                }
+              ]
+            },
+            {
+              "type": "tile",
+              "entity": "input_number.maxsoc",
+              "name": "MaxSOC %",
+              "features": [
+                {
+                  "type": "numeric-input"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "📈 Verlauf (24 h)",
+          "cards": [
+            {
+              "type": "custom:apexcharts-card",
+              "header": {
+                "show": true,
+                "title": "Preis & SoC"
+              },
+              "graph_span": "24h",
+              "yaxis": [
+                {
+                  "id": "ct",
+                  "decimals": 0
+                },
+                {
+                  "id": "soc",
+                  "opposite": true,
+                  "min": 0,
+                  "max": 100,
+                  "decimals": 0
+                }
+              ],
+              "series": [
+                {
+                  "entity": "sensor.opti_price_current_ct_kwh",
+                  "name": "Preis ct/kWh",
+                  "yaxis_id": "ct",
+                  "stroke_width": 2
+                },
+                {
+                  "entity": "sensor.opti_soc",
+                  "name": "SoC %",
+                  "yaxis_id": "soc",
+                  "type": "area",
+                  "stroke_width": 1,
+                  "opacity": 0.2
+                }
+              ]
+            },
+            {
+              "type": "custom:apexcharts-card",
+              "header": {
+                "show": true,
+                "title": "Leistung"
+              },
+              "graph_span": "24h",
+              "series": [
+                {
+                  "entity": "sensor.opti_pv_power_w",
+                  "name": "PV",
+                  "type": "area",
+                  "stroke_width": 1,
+                  "opacity": 0.2
+                },
+                {
+                  "entity": "sensor.opti_house_consumption_w",
+                  "name": "Haus",
+                  "stroke_width": 2
+                },
+                {
+                  "entity": "sensor.opti_battery_power_w",
+                  "name": "Batterie",
+                  "stroke_width": 2
+                }
+              ]
+            },
+            {
+              "type": "custom:apexcharts-card",
+              "header": {
+                "show": true,
+                "title": "Zellspannung & Spreizung (BMS, optional)"
+              },
+              "graph_span": "24h",
+              "yaxis": [
+                {
+                  "id": "volt",
+                  "decimals": 2
+                },
+                {
+                  "id": "mv",
+                  "opposite": true,
+                  "min": 0,
+                  "decimals": 0
+                }
+              ],
+              "series": [
+                {
+                  "entity": "__ZELL_SPANNUNG_MAX_V__",
+                  "name": "Zelle max V",
+                  "yaxis_id": "volt",
+                  "stroke_width": 1
+                },
+                {
+                  "entity": "__ZELL_SPANNUNG_MIN_V__",
+                  "name": "Zelle min V",
+                  "yaxis_id": "volt",
+                  "stroke_width": 1
+                },
+                {
+                  "entity": "__ZELL_SPREIZUNG_MV__",
+                  "name": "Spreizung mV",
+                  "yaxis_id": "mv",
+                  "type": "area",
+                  "stroke_width": 2,
+                  "opacity": 0.2
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/dashboard-template/uebersicht.json
+++ b/dashboard-template/uebersicht.json
@@ -21,7 +21,7 @@
                   }
                 },
                 "solar": {
-                  "entity": "sensor.opti_pv_power_w"
+                  "entity": "sensor.opti_pv_generation_w"
                 },
                 "battery": {
                   "entity": "sensor.opti_battery_power_w",

--- a/dashboard-template/uebersicht.json
+++ b/dashboard-template/uebersicht.json
@@ -16,7 +16,7 @@
               "entities": {
                 "grid": {
                   "entity": {
-                    "consumption": "__NETZ_BEZUG_W__",
+                    "consumption": "sensor.opti_grid_import_w",
                     "production": "sensor.opti_grid_export_w"
                   }
                 },

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -29,6 +29,7 @@ opti_mapping.yaml  →  sensor.opti_*  →  opti_derived.yaml  →  opti_strateg
 | `sensor.opti_pv_power_w` | W | ≥ 0 (AC-Ausgangsleistung) | `sensor.sma_pv_power` | `sensor.huawei_pv_power` | Direkt |
 | `sensor.opti_pv_generation_w` | W | ≥ 0 (DC-Eingangsleistung) | `sensor.sma_pv_generation` | `sensor.huawei_pv_generation` | Direkt |
 | `sensor.opti_grid_export_w` | W | **≥ 0** (positiv = Einspeisung) | `sensor.sma_grid_export_power` | `sensor.huawei_grid_export_power` | Einspeisung positiv: `[0, float(0)] \| max`; Einspeisung negativ: `[0, float(0) * -1] \| max` |
+| `sensor.opti_grid_import_w` | W | **≥ 0** (positiv = Bezug) | `sensor.sma_metering_power_absorbed` | `sensor.huawei_grid_consumption_power` | Bezug positiv: `[0, float(0)] \| max`; Bezug negativ: `[0, float(0) * -1] \| max` |
 | `sensor.opti_house_consumption_w` | W | ≥ 0 | `sensor.sma_house_consumption` | `sensor.huawei_house_consumption` | Direkt |
 | `sensor.opti_price_current_ct_kwh` | ct/kWh | beliebig | `sensor.tibber_electricity_price` (EUR/kWh) | `sensor.nordpool_electricity_price` (EUR/kWh) | `float(0) * 100` |
 | `sensor.opti_price_series` | ct/kWh | Attribut `today`/`tomorrow` = Listen in ct/kWh | `sensor.tibber_electricity_price` | `sensor.nordpool_electricity_price` | EUR-Attribut-Listen × 100 (im Mapping normalisiert) |
@@ -47,6 +48,14 @@ Alle nachgelagerten Sensoren arbeiten intern mit ct/kWh.
 **`opti_grid_export_w`:** Immer ≥ 0. Positiv = Einspeisung ins Netz. Je nach Wechselrichter
 das Vorzeichen im Mapping korrigieren (Kommentare in `opti_mapping.example.yaml` unter
 Sensor 6 beschreiben beide Varianten).
+
+**`opti_grid_import_w` (optional):** Immer ≥ 0. Positiv = Bezug aus dem Netz. Symmetrisch zu
+`opti_grid_export_w`, nur mit umgekehrtem Vorzeichen des Quellzählers (Sensor 6b in
+`opti_mapping.example.yaml`). Wird von der Strategie **nicht** konsumiert - er dient nur der
+Anzeige (z. B. der `power-flow-card-plus` im Übersichts-Dashboard, die Bezug UND Einspeisung als
+Leistung braucht). Bei SMA typischerweise `..._metering_power_absorbed` (positiv = Bezug), bei
+einem signierten Netz-Zähler das Vorzeichen entsprechend drehen. Fehlt eine Bezugsquelle, den
+Sensor einfach ungemappt lassen.
 
 **`opti_battery_power_w`:** Positiv = Batterie lädt (`+=`-Konvention).
 - SMA: Zwei separate Sensoren für Laden/Entladen (beide ≥ 0) → `charge - discharge`
@@ -308,6 +317,7 @@ In `packages/opti_mapping.yaml` alle `DEIN_*`-Platzhalter durch die echten Entit
 | `sensor.DEIN_PV_POWER` | `sensor.sma_pv_power` | `sensor.huawei_pv_power` |
 | `sensor.DEIN_PV_GENERATION` | `sensor.sma_pv_generation` | `sensor.huawei_pv_generation` |
 | `sensor.DEIN_GRID_EXPORT` | `sensor.sma_grid_export_power` | `sensor.huawei_grid_export_power` |
+| `sensor.DEIN_GRID_IMPORT` (optional) | `sensor.sma_metering_power_absorbed` | `sensor.huawei_grid_consumption_power` |
 | `sensor.DEIN_HAUSVERBRAUCH` | `sensor.sma_house_consumption` | `sensor.huawei_house_consumption` |
 | `sensor.DEIN_STROMPREIS` | `sensor.tibber_electricity_price` | `sensor.nordpool_electricity_price` |
 | `sensor.DEIN_PREIS_REIHE` | `sensor.tibber_electricity_price` | `sensor.nordpool_electricity_price` |

--- a/opti_mapping.example.yaml
+++ b/opti_mapping.example.yaml
@@ -102,6 +102,27 @@ template:
         # state: "{{ [0, states('sensor.DEIN_GRID_EXPORT') | float(0) * -1] | max }}"
 
       # -----------------------------------------------------------------------
+      # 6b. Netz-Bezug (W) — IMMER >= 0 (positiv = Bezug aus dem Netz)
+      # Symmetrisch zu opti_grid_export_w, nur mit umgekehrtem Vorzeichen.
+      #
+      # Vorzeichen-Rezept:
+      #   Quelle positiv = Netzbezug (SMA metering_power_absorbed, eigener Bezugs-Zähler):
+      #     state: "{{ [0, states('sensor.DEIN_GRID_IMPORT') | float(0)] | max }}"
+      #   Quelle positiv = Einspeisung (Bezug ist negativ, z. B. ein signierter Netz-Zähler):
+      #     state: "{{ [0, states('sensor.DEIN_GRID_IMPORT') | float(0) * -1] | max }}"
+      # -----------------------------------------------------------------------
+      - unique_id: opti_mapping_grid_import_w
+        name: "Opti Grid Import W"
+        unit_of_measurement: "W"
+        device_class: power
+        state_class: measurement
+        availability: "{{ has_value('sensor.DEIN_GRID_IMPORT') }}"
+        # Standard: Quelle positiv = Netzbezug → auf >= 0 clippen
+        state: "{{ [0, states('sensor.DEIN_GRID_IMPORT') | float(0)] | max }}"
+        # Alternative: Quelle positiv = Einspeisung (Bezug negativ) → Vorzeichen drehen:
+        # state: "{{ [0, states('sensor.DEIN_GRID_IMPORT') | float(0) * -1] | max }}"
+
+      # -----------------------------------------------------------------------
       # 7. Hausverbrauch (W)
       # -----------------------------------------------------------------------
       - unique_id: opti_mapping_house_consumption_w


### PR DESCRIPTION
## Was

1. **`dashboard-template/`**: portables Template der Übersicht-View (für die Portierung auf eine Huawei-Instanz, Spec: UEBERGABEPROMPT-DASHBOARD-TEMPLATE.md).
   Rund 40 Rollen direkt auf Canonical-Sensoren verdrahtet, nur noch 7 BMS/Zell-Platzhalter.
   README mit Rollen-Tabelle, Vorzeichenkonventionen und HACS-Abhängigkeiten (Ziel braucht noch: card-mod, bar-card, apexcharts-card).
   Ergänzt: power-flow-card-plus als Energiefluss-Diagramm (auf Ziel vorhanden).
2. **`sensor.opti_grid_import_w`**: Canonical-Layer symmetrisch zum Export erweitert (immer >= 0, positiv = Bezug; `opti_mapping.example.yaml` Sensor 6b + `docs/canonical-layer.md`).

## Live-Status (12.7.)

Beides bereits deployed und verifiziert: Import-Sensor aus `..._metering_power_absorbed` (0 W bei Einspeisung bestätigt), Flow-Karte in der Übersicht aktiv.
Dieser PR holt das Repo auf den Live-Stand.
