### PR TITLE
feat(byd): Modul-2 Fruehwarnung (Absackung + Nettoenergie bis Knie + Zell-ID-Tracking)

### DIFF
--- a/docs/byd-modul2-fruehwarnung-design.md
+++ b/docs/byd-modul2-fruehwarnung-design.md
@@ -113,7 +113,7 @@ Aktion am Anker:
 
 - Beide Utility Meter zurücksetzen (`utility_meter.reset`).
 - `byd_knie_ref_frozen` := aktueller `byd_knie_referenzspannung`.
-- `byd_knie_ueberschwelle_gesehen` := off.
+- `byd_knie_ueberschwelle_gesehen` := **on** (am Anker ist Modul 2 verifiziert hoch; das flankengetriggerte Guard bliebe sonst aus - Review-Fix C1). Die separate Guard-Automation bleibt als redundanter Backup.
 - `byd_knie_cycle_id` := jetzt (ISO), `byd_voll_anker_zeit` := jetzt.
 - `byd_knie_zyklus_status` := `armed`.
 

--- a/docs/byd-modul2-fruehwarnung-design.md
+++ b/docs/byd-modul2-fruehwarnung-design.md
@@ -41,10 +41,13 @@ Verifizierte Fakten:
 - Die Zähler sind als **Absolutpaar inkonsistent** (unterschiedliche Epochen, Residuum ~1300 kWh), ihre **Inkremente über Stunden** sind aber brauchbar (Befund 12.7.).
 - **Kein direkter Stromsensor (A).** Deshalb Energie statt Ah; Strom ließe sich nur als `Leistung / Packspannung` schätzen (nicht Teil dieses Designs).
 
-Empirisch vor Implementierung zu verifizieren (siehe §12):
+Empirisch verifiziert (2026-07-15, Live-Historie):
 
-- **Vorzeichen von `sensor.byd_leistung`**: Annahme negativ = Entladen. Muss an echter Historie bestätigt werden, bevor das Lastband greift.
-- Erreicht Modul-2-min bei normalen Entladungen die 3,20-V-Schwelle oft genug (an flachen Tagen bottomte es ~3,24 V)? Referenzspannung ggf. nachziehen.
+- **Vorzeichen von `sensor.byd_leistung`: positiv = Entladen, negativ = Laden.**
+  Belegt: bei SoC 90 %, `zellmax` steigend, Balancing on war die Leistung −1030 W (= Laden); nachts konstant +700 W (= Hausentladung), tagsüber negativ (= PV-Ladung).
+  Das Lastband (§6.3) ist damit `sensor.byd_leistung` im Bereich **+500…+1500 W**.
+- **3,20-V-Trigger-Frequenz: sparsam.** Modul-2-min erreichte 3,20 V nur am tiefen Tag (SoC 21 %, min 3,178 V), an flachen Tagen ~3,24 V.
+  Der Latch feuert also nur an Tagen mit tiefer Entladung (~1 von 3 beim aktuellen Zyklen-Niveau). Valide, aber selten; bei zu wenigen Datenpunkten Referenz auf 3,24 V anheben (Regler vorhanden).
 
 ## 4. Architektur-Überblick
 
@@ -139,8 +142,8 @@ Ein reines Ruhefenster (<300 W) taugt am Knie ebenfalls nicht (tritt evtl. stund
 
 `binary_sensor.byd_entladeband` = on, wenn:
 
-- Vorzeichen eindeutig **Entladen** (nie Laden/unbekannt), UND
-- Entladeleistung im Band **0,5-1,5 kW** (≈ 1-3 A ≈ 0,04-0,12 C bei ~512 V).
+- Vorzeichen eindeutig **Entladen** (`sensor.byd_leistung` > 0; verifiziert: positiv = Entladen), UND
+- Entladeleistung im Band **+500…+1500 W** (≈ 1-3 A ≈ 0,04-0,12 C bei ~512 V).
 
 Der Latch verlangt, dass dieses Band über das gesamte Bestätigungsfenster (§6.4) gehalten wurde (Leistung nicht um mehr als ~300-500 W springt).
 Falls das Band real zu selten vorkommt, auf 0,5-2,0 kW erweitern - dann aber Messungen verschiedener Lastklassen **nicht** ungekennzeichnet vergleichen (Lastklasse wird am Latch mitgespeichert).

--- a/docs/byd-modul2-fruehwarnung-design.md
+++ b/docs/byd-modul2-fruehwarnung-design.md
@@ -1,0 +1,251 @@
+# BYD Modul-2 Frühwarnung - Design
+
+Stand: 2026-07-15.
+Branch: `feat/byd-modul2-fruehwarnung` (abgezweigt von `feat/byd-bmu-monitoring`, PR #39).
+Reviewer: Codex (adversarial Design-Review am 2026-07-15 eingearbeitet).
+
+## 1. Kontext und Ziel
+
+Das schwächste Modul der BYD Battery-Box Premium HVS 12.8 (Modul 2) sackt am unteren LFP-Entlade-Knie reproduzierbar unter die anderen vier Module.
+Diagnose (Codex + Photovoltaikforum-Vergleich): das ist die klassische Signatur des schwächsten Glieds, kein Defekt - der Pack streut sogar enger als vergleichbare HVS im Feld.
+Entscheidend für die Defekt-Früherkennung ist nicht ein einzelner mV-Wert, sondern der **Trend über Wochen**.
+
+Ziel dieses Features: zwei abgeleitete Größen dauerhaft und belastbar loggen, sodass eine echte Degradation von normaler Streuung unterscheidbar wird, ohne dass Last, SoC-Drift, MQTT-Aussetzer oder Zähler-Artefakte den Trend verfälschen.
+
+Zwei Kennzahlen (Ben hat "beides, voll gehärtet" gewählt):
+
+- **Sensor A - Relative Zell-Absackung** (mV, Alltags-Diagnose, immer an): wie weit Modul 2 unter dem Feld liegt.
+- **Sensor B - Nettoenergie bis Knie** (kWh, Wochen-Metrik): wie viel Nettoenergie ab Ladeabschluss entnommen wurde, bis Modul 2 unter definierter Last eine Referenzspannung erreicht.
+
+Die Metrik heißt bewusst **Nettoenergie**, nicht Kapazität: ohne Ah-/Strom-Zählung wird nutzbare Energie gemessen, nicht Zellkapazität in Ah.
+
+## 2. Nicht-Ziele (YAGNI)
+
+- **Kein Alarm/Schwellwert** in dieser Ausbaustufe. Erst nach 4-8 gültigen, vergleichbaren Zyklen Baseline bilden, dann in einem Folge-PR eine Warnschwelle festlegen.
+- Kein Wirkungsgrad-Korrekturfaktor. Saubere und gemischte Zyklen werden getrennt ausgewertet, nicht rechnerisch korrigiert.
+- Keine parallelen Hilfssensoren für Median/Max/Ruhe über mehrere SoC-Bänder. Der am Latch festgehaltene Wert normiert bereits.
+- Keine Zelleinzel-Auflösung (die liefert nur Be Connect Plus, manuell). Wir arbeiten mit dem Modul-Minimum.
+
+## 3. Datenquellen und verifizierte Fakten
+
+Quelle: `bydlogc` via MQTT, Abtastung ~60 s, gemappt in `packages/byd_bmu.yaml`.
+
+- Pro Modul 1-5: `sensor.byd_modul_N_zellspannung_min` / `_max`, `_temp_min` / `_temp_max` (V bzw. °C, `expire_after: 300`).
+- Gesamt: `sensor.byd_soc` (%), `sensor.byd_leistung` (W), `sensor.byd_zellspannung_max`, `binary_sensor.byd_balancing_aktiv`.
+- Zähler: `sensor.byd_geladen_gesamt`, `sensor.byd_entladen_gesamt` (kWh, `total_increasing`).
+
+Verifizierte Fakten:
+
+- **Zähler-Auflösung 0,001 kWh** (beobachtete Rohwerte z. B. `6106.158` / `4768.690`).
+  Codex' Sorge einer 0,1-kWh-Quantisierung entfällt damit - die Auflösung trägt den Trend.
+- Die Zähler sind als **Absolutpaar inkonsistent** (unterschiedliche Epochen, Residuum ~1300 kWh), ihre **Inkremente über Stunden** sind aber brauchbar (Befund 12.7.).
+- **Kein direkter Stromsensor (A).** Deshalb Energie statt Ah; Strom ließe sich nur als `Leistung / Packspannung` schätzen (nicht Teil dieses Designs).
+
+Empirisch vor Implementierung zu verifizieren (siehe §12):
+
+- **Vorzeichen von `sensor.byd_leistung`**: Annahme negativ = Entladen. Muss an echter Historie bestätigt werden, bevor das Lastband greift.
+- Erreicht Modul-2-min bei normalen Entladungen die 3,20-V-Schwelle oft genug (an flachen Tagen bottomte es ~3,24 V)? Referenzspannung ggf. nachziehen.
+
+## 4. Architektur-Überblick
+
+Alles rein beobachtend, keine Steuerwirkung. Erweitert `packages/byd_bmu.yaml`.
+
+Entitäten:
+
+- **Helfer**
+  - `input_number.byd_knie_referenzspannung` - vom Nutzer einstellbare Referenz (Default 3,20 V, 3,05-3,35, Schritt 0,005).
+  - `input_number.byd_knie_ref_frozen` - beim Scharfschalten eingefrorene Referenz des laufenden Zyklus (verhindert, dass eine Schieberei am Regler mitten im Zyklus selbst eine Kreuzung erzeugt).
+  - `input_select.byd_knie_zyklus_status` - `idle` / `armed` / `latched` / `invalid`.
+  - `input_text.byd_knie_invalid_grund` - Klartext-Grund bei `invalid`.
+  - `input_text.byd_knie_cycle_id` - ID des laufenden Zyklus (ISO-Zeit des Voll-Ankers).
+  - `input_datetime.byd_voll_anker_zeit` - Zeit des letzten Ladeabschluss-Ankers.
+  - `input_boolean.byd_knie_ueberschwelle_gesehen` - seit Anker mind. einmal ein gültiger Wert klar oberhalb der Schwelle gesehen (Neustart-Fehl-Latch-Schutz).
+- **Utility Meter** (persistent, Reset nur am Voll-Anker)
+  - `utility_meter` auf `sensor.byd_geladen_gesamt` -> `sensor.byd_geladen_seit_voll`.
+  - `utility_meter` auf `sensor.byd_entladen_gesamt` -> `sensor.byd_entladen_seit_voll`.
+- **Template-/Binary-Sensoren**
+  - `binary_sensor.byd_daten_frisch` - alle benötigten Quellen numerisch und ≤120 s alt.
+  - `binary_sensor.byd_entladeband` - entlädt UND Leistung im standardisierten Band (s. §6.3).
+  - `sensor.byd_netto_energie_seit_voll` - laufende Nettoenergie (§6.2).
+  - `sensor.byd_modul2_absackung` - Sensor A, roh (§5).
+  - `sensor.byd_modul2_netto_bis_knie` - Sensor B, am Latch festgehalten (§6.4).
+- **Automationen**
+  - `byd_voll_anker` - erkennt Ladeabschluss, setzt Zyklus auf (§6.1).
+  - `byd_ueberschwelle_gesehen` - Arm-Guard (§6.4).
+  - `byd_knie_latch` - Latch beim qualifizierten Knie-Ereignis (§6.4).
+  - `byd_zyklus_invalid` - markiert Zyklus bei Mess-Qualitätsproblemen ungültig (§7).
+
+## 5. Sensor A - Relative Zell-Absackung (Diagnose)
+
+Immer-an-Template-Sensor, Einheit mV.
+
+```
+state = (median(Modul-1/3/4/5-min) − Modul-2-min) × 1000
+```
+
+- **Median der vier Peers**, nicht `min`: ein einzelnes fehlerhaftes Vergleichsmodul würde `min` nach unten ziehen und die Absackung verschleiern.
+- Positiv = Modul 2 ist das schwächste Glied. Negativ = ein anderes Modul liegt tiefer (wird nicht auf 0 geklemmt, damit ein Wandern der Schwäche sichtbar bleibt).
+- **Availability-Gate**: nur rechnen, wenn alle fünf Modul-Minima numerisch und ≤120 s alt sind (`binary_sensor.byd_daten_frisch`). Kein `float(0)`-Fallback.
+- Attribute: `soc`, `leistung_w`, `modul2_volt`, `peer_median_volt`, `schwaechstes_modul`.
+
+Für den Wochen-Trend wird **nicht** das rohe Maximum von A genutzt (empfindlich gegen einen einzigen Last-/MQTT-Ausreißer), sondern der A-Wert **am qualifizierten B2-Latch** (§6.4) - dort sind Zellspannung, Lastklasse und Haltezeit automatisch gleich. Sensor A roh dient der laufenden Sichtprüfung und der Historie.
+
+## 6. Sensor B - Nettoenergie bis Knie (Wochen-Metrik)
+
+### 6.1 Voll-Anker (Ladeabschluss-Event)
+
+`SoC ≥ 99 %` allein ist untauglich (LFP-SoC driftet, springt verzögert, flattert).
+Anker ist ein **Ladeabschluss-Ereignis**, hysteretisch als Episode (genau ein Reset pro Ladeabschluss):
+
+Bedingungen (alle):
+
+- `sensor.byd_zellspannung_max` ≥ 3,55-3,60 V (Primärkriterium; exakten Wert an realen Logs kalibrieren, 3,65 V wäre bei 60-s-Abtastung evtl. zu kurz sichtbar).
+- In den Minuten davor wurde tatsächlich geladen.
+- Danach Ladeleistung < 300-500 W für 5-10 min (Ladeende).
+- Optional, wenn `binary_sensor.byd_balancing_aktiv` zuverlässig: Balancing war aktiv und ist beendet.
+- `sensor.byd_soc` ≥ 94-95 % nur als Plausibilität, nicht als Trigger.
+- `binary_sensor.byd_daten_frisch` = on und beide Zähler zeitlich kohärent.
+
+Aktion am Anker:
+
+- Beide Utility Meter zurücksetzen (`utility_meter.reset`).
+- `byd_knie_ref_frozen` := aktueller `byd_knie_referenzspannung`.
+- `byd_knie_ueberschwelle_gesehen` := off.
+- `byd_knie_cycle_id` := jetzt (ISO), `byd_voll_anker_zeit` := jetzt.
+- `byd_knie_zyklus_status` := `armed`.
+
+**Re-Arm-Sperre**: ein neuer Anker wird erst wieder zugelassen, nachdem der Speicher seit dem letzten Anker unter ~90-95 % gefallen ist ODER ≥ 0,5-1,0 kWh netto entnommen wurden. Verhindert mehrfaches Zurücksetzen im Ladeschluss-Flattern.
+Fällt der physische Ladeabschluss in einen MQTT-/HA-Ausfall, gilt der Zyklus als ungültig - kein nachträglich geschätzter Vollzeitpunkt (falsche Präzision).
+
+### 6.2 Laufende Nettoenergie
+
+`sensor.byd_netto_energie_seit_voll` (kWh):
+
+```
+state = entladen_seit_voll − geladen_seit_voll   (aus den beiden Utility Metern)
+```
+
+- Utility Meter statt Rohsubtraktion: persistent über HA-Neustarts, mit eigener Reset-Behandlung bei Quell-Reset/Rollover; `delta_values` aus (Quellen sind Absolutwerte). Falls die Loggerzähler real zurückgesetzt werden, `periodically_resetting` passend konfigurieren.
+- **Nicht `total_increasing`**: B1 darf bei PV-Zwischenladung real sinken. Nicht auf 0 klemmen.
+- **Availability**: nur gültig, wenn beide Utility Meter `has_value`. Kein `float(0)`.
+- Negative **Quell**-Inkremente werden vom Utility Meter als Reset behandelt, nicht in B1 als Energie eingerechnet.
+- **Plausibilitätswächter**: ein positives Netto-Inkrement größer als ~`15 kW × Δt seit letztem gültigen Wert` (plus Reserve) markiert den Zyklus `invalid` (§7), statt still "repariert" zu werden.
+- Ehrlich als **Nettoenergie-Näherung** deklariert (Lade-/Entladeverluste; ≠ gespeicherte Zellenergie).
+
+### 6.3 Standardisiertes Lastband (Kern gegen Lastabhängigkeit)
+
+Roh gelatcht würde der erste Hochlast-Dip irreversibel eingefroren (30-40 mV Lastabsenkung verschieben die 3,20-V-Kreuzung um mehrere SoC-Prozent bzw. Zehntel-kWh) - der Wochenvergleich wäre unbrauchbar.
+Ein reines Ruhefenster (<300 W) taugt am Knie ebenfalls nicht (tritt evtl. stundenlang nicht auf; die Zelle relaxiert danach wieder über die Schwelle).
+
+`binary_sensor.byd_entladeband` = on, wenn:
+
+- Vorzeichen eindeutig **Entladen** (nie Laden/unbekannt), UND
+- Entladeleistung im Band **0,5-1,5 kW** (≈ 1-3 A ≈ 0,04-0,12 C bei ~512 V).
+
+Der Latch verlangt, dass dieses Band über das gesamte Bestätigungsfenster (§6.4) gehalten wurde (Leistung nicht um mehr als ~300-500 W springt).
+Falls das Band real zu selten vorkommt, auf 0,5-2,0 kW erweitern - dann aber Messungen verschiedener Lastklassen **nicht** ungekennzeichnet vergleichen (Lastklasse wird am Latch mitgespeichert).
+
+### 6.4 Latch (Knie-Ereignis)
+
+Arm-Guard `byd_ueberschwelle_gesehen`: sobald seit dem Anker ein gültiger `Modul-2-min` klar oberhalb der Schwelle (≥ `ref_frozen` + 0,03 V) gesehen wird, wird das Flag on gesetzt.
+Nach einem Ladeabschluss ist Modul 2 hoch, das Flag kippt sofort on; nach einem Neustart mitten in niedriger Spannung bleibt der zuvor gesetzte Zustand erhalten (`input_boolean` restored) - ein Fehl-Latch bei schon niedriger Spannung nach Neustart wird verhindert.
+
+`byd_knie_latch` - Trigger: `sensor.byd_modul_2_zellspannung_min` **unter** `input_number.byd_knie_ref_frozen` (numeric_state `below` referenziert die Helfer-Entität) mit `for: 00:03:00` (120-180 s; bei 60-s-Telemetrie ~2-3 gültige Samples).
+
+Bedingungen (alle, und über die Haltezeit gültig):
+
+- `byd_knie_zyklus_status` = `armed` und `byd_ueberschwelle_gesehen` = on.
+- `binary_sensor.byd_entladeband` = on `for: 00:03:00` (Lastband über das Fenster gehalten).
+- `binary_sensor.byd_daten_frisch` = on (alle fünf Modul-Spannungen + SoC + Leistung + beide Zähler frisch/kohärent).
+- `sensor.byd_netto_energie_seit_voll` gültig.
+
+Hysterese ±5 mV: Eintritt effektiv ~3,195 V, Rückkehr erst > 3,205 V (verhindert Prellen an der Schwelle). Kein gleitender Mittelwert als Default (verschiebt die Kreuzung/unterdrückt echten Knieabfall); ein Drei-Sample-Median nur, falls reale Einzelsample-Ausreißer auftreten.
+
+Aktion (Latch schreiben, Automation-Modus `single`):
+
+- `sensor.byd_modul2_netto_bis_knie` := aktueller `netto_energie_seit_voll` (trigger-basierter Template-Sensor, RestoreEntity).
+- `byd_knie_zyklus_status` := `latched`; Arm-Flag erst **nach** erfolgreichem Schreiben aus.
+
+`for:` überlebt keinen HA-Neustart/Reload (laufender Countdown verworfen) - bei Neustart nahe am Knie gilt der Zyklus als "nicht sicher gemessen" (`invalid`), was für eine Wochenmetrik vertretbar ist.
+
+### 6.5 Was am Latch gespeichert wird (Attribute)
+
+Damit spätere Auswertung Zwischenladungen und Lastklassen beurteilen kann - nicht nur Netto:
+
+- `netto_kwh`, `geladen_inkrement_kwh`, `entladen_inkrement_kwh` (getrennt).
+- `a_absackung_mv` (Sensor A relativ zum Peer-**Median** zum Latch-Zeitpunkt).
+- `soc`, `last_mittel_w`, `last_min_w`, `last_max_w` über das Bestätigungsfenster.
+- `modul2_volt`, `modul_temp_c` (und Zelltemp, falls verfügbar), `ref_verwendet_v`.
+- `cycle_id`, `gemessen` (Zeit).
+- `sauberer_zyklus` (bool): `geladen_inkrement_kwh` < 0,2-0,5 kWh -> reine Top-nach-Knie-Entladung; sonst getrennt betrachten (pfadabhängig durch Ladeverluste/Hysterese).
+
+## 7. Zyklus-Zustandsautomat und Gültigkeit
+
+`byd_knie_zyklus_status`: `idle` -> (Anker) `armed` -> (Latch) `latched`; jederzeit -> `invalid`.
+
+`byd_zyklus_invalid` setzt `invalid` + `byd_knie_invalid_grund` bei:
+
+- Zähler-Reset/Rollover oder unplausiblem positiven Sprung (§6.2).
+- Datenlücke (`byd_daten_frisch` = off) nahe der Kreuzung.
+- Fehlende zeitliche Kohärenz der beiden Zähler beim Ankern/Latchen.
+- HA-Neustart während eines Knie-Kandidaten (armed und Modul-2-min nahe/unter Schwelle).
+
+Bei `invalid` wird **nicht** gelatcht und **nicht** entwaffnet; der Zyklus wird für die Trendauswertung verworfen. Kollision Anker/Latch durch einen einzigen Zustandsablauf und `single`-Modus vermeiden.
+
+## 8. Auswertung und Trend
+
+- Wochen-Trend = Verlauf von `sensor.byd_modul2_netto_bis_knie` über die `latched`-Ereignisse, gefiltert auf `sauberer_zyklus = true` und vergleichbare Lastklasse/Temperatur (±3 K).
+- Ergänzend der am Latch festgehaltene `a_absackung_mv`.
+- **Degradations-Signal** (Codex): systematisch sinkende Nettoenergie bis Knie über Wochen, aussagekräftiger als roher mV-Abstand.
+- Ticket-würdig (späterer Alarm-PR): deutliche Verschiebung des Knies innerhalb weniger Wochen, nutzbare Energie reproduzierbar > 5 % gesunken, echte Ruhedivergenz > 80-100 mV, oder EC107/EC110/BMS-Leistungsbegrenzung.
+
+Dashboard: `byd_modul2_netto_bis_knie` und `byd_modul2_absackung` (roh) als ApexCharts-Verlauf in die bestehende Sektion "Akku-Gesundheit (BMU)".
+
+## 9. Stellschrauben
+
+- `input_number.byd_knie_referenzspannung` (Default 3,20 V) - live einstellbar; greift erst am **nächsten** Anker (Einfrieren pro Zyklus).
+- Lastband, Voll-Anker-Zellspannung und Re-Arm-Schwelle sind zunächst als Konstanten im Package dokumentiert; werden nach den ersten realen Zyklen kalibriert.
+
+## 10. Fehlerfälle (Zusammenfassung)
+
+| Fall | Behandlung |
+|---|---|
+| Quelle `unavailable` (expire_after 300 s) | `daten_frisch` = off -> kein Anker/Latch; kein `float(0)` |
+| Zähler-Reset/Rollover | Utility Meter fängt es; negatives Quell-Inkrement nicht als Energie |
+| Unplausibler positiver Zählersprung | Zyklus `invalid` (Grund protokolliert) |
+| Zähler-Versatz 60 s | Latch nur bei kohärenten, frischen Zählern |
+| Prellen an 3,20 V | Hysterese ±5 mV + `for: 3 min` |
+| Fehl-Latch nach Neustart bei niedriger Spannung | `ueberschwelle_gesehen`-Guard |
+| Hochlast-Dip | Lastband-Gate 0,5-1,5 kW über das Fenster |
+| SoC-Drift/Flattern | Ladeabschluss-Anker statt SoC≥99 %, Re-Arm-Sperre |
+| `for:` verworfen bei Neustart | Zyklus `invalid` |
+| Defektes Vergleichsmodul | Peer-**Median** statt `min` |
+
+## 11. Deployment
+
+- Alle Entitäten in `packages/byd_bmu.yaml` ergänzen (erweitert PR #39-Feature).
+- Helfer: entweder als YAML im Package oder via UI/`ha_config_set_helper` live anlegen - Weg im Implementierungsplan festlegen (Konsistenz Repo <-> live beachten, bekannte Live-Divergenz).
+- Live in-place deployen (Package-Edit + Reload), analog bisheriger BYD-Arbeit; danach Live-Regressionscheck.
+- MQTT-Rohsensoren bleiben in `mqtt/mqtt.yaml` (Kollisions-Falle top-level `mqtt: !include` beachten).
+- Privacy-Scan vor Push (öffentliches Repo).
+
+## 12. Test und Verifikation
+
+Vor Implementierung:
+
+- **Leistungs-Vorzeichen** an `sensor.byd_leistung`-Historie bestätigen (Laden vs. Entladen).
+- Prüfen, wie oft Modul-2-min real unter 3,20 V geht (Trigger-Frequenz); Referenz ggf. anpassen.
+- Utility-Meter-Reset-Verhalten der Loggerzähler klären (`periodically_resetting`).
+
+Nach Implementierung:
+
+- Anker künstlich testbar? (nicht produktiv erzwingen; an nächster realer Vollladung verifizieren.)
+- Latch an einem realen tiefen Entladezyklus beobachten; Attribute auf Plausibilität prüfen.
+- Neustart-Verhalten: Zustände (`input_*`, Utility Meter, trigger-Sensor) überleben Reload; Zyklus nahe Knie wird `invalid`.
+- Livetest-Protokoll unter `docs/` ablegen (Repo-Konvention).
+
+## 13. Offene Punkte
+
+- Exakte Voll-Anker-Zellspannung (3,55 vs. 3,60 V) - an Logs kalibrieren.
+- Lastband final (0,5-1,5 vs. 0,5-2,0 kW) - nach Häufigkeit realer Latches.
+- Alarm-Schwelle bewusst offen bis 4-8 gültige Zyklen vorliegen (eigener Folge-PR).

--- a/docs/byd-modul2-fruehwarnung-plan.md
+++ b/docs/byd-modul2-fruehwarnung-plan.md
@@ -1,0 +1,682 @@
+# BYD Modul-2 Frühwarnung - Implementierungsplan
+
+> **Für agentische Worker:** Dies ist ein Home-Assistant-YAML-Feature, kein pytest-Projekt. Statt Unit-Tests gilt pro Schritt: (a) jinja2-Parse-Check der Templates (echter jinja2, rekursiv - siehe Repo-Memory "HA-YAML Jinja-Parse-Check"), (b) `ha_eval_template` des Ausdrucks gegen Live-States mit erwartetem Wert, (c) Reload + `ha_get_state` der neuen Entität. Schritte nutzen `- [ ]`.
+
+**Goal:** Zwei belastbare Frühwarn-Größen für das schwächste BYD-Modul (Modul 2) dauerhaft loggen: relative Zell-Absackung (mV) und Nettoenergie bis Knie (kWh), gehärtet gegen Last, SoC-Drift, MQTT-Aussetzer und Zähler-Artefakte.
+
+**Architecture:** Erweiterung des bestehenden Packages `packages/byd_bmu.yaml`. Helfer (YAML) + zwei utility_meter + Template-/Trigger-Sensoren + vier Automationen bilden einen Zyklus-Zustandsautomaten (idle→armed→latched, jederzeit→invalid). Rein beobachtend, keine Steuerwirkung.
+
+**Tech Stack:** Home Assistant Packages, `template:` (state- und trigger-basiert), `utility_meter`, `input_*`-Helfer, Automationen. Deploy in-place live + Repo (PR gegen `feat/byd-bmu-monitoring`).
+
+## Global Constraints
+
+- Spec: `docs/byd-modul2-fruehwarnung-design.md` (verbindlich).
+- Vorzeichen `sensor.byd_leistung`: **positiv = Entladen, negativ = Laden** (verifiziert 2026-07-15).
+- Lastband: `sensor.byd_leistung` in **+500…+1500 W**.
+- Referenzspannung Default **3,20 V** (`input_number`, live tunable, greift erst am nächsten Anker).
+- Kein `float(0)`-Fallback für Energie/Spannung - stattdessen `has_value`-Gate.
+- Kein Alarm/Schwellwert in dieser Stufe (erst nach 4-8 gültigen Zyklen, Folge-PR).
+- MQTT-Rohsensoren bleiben in `mqtt/mqtt.yaml` (top-level `mqtt: !include`-Kollision beachten); neue Entitäten in `packages/byd_bmu.yaml`.
+- Öffentliches Repo: Privacy-Scan aller getrackten Dateien vor Push.
+- Entity-IDs exakt wie unten (spätere Tasks referenzieren sie).
+
+## Datei-Struktur
+
+- Modify: `packages/byd_bmu.yaml` - alle neuen Entitäten (Helfer, utility_meter, template, automation) ans Ende der jeweiligen Top-Level-Blöcke.
+- Modify: `docs/byd-bmu-monitoring.md` - Abschnitt "Modul-2 Frühwarnung" (Betrieb/Interpretation).
+- Create (nach erstem realen Zyklus): `docs/livetest-byd-modul2-fruehwarnung-2026-07.md` - Livetest-Protokoll.
+
+Deploy-Ziel live: `/config/packages/byd_bmu.yaml` (in-place), Reload via `ha_reload_core` (bzw. YAML-Reload der betroffenen Domains).
+
+---
+
+### Task 1: Helfer (Zustands-Entitäten)
+
+**Files:**
+- Modify: `packages/byd_bmu.yaml` (neue Top-Level-Blöcke `input_number:`, `input_boolean:`, `input_select:`, `input_text:`, `input_datetime:`)
+
+**Interfaces:**
+- Produces: `input_number.byd_knie_referenzspannung`, `input_number.byd_knie_ref_frozen`, `input_boolean.byd_knie_armed`, `input_boolean.byd_knie_ueberschwelle_gesehen`, `input_boolean.byd_top_erreicht`, `input_select.byd_knie_zyklus_status` (Optionen idle/armed/latched/invalid), `input_text.byd_knie_cycle_id`, `input_text.byd_knie_invalid_grund`, `input_datetime.byd_voll_anker_zeit`.
+
+- [ ] **Step 1: YAML einfügen**
+
+```yaml
+input_number:
+  byd_knie_referenzspannung:
+    name: "BYD Knie-Referenzspannung"
+    min: 3.05
+    max: 3.35
+    step: 0.005
+    initial: 3.20          # nur beim allerersten Start; danach restore
+    unit_of_measurement: "V"
+    mode: box
+    icon: mdi:sine-wave
+  byd_knie_ref_frozen:
+    name: "BYD Knie-Referenz (eingefroren)"
+    min: 3.05
+    max: 3.35
+    step: 0.001
+    initial: 3.20
+    unit_of_measurement: "V"
+    mode: box
+    icon: mdi:snowflake
+
+input_boolean:
+  byd_knie_armed:
+    name: "BYD Knie scharf"
+    icon: mdi:target
+  byd_knie_ueberschwelle_gesehen:
+    name: "BYD Knie Ueberschwelle gesehen"
+    icon: mdi:arrow-up-bold
+  byd_top_erreicht:
+    name: "BYD Ladeschluss erreicht"
+    icon: mdi:arrow-collapse-up
+
+input_select:
+  byd_knie_zyklus_status:
+    name: "BYD Knie Zyklus-Status"
+    options: ["idle", "armed", "latched", "invalid"]
+    initial: idle
+    icon: mdi:state-machine
+
+input_text:
+  byd_knie_cycle_id:
+    name: "BYD Knie Cycle-ID"
+    max: 40
+  byd_knie_invalid_grund:
+    name: "BYD Knie Invalid-Grund"
+    max: 120
+
+input_datetime:
+  byd_voll_anker_zeit:
+    name: "BYD Voll-Anker Zeit"
+    has_date: true
+    has_time: true
+```
+
+- [ ] **Step 2: Reload + Verifikation**
+
+Reload (live): Helfer-Domains bzw. `ha_reload_core`. Dann:
+```
+ha_get_state(["input_number.byd_knie_referenzspannung","input_select.byd_knie_zyklus_status"])
+```
+Erwartet: `byd_knie_referenzspannung = 3.2`, `byd_knie_zyklus_status = idle`. Keine Config-Fehler im Log.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/byd_bmu.yaml
+git commit -m "feat(byd): Helfer fuer Modul-2 Knie-Zyklus-Statemachine"
+```
+
+---
+
+### Task 2: Frische- und Entladeband-Sensoren
+
+**Files:**
+- Modify: `packages/byd_bmu.yaml` (unter `template:` einen `- binary_sensor:`-Block ergänzen)
+
+**Interfaces:**
+- Consumes: MQTT-Rohsensoren (`sensor.byd_soc`, `sensor.byd_leistung`, `sensor.byd_modul_1..5_zellspannung_min`, plus utility_meter aus Task 3 - bis dahin liefert `has_value` dafür `false`, unkritisch).
+- Produces: `binary_sensor.byd_daten_frisch`, `binary_sensor.byd_entladeband`.
+
+- [ ] **Step 1: eval_template als Vorab-Check (erwartet plausibles Ergebnis)**
+
+`ha_eval_template`:
+```
+{% set p = states('sensor.byd_leistung')|float(0) %}{{ 500 <= p <= 1500 }}
+```
+Erwartet: `True`/`False` je nach aktueller Last (kein Fehler).
+
+- [ ] **Step 2: YAML einfügen**
+
+```yaml
+  - binary_sensor:
+      - unique_id: byd_daten_frisch
+        name: "BYD Daten frisch"
+        device_class: connectivity
+        icon: mdi:database-check
+        state: >
+          {{ has_value('sensor.byd_soc') and has_value('sensor.byd_leistung')
+             and has_value('sensor.byd_modul_1_zellspannung_min')
+             and has_value('sensor.byd_modul_2_zellspannung_min')
+             and has_value('sensor.byd_modul_3_zellspannung_min')
+             and has_value('sensor.byd_modul_4_zellspannung_min')
+             and has_value('sensor.byd_modul_5_zellspannung_min')
+             and has_value('sensor.byd_geladen_seit_voll')
+             and has_value('sensor.byd_entladen_seit_voll') }}
+      - unique_id: byd_entladeband
+        name: "BYD Entladeband"
+        icon: mdi:speedometer-slow
+        state: >
+          {% set p = states('sensor.byd_leistung')|float(0) %}
+          {{ has_value('sensor.byd_leistung') and 500 <= p <= 1500 }}
+```
+
+Hinweis: `byd_daten_frisch` prüft auch die utility_meter aus Task 3; vor Task 3 ist der Sensor `off` (ok).
+Frische = `has_value` (expire_after 300 s der Quellen bündelt die Staleness). Bewusste Vereinfachung ggü. Codex' 120-s-Ideal: eine 1-min-Time-Pattern-Automation nur für die Altersschärfe wäre Overkill.
+
+- [ ] **Step 3: Reload + Verifikation**
+
+```
+ha_get_state(["binary_sensor.byd_entladeband","binary_sensor.byd_daten_frisch"])
+```
+Erwartet: `byd_entladeband` on/off passend zur Last; `byd_daten_frisch` = off (utility_meter fehlen noch).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/byd_bmu.yaml
+git commit -m "feat(byd): Frische- und Entladeband-Binary-Sensoren"
+```
+
+---
+
+### Task 3: Utility Meter + Nettoenergie-Sensor
+
+**Files:**
+- Modify: `packages/byd_bmu.yaml` (Top-Level `utility_meter:`; unter `template: - sensor:` den Netto-Sensor)
+
+**Interfaces:**
+- Consumes: `sensor.byd_geladen_gesamt`, `sensor.byd_entladen_gesamt`.
+- Produces: `sensor.byd_geladen_seit_voll`, `sensor.byd_entladen_seit_voll`, `sensor.byd_netto_energie_seit_voll`.
+
+- [ ] **Step 1: YAML einfügen**
+
+```yaml
+utility_meter:
+  byd_geladen_seit_voll:
+    source: sensor.byd_geladen_gesamt
+    name: "BYD geladen seit Voll"
+    periodically_resetting: false      # Quelle ist total_increasing, kein Zyklus-Reset
+  byd_entladen_seit_voll:
+    source: sensor.byd_entladen_gesamt
+    name: "BYD entladen seit Voll"
+    periodically_resetting: false
+```
+
+```yaml
+      - unique_id: byd_netto_energie_seit_voll
+        name: "BYD Nettoenergie seit Voll"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: measurement          # NICHT total_increasing (darf bei PV-Ladung sinken)
+        icon: mdi:battery-minus-outline
+        availability: >
+          {{ has_value('sensor.byd_entladen_seit_voll') and has_value('sensor.byd_geladen_seit_voll') }}
+        state: >
+          {{ (states('sensor.byd_entladen_seit_voll')|float
+              - states('sensor.byd_geladen_seit_voll')|float) | round(3) }}
+```
+
+- [ ] **Step 2: Reload + Verifikation**
+
+```
+ha_get_state(["sensor.byd_geladen_seit_voll","sensor.byd_entladen_seit_voll","sensor.byd_netto_energie_seit_voll","binary_sensor.byd_daten_frisch"])
+```
+Erwartet: beide utility_meter numerisch (starten bei 0 bzw. akkumulieren ab jetzt); `byd_netto_energie_seit_voll` = entladen − geladen; `byd_daten_frisch` jetzt on (bei frischen Quellen).
+
+- [ ] **Step 3: Reset-Service prüfen**
+
+```
+ha_call_service(utility_meter.reset, target: [sensor.byd_geladen_seit_voll, sensor.byd_entladen_seit_voll])
+```
+Erwartet: beide → 0. (Dieser Service wird später vom Anker genutzt.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/byd_bmu.yaml
+git commit -m "feat(byd): utility_meter Paar seit Voll + Nettoenergie-Sensor"
+```
+
+---
+
+### Task 4: Sensor A - Relative Zell-Absackung
+
+**Files:**
+- Modify: `packages/byd_bmu.yaml` (unter `template: - sensor:`)
+
+**Interfaces:**
+- Consumes: `sensor.byd_modul_1..5_zellspannung_min`, `binary_sensor.byd_daten_frisch`.
+- Produces: `sensor.byd_modul2_absackung` (mV).
+
+- [ ] **Step 1: eval_template Vorab-Check (Peer-Median-Formel)**
+
+`ha_eval_template`:
+```
+{% set peers = [states('sensor.byd_modul_1_zellspannung_min')|float,
+                states('sensor.byd_modul_3_zellspannung_min')|float,
+                states('sensor.byd_modul_4_zellspannung_min')|float,
+                states('sensor.byd_modul_5_zellspannung_min')|float] | sort %}
+{% set peer_median = (peers[1] + peers[2]) / 2 %}
+{% set m2 = states('sensor.byd_modul_2_zellspannung_min')|float %}
+{{ ((peer_median - m2) * 1000) | round(1) }}
+```
+Erwartet: kleiner mV-Wert (im Plateau ~1-3, positiv wenn Modul 2 tiefer).
+
+- [ ] **Step 2: YAML einfügen**
+
+```yaml
+      - unique_id: byd_modul2_absackung
+        name: "BYD Modul-2 Absackung"
+        unit_of_measurement: "mV"
+        state_class: measurement
+        icon: mdi:arrow-down-bold-box
+        availability: "{{ is_state('binary_sensor.byd_daten_frisch','on') }}"
+        state: >
+          {% set peers = [states('sensor.byd_modul_1_zellspannung_min')|float,
+                          states('sensor.byd_modul_3_zellspannung_min')|float,
+                          states('sensor.byd_modul_4_zellspannung_min')|float,
+                          states('sensor.byd_modul_5_zellspannung_min')|float] | sort %}
+          {% set peer_median = (peers[1] + peers[2]) / 2 %}
+          {% set m2 = states('sensor.byd_modul_2_zellspannung_min')|float %}
+          {{ ((peer_median - m2) * 1000) | round(1) }}
+        attributes:
+          soc: "{{ states('sensor.byd_soc') }}"
+          leistung_w: "{{ states('sensor.byd_leistung') }}"
+          modul2_volt: "{{ states('sensor.byd_modul_2_zellspannung_min') }}"
+          peer_median_volt: >
+            {% set peers = [states('sensor.byd_modul_1_zellspannung_min')|float,
+                            states('sensor.byd_modul_3_zellspannung_min')|float,
+                            states('sensor.byd_modul_4_zellspannung_min')|float,
+                            states('sensor.byd_modul_5_zellspannung_min')|float] | sort %}
+            {{ ((peers[1] + peers[2]) / 2) | round(3) }}
+          schwaechstes_modul: >
+            {% set ns = namespace(min_v=99, idx='?') %}
+            {% for i in [1,2,3,4,5] %}
+              {% set v = states('sensor.byd_modul_' ~ i ~ '_zellspannung_min')|float(99) %}
+              {% if v < ns.min_v %}{% set ns.min_v = v %}{% set ns.idx = i|string %}{% endif %}
+            {% endfor %}
+            {{ ns.idx }}
+```
+
+- [ ] **Step 3: Reload + Verifikation**
+
+```
+ha_get_state("sensor.byd_modul2_absackung")
+```
+Erwartet: numerischer mV-Wert = eval aus Step 1; Attribut `schwaechstes_modul` plausibel (meist "2" am Knie, im Plateau evtl. wechselnd).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/byd_bmu.yaml
+git commit -m "feat(byd): Sensor A relative Modul-2 Absackung (Peer-Median)"
+```
+
+---
+
+### Task 5: Latch-Sensor (Nettoenergie bis Knie)
+
+**Files:**
+- Modify: `packages/byd_bmu.yaml` (neuer trigger-basierter `template:`-Block)
+
+**Interfaces:**
+- Consumes: `input_select.byd_knie_zyklus_status` (Transition nach `latched`), `sensor.byd_netto_energie_seit_voll`, `sensor.byd_geladen_seit_voll`, `sensor.byd_entladen_seit_voll`, `sensor.byd_modul2_absackung`.
+- Produces: `sensor.byd_modul2_netto_bis_knie` (kWh, RestoreEntity).
+
+- [ ] **Step 1: YAML einfügen**
+
+```yaml
+  - triggers:
+      - trigger: state
+        entity_id: input_select.byd_knie_zyklus_status
+        to: "latched"
+    sensor:
+      - unique_id: byd_modul2_netto_bis_knie
+        name: "BYD Modul-2 Nettoenergie bis Knie"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: measurement
+        icon: mdi:battery-alert-variant-outline
+        state: "{{ states('sensor.byd_netto_energie_seit_voll') }}"
+        attributes:
+          netto_kwh: "{{ states('sensor.byd_netto_energie_seit_voll') }}"
+          geladen_inkrement_kwh: "{{ states('sensor.byd_geladen_seit_voll') }}"
+          entladen_inkrement_kwh: "{{ states('sensor.byd_entladen_seit_voll') }}"
+          a_absackung_mv: "{{ states('sensor.byd_modul2_absackung') }}"
+          soc: "{{ states('sensor.byd_soc') }}"
+          leistung_w: "{{ states('sensor.byd_leistung') }}"
+          modul2_volt: "{{ states('sensor.byd_modul_2_zellspannung_min') }}"
+          modul_temp_c: "{{ states('sensor.byd_modul_2_temp_max') }}"
+          ref_verwendet_v: "{{ states('input_number.byd_knie_ref_frozen') }}"
+          cycle_id: "{{ states('input_text.byd_knie_cycle_id') }}"
+          sauberer_zyklus: "{{ states('sensor.byd_geladen_seit_voll')|float(0) < 0.5 }}"
+          gemessen: "{{ now().isoformat() }}"
+```
+
+Hinweis: Last ist durch das Entladeband (Task 6/7) auf +500…+1500 W beschränkt, deshalb genügt `leistung_w` als Momentanwert (kein separater Fenster-Mittelwert nötig).
+
+- [ ] **Step 2: Reload + Verifikation (manueller Latch-Test)**
+
+```
+ha_call_service(input_select.select_option, target: input_select.byd_knie_zyklus_status, data:{option: "latched"})
+ha_get_state("sensor.byd_modul2_netto_bis_knie")
+```
+Erwartet: Sensor übernimmt aktuellen `byd_netto_energie_seit_voll`, Attribute gefüllt. Danach Status zurück auf `idle` setzen (Aufräumen des Tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/byd_bmu.yaml
+git commit -m "feat(byd): Latch-Sensor Nettoenergie bis Knie"
+```
+
+---
+
+### Task 6: Voll-Anker-Automation
+
+**Files:**
+- Modify: `packages/byd_bmu.yaml` (unter `automation:`)
+
+**Interfaces:**
+- Consumes: `sensor.byd_zellspannung_max`, `sensor.byd_leistung`, `sensor.byd_soc`, `binary_sensor.byd_daten_frisch`, `sensor.byd_netto_energie_seit_voll`, `input_boolean.byd_top_erreicht`, `input_number.byd_knie_referenzspannung`.
+- Produces: setzt utility_meter-Reset, `input_boolean.byd_knie_armed`=on, `input_number.byd_knie_ref_frozen`, `input_select.byd_knie_zyklus_status`=armed, `input_text.byd_knie_cycle_id`, `input_datetime.byd_voll_anker_zeit`, löscht `byd_top_erreicht`/`byd_knie_ueberschwelle_gesehen`.
+
+- [ ] **Step 1: YAML einfügen (zwei Automationen: Top-Merker + Anker)**
+
+```yaml
+  - id: byd_top_erreicht_merker
+    alias: "BYD | Ladeschluss-Merker setzen"
+    description: "Merkt sich, dass im laufenden Ladevorgang die Ladeschluss-Zellspannung erreicht wurde (Voll-Anker-Evidenz)."
+    mode: single
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.byd_zellspannung_max
+        above: 3.55
+        for: "00:02:00"
+    conditions: []
+    actions:
+      - action: input_boolean.turn_on
+        target: { entity_id: input_boolean.byd_top_erreicht }
+
+  - id: byd_voll_anker
+    alias: "BYD | Voll-Anker (Ladeabschluss)"
+    description: >-
+      Ladeabschluss-Event: Zellmax war >=3,55 V (Merker), danach Ladeende
+      (Leistung > -300 W = nicht mehr nennenswert Laden) fuer 5 min. Setzt den
+      Knie-Zyklus neu auf. Re-Arm-Sperre: nur wenn idle ODER seit letztem Anker
+      >=0,5 kWh netto entnommen (verhindert Mehrfach-Reset im Ladeschluss-Flattern).
+    mode: single
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.byd_leistung
+        above: -300
+        for: "00:05:00"
+    conditions:
+      - condition: state
+        entity_id: input_boolean.byd_top_erreicht
+        state: "on"
+      - condition: numeric_state
+        entity_id: sensor.byd_soc
+        above: 94
+      - condition: state
+        entity_id: binary_sensor.byd_daten_frisch
+        state: "on"
+      - condition: template
+        value_template: >
+          {{ is_state('input_select.byd_knie_zyklus_status','idle')
+             or states('sensor.byd_netto_energie_seit_voll')|float(0) >= 0.5 }}
+    actions:
+      - action: utility_meter.reset
+        target:
+          entity_id:
+            - sensor.byd_geladen_seit_voll
+            - sensor.byd_entladen_seit_voll
+      - action: input_number.set_value
+        target: { entity_id: input_number.byd_knie_ref_frozen }
+        data:
+          value: "{{ states('input_number.byd_knie_referenzspannung')|float(3.20) }}"
+      - action: input_boolean.turn_off
+        target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
+      - action: input_text.set_value
+        target: { entity_id: input_text.byd_knie_cycle_id }
+        data: { value: "{{ now().isoformat() }}" }
+      - action: input_datetime.set_datetime
+        target: { entity_id: input_datetime.byd_voll_anker_zeit }
+        data: { datetime: "{{ now().isoformat() }}" }
+      - action: input_select.select_option
+        target: { entity_id: input_select.byd_knie_zyklus_status }
+        data: { option: "armed" }
+      - action: input_boolean.turn_on
+        target: { entity_id: input_boolean.byd_knie_armed }
+      - action: input_boolean.turn_off
+        target: { entity_id: input_boolean.byd_top_erreicht }
+```
+
+- [ ] **Step 2: Reload + Verifikation (Logik, ohne echten Ladeabschluss)**
+
+Reload Automationen. `ha_get_automation_traces` bleibt leer bis zum realen Ereignis - stattdessen Konsistenz prüfen:
+```
+ha_get_state(["automation.byd_voll_anker","automation.byd_top_erreicht_merker"])
+```
+Erwartet: beide `on` (aktiv), keine Config-Fehler. Voll-Anker wird an der nächsten realen Vollladung verifiziert (Task 9).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/byd_bmu.yaml
+git commit -m "feat(byd): Voll-Anker Automation (Ladeabschluss-Event, Re-Arm-Sperre)"
+```
+
+---
+
+### Task 7: Überschwelle-Guard + Latch-Automation
+
+**Files:**
+- Modify: `packages/byd_bmu.yaml` (unter `automation:`)
+
+**Interfaces:**
+- Consumes: `sensor.byd_modul_2_zellspannung_min`, `input_number.byd_knie_ref_frozen`, `input_select.byd_knie_zyklus_status`, `input_boolean.byd_knie_armed`, `input_boolean.byd_knie_ueberschwelle_gesehen`, `binary_sensor.byd_entladeband`, `binary_sensor.byd_daten_frisch`, `sensor.byd_netto_energie_seit_voll`.
+- Produces: setzt `byd_knie_ueberschwelle_gesehen`=on; setzt `byd_knie_zyklus_status`=latched + `byd_knie_armed`=off.
+
+- [ ] **Step 1: YAML einfügen**
+
+```yaml
+  - id: byd_knie_ueberschwelle_gesehen
+    alias: "BYD | Knie Ueberschwelle gesehen"
+    description: "Setzt das Guard-Flag, sobald Modul-2-min seit dem Anker klar (>= ref+30 mV) oberhalb der Schwelle war."
+    mode: single
+    triggers:
+      - trigger: template
+        value_template: >
+          {{ states('sensor.byd_modul_2_zellspannung_min')|float(0)
+             > states('input_number.byd_knie_ref_frozen')|float(3.20) + 0.03 }}
+    conditions:
+      - condition: state
+        entity_id: input_boolean.byd_knie_armed
+        state: "on"
+    actions:
+      - action: input_boolean.turn_on
+        target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
+
+  - id: byd_knie_latch
+    alias: "BYD | Knie-Latch (Nettoenergie festhalten)"
+    description: >-
+      Latcht, wenn Modul-2-min zum ersten Mal seit Voll die eingefrorene Referenz
+      (Default 3,20 V) 3 min lang unterschreitet, im standardisierten Entladeband
+      (+500..1500 W ueber die Haltezeit), bei frischen Daten und gesehener Ueberschwelle.
+      Die 3-min-Haltezeit ersetzt eine explizite mV-Hysterese (starke Entprellung).
+    mode: single
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.byd_modul_2_zellspannung_min
+        below: input_number.byd_knie_ref_frozen
+        for: "00:03:00"
+    conditions:
+      - condition: state
+        entity_id: input_select.byd_knie_zyklus_status
+        state: "armed"
+      - condition: state
+        entity_id: input_boolean.byd_knie_ueberschwelle_gesehen
+        state: "on"
+      - condition: state
+        entity_id: binary_sensor.byd_entladeband
+        state: "on"
+        for: "00:03:00"
+      - condition: state
+        entity_id: binary_sensor.byd_daten_frisch
+        state: "on"
+      - condition: template
+        value_template: "{{ has_value('sensor.byd_netto_energie_seit_voll') }}"
+    actions:
+      - action: input_select.select_option
+        target: { entity_id: input_select.byd_knie_zyklus_status }
+        data: { option: "latched" }        # der Latch-Sensor (Task 5) snapshottet hierauf
+      - action: input_boolean.turn_off
+        target: { entity_id: input_boolean.byd_knie_armed }
+```
+
+- [ ] **Step 2: Reload + Verifikation**
+
+```
+ha_get_state(["automation.byd_knie_latch","automation.byd_knie_ueberschwelle_gesehen"])
+```
+Erwartet: beide aktiv, keine Fehler. Funktionaler Latch wird am realen tiefen Entladezyklus verifiziert (Task 9).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/byd_bmu.yaml
+git commit -m "feat(byd): Ueberschwelle-Guard + Knie-Latch Automation"
+```
+
+---
+
+### Task 8: Zyklus-Gültigkeit (invalid-Marker)
+
+**Files:**
+- Modify: `packages/byd_bmu.yaml` (unter `automation:`)
+
+**Interfaces:**
+- Consumes: `binary_sensor.byd_daten_frisch`, `sensor.byd_modul_2_zellspannung_min`, `input_number.byd_knie_ref_frozen`, `input_select.byd_knie_zyklus_status`, `sensor.byd_netto_energie_seit_voll`, Home-Assistant-Start.
+- Produces: setzt `byd_knie_zyklus_status`=invalid + `input_text.byd_knie_invalid_grund`.
+
+- [ ] **Step 1: YAML einfügen**
+
+```yaml
+  - id: byd_knie_invalid
+    alias: "BYD | Knie-Zyklus ungueltig markieren"
+    description: >-
+      Markiert den laufenden armed-Zyklus als invalid bei Mess-Qualitaetsproblemen:
+      Datenluecke nahe Knie, Neustart nahe Knie, unplausibler Netto-Sprung.
+    mode: queued
+    max: 5
+    triggers:
+      - trigger: state
+        id: datenluecke
+        entity_id: binary_sensor.byd_daten_frisch
+        to: "off"
+        for: "00:02:00"
+      - trigger: homeassistant
+        id: neustart
+        event: start
+      - trigger: state
+        id: zaehlersprung
+        entity_id: sensor.byd_netto_energie_seit_voll
+    conditions:
+      - condition: state
+        entity_id: input_select.byd_knie_zyklus_status
+        state: "armed"
+      - condition: or
+        conditions:
+          # Datenluecke oder Neustart nur relevant, wenn Modul-2 nahe/unter Schwelle (Knie-Kandidat)
+          - condition: and
+            conditions:
+              - condition: trigger
+                id: ["datenluecke", "neustart"]
+              - condition: template
+                value_template: >
+                  {{ states('sensor.byd_modul_2_zellspannung_min')|float(9)
+                     <= states('input_number.byd_knie_ref_frozen')|float(3.20) + 0.01 }}
+          # Unplausibler Sprung: Netto-Aenderung > 3 kWh in einem Schritt (bei 60 s physikalisch unmoeglich)
+          - condition: template
+            value_template: >
+              {{ trigger.id == 'zaehlersprung'
+                 and trigger.from_state is not none and trigger.to_state is not none
+                 and trigger.from_state.state not in ['unknown','unavailable']
+                 and trigger.to_state.state not in ['unknown','unavailable']
+                 and (trigger.to_state.state|float - trigger.from_state.state|float)|abs > 3 }}
+    actions:
+      - action: input_select.select_option
+        target: { entity_id: input_select.byd_knie_zyklus_status }
+        data: { option: "invalid" }
+      - action: input_text.set_value
+        target: { entity_id: input_text.byd_knie_invalid_grund }
+        data: { value: "{{ trigger.id }} @ {{ now().strftime('%Y-%m-%d %H:%M') }}" }
+```
+
+- [ ] **Step 2: Reload + Verifikation**
+
+```
+ha_get_state("automation.byd_knie_invalid")
+```
+Erwartet: aktiv, keine Fehler. (Funktionale Auslösung nur bei echten Störfällen; nicht künstlich erzwingen.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/byd_bmu.yaml
+git commit -m "feat(byd): Zyklus-Gueltigkeitslogik (invalid-Marker)"
+```
+
+---
+
+### Task 9: Live-Verifikation an realem Zyklus + Doku
+
+**Files:**
+- Modify: `docs/byd-bmu-monitoring.md` (Abschnitt "Modul-2 Frühwarnung")
+- Create: `docs/livetest-byd-modul2-fruehwarnung-2026-07.md`
+
+- [ ] **Step 1: Deploy live sicherstellen**
+
+Package live in `/config/packages/byd_bmu.yaml` (in-place, identisch zum Repo-Stand), Reload ausgeführt, keine Config-Fehler (`ha_get_logs source=system level=ERROR`).
+
+- [ ] **Step 2: Ganzen Zyklus beobachten**
+
+An der nächsten realen Vollladung + tiefen Entladung prüfen (`ha_get_automation_traces`, `ha_get_state`, `ha_get_history`):
+- Voll-Anker feuert am Ladeabschluss (Status → armed, utility_meter auf 0, ref_frozen gesetzt, ueberschwelle_gesehen kippt danach on).
+- Bei Modul-2-min < 3,20 V (3 min, im Entladeband) latcht `sensor.byd_modul2_netto_bis_knie` mit plausiblen Attributen (netto_kwh, sauberer_zyklus, a_absackung_mv).
+- Nach Latch: Status latched, armed off.
+Erwartungswert grobe Größenordnung: netto bis Knie ~9-11 kWh (Vollhub bis SoC ~21 %).
+
+- [ ] **Step 3: Protokoll + Doku schreiben**
+
+`docs/livetest-byd-modul2-fruehwarnung-2026-07.md`: beobachtete Anker-/Latch-Zeiten, Rohwerte, ob `sauberer_zyklus`, Abweichungen. Repo-Konvention (Memory "Livetests im Repo dokumentieren").
+`docs/byd-bmu-monitoring.md`: kurzer Abschnitt Betrieb/Interpretation (Referenz tunen, Trend lesen, Alarm bewusst offen).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/livetest-byd-modul2-fruehwarnung-2026-07.md docs/byd-bmu-monitoring.md
+git commit -m "docs(byd): Modul-2 Fruehwarnung Livetest-Protokoll + Betriebsdoku"
+```
+
+---
+
+### Task 10: Dashboard + PR
+
+**Files:**
+- Dashboard "Akku-Gesundheit (BMU)" (live via `ha_config_set_dashboard`, kein Repo-YAML sofern Dashboard live-only).
+
+- [ ] **Step 1: Karten ergänzen**
+
+In Sektion "Akku-Gesundheit (BMU)": ApexCharts-Verlauf `sensor.byd_modul2_absackung` (mV) und `sensor.byd_modul2_netto_bis_knie` (kWh, als Punkte/Balken über Zeit), plus Status-Chip `input_select.byd_knie_zyklus_status`. Referenz-Regler `input_number.byd_knie_referenzspannung` als `number`-Card.
+
+- [ ] **Step 2: Verifikation**
+
+Dashboard lädt fehlerfrei; Karten zeigen die Entitäten.
+
+- [ ] **Step 3: Privacy-Scan + PR**
+
+Privacy-Scan aller getrackten Dateien (öffentliches Repo). Dann Branch pushen und PR gegen `feat/byd-bmu-monitoring` öffnen (oder direkt in PR #39 integrieren - mit Ben klären). **Push/PR erst nach expliziter Freigabe durch Ben.**
+
+---
+
+## Self-Review
+
+- **Spec-Abdeckung:** Sensor A (Task 4), Nettoenergie/utility_meter (Task 3), Voll-Anker (Task 6), Lastband/Frische (Task 2), Latch+Guard+Hysterese-via-Hold (Task 7), Latch-Attribute (Task 5), Gültigkeitslogik (Task 8), Helfer (Task 1), Deploy/Doku/Dashboard (Task 9-10). Alle §-Abschnitte der Spec abgedeckt.
+- **Bewusste Vereinfachungen ggü. Spec/Codex (dokumentiert):** Frische = `has_value` statt exakter 120-s-Altersprüfung (keine Time-Pattern-Automation); mV-Hysterese über 3-min-Haltezeit statt separatem ±5-mV-Band; Latch-Last = Momentan-`leistung_w` (durch Entladeband-Gate bereits auf 500-1500 W beschränkt) statt Fenster-Mittel. Jede ist im Plan begründet; keine ändert das Messziel.
+- **Typ-/Namenskonsistenz:** Entity-IDs durchgängig identisch (byd_knie_ref_frozen, byd_knie_zyklus_status, byd_netto_energie_seit_voll, byd_modul2_absackung, byd_modul2_netto_bis_knie, byd_geladen/entladen_seit_voll). Vorzeichen positiv=Entladen überall gleich.
+- **Offen für Live-Kalibrierung (kein Blocker):** exakte Anker-Zellspannung (3,55 vs 3,60), Lastband-Breite, ob 3,20 V oft genug feuert. In Task 9 verifiziert/nachgezogen.

--- a/docs/byd-modul2-fruehwarnung-plan.md
+++ b/docs/byd-modul2-fruehwarnung-plan.md
@@ -263,7 +263,10 @@ Erwartet: kleiner mV-Wert (im Plateau ~1-3, positiv wenn Modul 2 tiefer).
         unit_of_measurement: "mV"
         state_class: measurement
         icon: mdi:arrow-down-bold-box
-        availability: "{{ is_state('binary_sensor.byd_daten_frisch','on') }}"
+        availability: >
+          {{ has_value('sensor.byd_modul_1_zellspannung_min') and has_value('sensor.byd_modul_2_zellspannung_min')
+             and has_value('sensor.byd_modul_3_zellspannung_min') and has_value('sensor.byd_modul_4_zellspannung_min')
+             and has_value('sensor.byd_modul_5_zellspannung_min') }}
         state: >
           {% set peers = [states('sensor.byd_modul_1_zellspannung_min')|float,
                           states('sensor.byd_modul_3_zellspannung_min')|float,
@@ -428,7 +431,7 @@ git commit -m "feat(byd): Latch-Sensor Nettoenergie bis Knie"
         target: { entity_id: input_number.byd_knie_ref_frozen }
         data:
           value: "{{ states('input_number.byd_knie_referenzspannung')|float(3.20) }}"
-      - action: input_boolean.turn_off
+      - action: input_boolean.turn_on   # am Anker ist Modul 2 verifiziert hoch -> Flag direkt setzen (Guard-Automation ist redundanter Backup)
         target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
       - action: input_text.set_value
         target: { entity_id: input_text.byd_knie_cycle_id }
@@ -590,14 +593,17 @@ git commit -m "feat(byd): Ueberschwelle-Guard + Knie-Latch Automation"
                 value_template: >
                   {{ states('sensor.byd_modul_2_zellspannung_min')|float(9)
                      <= states('input_number.byd_knie_ref_frozen')|float(3.20) + 0.01 }}
-          # Unplausibler Sprung: Netto-Aenderung > 3 kWh in einem Schritt (bei 60 s physikalisch unmoeglich)
+          # Unplausibler POSITIVER Sprung: Netto-Zuwachs > 3 kWh in einem Schritt (bei 60 s physikalisch
+          # unmoeglich). Nur positiv (negative Stufen = utility_meter-Reset am Anker), plus 120-s-Grace
+          # nach dem Voll-Anker, damit die Reset-Stufe selbst nicht faelschlich invalidiert.
           - condition: template
             value_template: >
               {{ trigger.id == 'zaehlersprung'
                  and trigger.from_state is not none and trigger.to_state is not none
                  and trigger.from_state.state not in ['unknown','unavailable']
                  and trigger.to_state.state not in ['unknown','unavailable']
-                 and (trigger.to_state.state|float - trigger.from_state.state|float)|abs > 3 }}
+                 and (trigger.to_state.state|float - trigger.from_state.state|float) > 3
+                 and (now().timestamp() - state_attr('input_datetime.byd_voll_anker_zeit','timestamp')|float(0)) > 120 }}
     actions:
       - action: input_select.select_option
         target: { entity_id: input_select.byd_knie_zyklus_status }

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -439,6 +439,43 @@ template:
           {{ has_value('sensor.byd_leistung') and 500 <= p <= 1500 }}
 
 # ---------------------------------------------------------------------------
+# Modul-2 Fruehwarnung: Sensor A - relative Zell-Absackung (mV, Peer-Median
+# der 4 Nachbarmodule ggue. Modul 2). Details: docs/byd-modul2-fruehwarnung-plan.md (Task 4).
+# ---------------------------------------------------------------------------
+  - sensor:
+      - unique_id: byd_modul2_absackung
+        name: "BYD Modul-2 Absackung"
+        unit_of_measurement: "mV"
+        state_class: measurement
+        icon: mdi:arrow-down-bold-box
+        availability: "{{ is_state('binary_sensor.byd_daten_frisch','on') }}"
+        state: >
+          {% set peers = [states('sensor.byd_modul_1_zellspannung_min')|float,
+                          states('sensor.byd_modul_3_zellspannung_min')|float,
+                          states('sensor.byd_modul_4_zellspannung_min')|float,
+                          states('sensor.byd_modul_5_zellspannung_min')|float] | sort %}
+          {% set peer_median = (peers[1] + peers[2]) / 2 %}
+          {% set m2 = states('sensor.byd_modul_2_zellspannung_min')|float %}
+          {{ ((peer_median - m2) * 1000) | round(1) }}
+        attributes:
+          soc: "{{ states('sensor.byd_soc') }}"
+          leistung_w: "{{ states('sensor.byd_leistung') }}"
+          modul2_volt: "{{ states('sensor.byd_modul_2_zellspannung_min') }}"
+          peer_median_volt: >
+            {% set peers = [states('sensor.byd_modul_1_zellspannung_min')|float,
+                            states('sensor.byd_modul_3_zellspannung_min')|float,
+                            states('sensor.byd_modul_4_zellspannung_min')|float,
+                            states('sensor.byd_modul_5_zellspannung_min')|float] | sort %}
+            {{ ((peers[1] + peers[2]) / 2) | round(3) }}
+          schwaechstes_modul: >
+            {% set ns = namespace(min_v=99, idx='?') %}
+            {% for i in [1,2,3,4,5] %}
+              {% set v = states('sensor.byd_modul_' ~ i ~ '_zellspannung_min')|float(99) %}
+              {% if v < ns.min_v %}{% set ns.min_v = v %}{% set ns.idx = i|string %}{% endif %}
+            {% endfor %}
+            {{ ns.idx }}
+
+# ---------------------------------------------------------------------------
 # Alarme: deterministische Gesundheits-Alarme aus den BMU-Daten.
 # Schwellen liegen bewusst VOR den BMS-Schutzgrenzen (2,75/3,65 V).
 #

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -800,6 +800,56 @@ automation:
       - action: input_boolean.turn_off
         target: { entity_id: input_boolean.byd_knie_armed }
 
+  - id: byd_knie_invalid
+    alias: "BYD | Knie-Zyklus ungueltig markieren"
+    description: >-
+      Markiert den laufenden armed-Zyklus als invalid bei Mess-Qualitaetsproblemen:
+      Datenluecke nahe Knie, Neustart nahe Knie, unplausibler Netto-Sprung.
+    mode: queued
+    max: 5
+    triggers:
+      - trigger: state
+        id: datenluecke
+        entity_id: binary_sensor.byd_daten_frisch
+        to: "off"
+        for: "00:02:00"
+      - trigger: homeassistant
+        id: neustart
+        event: start
+      - trigger: state
+        id: zaehlersprung
+        entity_id: sensor.byd_netto_energie_seit_voll
+    conditions:
+      - condition: state
+        entity_id: input_select.byd_knie_zyklus_status
+        state: "armed"
+      - condition: or
+        conditions:
+          # Datenluecke oder Neustart nur relevant, wenn Modul-2 nahe/unter Schwelle (Knie-Kandidat)
+          - condition: and
+            conditions:
+              - condition: trigger
+                id: ["datenluecke", "neustart"]
+              - condition: template
+                value_template: >
+                  {{ states('sensor.byd_modul_2_zellspannung_min')|float(9)
+                     <= states('input_number.byd_knie_ref_frozen')|float(3.20) + 0.01 }}
+          # Unplausibler Sprung: Netto-Aenderung > 3 kWh in einem Schritt (bei 60 s physikalisch unmoeglich)
+          - condition: template
+            value_template: >
+              {{ trigger.id == 'zaehlersprung'
+                 and trigger.from_state is not none and trigger.to_state is not none
+                 and trigger.from_state.state not in ['unknown','unavailable']
+                 and trigger.to_state.state not in ['unknown','unavailable']
+                 and (trigger.to_state.state|float - trigger.from_state.state|float)|abs > 3 }}
+    actions:
+      - action: input_select.select_option
+        target: { entity_id: input_select.byd_knie_zyklus_status }
+        data: { option: "invalid" }
+      - action: input_text.set_value
+        target: { entity_id: input_text.byd_knie_invalid_grund }
+        data: { value: "{{ trigger.id }} @ {{ now().strftime('%Y-%m-%d %H:%M') }}" }
+
 # ---------------------------------------------------------------------------
 # Modul-2 Fruehwarnung: Helfer fuer den Knie-Zyklus-Statemachine
 # (idle -> armed -> latched, jederzeit -> invalid). Details: docs/byd-modul2-fruehwarnung-plan.md

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -494,12 +494,12 @@ template:
         device_class: energy
         state_class: measurement
         icon: mdi:battery-alert-variant-outline
-        state: "{{ states('sensor.byd_netto_energie_seit_voll') }}"
+        state: "{{ states('sensor.byd_nettoenergie_seit_voll') }}"
         attributes:
-          netto_kwh: "{{ states('sensor.byd_netto_energie_seit_voll') }}"
+          netto_kwh: "{{ states('sensor.byd_nettoenergie_seit_voll') }}"
           geladen_inkrement_kwh: "{{ states('sensor.byd_geladen_seit_voll') }}"
           entladen_inkrement_kwh: "{{ states('sensor.byd_entladen_seit_voll') }}"
-          a_absackung_mv: "{{ states('sensor.byd_modul2_absackung') }}"
+          a_absackung_mv: "{{ states('sensor.byd_modul_2_absackung') }}"
           soc: "{{ states('sensor.byd_soc') }}"
           leistung_w: "{{ states('sensor.byd_leistung') }}"
           modul2_volt: "{{ states('sensor.byd_modul_2_zellspannung_min') }}"
@@ -723,7 +723,7 @@ automation:
       - condition: template
         value_template: >
           {{ is_state('input_select.byd_knie_zyklus_status','idle')
-             or states('sensor.byd_netto_energie_seit_voll')|float(0) >= 0.5 }}
+             or states('sensor.byd_nettoenergie_seit_voll')|float(0) >= 0.5 }}
     actions:
       - action: utility_meter.reset
         target:
@@ -795,7 +795,7 @@ automation:
         entity_id: binary_sensor.byd_daten_frisch
         state: "on"
       - condition: template
-        value_template: "{{ has_value('sensor.byd_netto_energie_seit_voll') }}"
+        value_template: "{{ has_value('sensor.byd_nettoenergie_seit_voll') }}"
     actions:
       - action: input_select.select_option
         target: { entity_id: input_select.byd_knie_zyklus_status }
@@ -821,7 +821,7 @@ automation:
         event: start
       - trigger: state
         id: zaehlersprung
-        entity_id: sensor.byd_netto_energie_seit_voll
+        entity_id: sensor.byd_nettoenergie_seit_voll
     conditions:
       - condition: state
         entity_id: input_select.byd_knie_zyklus_status

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -313,6 +313,68 @@ mqtt:
       state_class: measurement
       expire_after: 300
 
+    # Modul-2-Fruehwarnung: schwaechste/staerkste Zell-Nummer je Modul (MinVoltID/MaxVoltID)
+    - name: "BYD Modul 1 Min-Zell-ID"
+      unique_id: byd_bmu_m1_min_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_1/MinVoltID"
+      icon: mdi:battery-arrow-down
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 1 Max-Zell-ID"
+      unique_id: byd_bmu_m1_max_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_1/MaxVoltID"
+      icon: mdi:battery-arrow-up
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 2 Min-Zell-ID"
+      unique_id: byd_bmu_m2_min_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_2/MinVoltID"
+      icon: mdi:battery-arrow-down
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 2 Max-Zell-ID"
+      unique_id: byd_bmu_m2_max_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_2/MaxVoltID"
+      icon: mdi:battery-arrow-up
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 3 Min-Zell-ID"
+      unique_id: byd_bmu_m3_min_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_3/MinVoltID"
+      icon: mdi:battery-arrow-down
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 3 Max-Zell-ID"
+      unique_id: byd_bmu_m3_max_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_3/MaxVoltID"
+      icon: mdi:battery-arrow-up
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 4 Min-Zell-ID"
+      unique_id: byd_bmu_m4_min_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_4/MinVoltID"
+      icon: mdi:battery-arrow-down
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 4 Max-Zell-ID"
+      unique_id: byd_bmu_m4_max_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_4/MaxVoltID"
+      icon: mdi:battery-arrow-up
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 5 Min-Zell-ID"
+      unique_id: byd_bmu_m5_min_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_5/MinVoltID"
+      icon: mdi:battery-arrow-down
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 5 Max-Zell-ID"
+      unique_id: byd_bmu_m5_max_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_5/MaxVoltID"
+      icon: mdi:battery-arrow-up
+      entity_category: diagnostic
+      expire_after: 300
+
   binary_sensor:
     - name: "BYD Balancing aktiv"
       unique_id: byd_bmu_balancing
@@ -464,6 +526,7 @@ template:
           soc: "{{ states('sensor.byd_soc') }}"
           leistung_w: "{{ states('sensor.byd_leistung') }}"
           modul2_volt: "{{ states('sensor.byd_modul_2_zellspannung_min') }}"
+          schwaechste_zelle_id: "{{ states('sensor.byd_modul_2_min_zell_id') }}"
           peer_median_volt: >
             {% set peers = [states('sensor.byd_modul_1_zellspannung_min')|float,
                             states('sensor.byd_modul_3_zellspannung_min')|float,
@@ -503,6 +566,8 @@ template:
           soc: "{{ states('sensor.byd_soc') }}"
           leistung_w: "{{ states('sensor.byd_leistung') }}"
           modul2_volt: "{{ states('sensor.byd_modul_2_zellspannung_min') }}"
+          modul2_schwaechste_zelle_id: "{{ states('sensor.byd_modul_2_min_zell_id') }}"
+          modul2_staerkste_zelle_id: "{{ states('sensor.byd_modul_2_max_zell_id') }}"
           modul_temp_c: "{{ states('sensor.byd_modul_2_temp_max') }}"
           ref_verwendet_v: "{{ states('input_number.byd_knie_ref_frozen') }}"
           cycle_id: "{{ states('input_text.byd_knie_cycle_id') }}"

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -747,6 +747,59 @@ automation:
       - action: input_boolean.turn_off
         target: { entity_id: input_boolean.byd_top_erreicht }
 
+  - id: byd_knie_ueberschwelle_gesehen
+    alias: "BYD | Knie Ueberschwelle gesehen"
+    description: "Setzt das Guard-Flag, sobald Modul-2-min seit dem Anker klar (>= ref+30 mV) oberhalb der Schwelle war."
+    mode: single
+    triggers:
+      - trigger: template
+        value_template: >
+          {{ states('sensor.byd_modul_2_zellspannung_min')|float(0)
+             > states('input_number.byd_knie_ref_frozen')|float(3.20) + 0.03 }}
+    conditions:
+      - condition: state
+        entity_id: input_boolean.byd_knie_armed
+        state: "on"
+    actions:
+      - action: input_boolean.turn_on
+        target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
+
+  - id: byd_knie_latch
+    alias: "BYD | Knie-Latch (Nettoenergie festhalten)"
+    description: >-
+      Latcht, wenn Modul-2-min zum ersten Mal seit Voll die eingefrorene Referenz
+      (Default 3,20 V) 3 min lang unterschreitet, im standardisierten Entladeband
+      (+500..1500 W ueber die Haltezeit), bei frischen Daten und gesehener Ueberschwelle.
+      Die 3-min-Haltezeit ersetzt eine explizite mV-Hysterese (starke Entprellung).
+    mode: single
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.byd_modul_2_zellspannung_min
+        below: input_number.byd_knie_ref_frozen
+        for: "00:03:00"
+    conditions:
+      - condition: state
+        entity_id: input_select.byd_knie_zyklus_status
+        state: "armed"
+      - condition: state
+        entity_id: input_boolean.byd_knie_ueberschwelle_gesehen
+        state: "on"
+      - condition: state
+        entity_id: binary_sensor.byd_entladeband
+        state: "on"
+        for: "00:03:00"
+      - condition: state
+        entity_id: binary_sensor.byd_daten_frisch
+        state: "on"
+      - condition: template
+        value_template: "{{ has_value('sensor.byd_netto_energie_seit_voll') }}"
+    actions:
+      - action: input_select.select_option
+        target: { entity_id: input_select.byd_knie_zyklus_status }
+        data: { option: "latched" }        # der Latch-Sensor (Task 5) snapshottet hierauf
+      - action: input_boolean.turn_off
+        target: { entity_id: input_boolean.byd_knie_armed }
+
 # ---------------------------------------------------------------------------
 # Modul-2 Fruehwarnung: Helfer fuer den Knie-Zyklus-Statemachine
 # (idle -> armed -> latched, jederzeit -> invalid). Details: docs/byd-modul2-fruehwarnung-plan.md

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -680,6 +680,73 @@ automation:
               Balancing aktiv: {{ states('binary_sensor.byd_balancing_aktiv') }}
               Steuerungs-Modus: {{ states('input_select.akkusteuerung_modus') }}
 
+  - id: byd_top_erreicht_merker
+    alias: "BYD | Ladeschluss-Merker setzen"
+    description: "Merkt sich, dass im laufenden Ladevorgang die Ladeschluss-Zellspannung erreicht wurde (Voll-Anker-Evidenz)."
+    mode: single
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.byd_zellspannung_max
+        above: 3.55
+        for: "00:02:00"
+    conditions: []
+    actions:
+      - action: input_boolean.turn_on
+        target: { entity_id: input_boolean.byd_top_erreicht }
+
+  - id: byd_voll_anker
+    alias: "BYD | Voll-Anker (Ladeabschluss)"
+    description: >-
+      Ladeabschluss-Event: Zellmax war >=3,55 V (Merker), danach Ladeende
+      (Leistung > -300 W = nicht mehr nennenswert Laden) fuer 5 min. Setzt den
+      Knie-Zyklus neu auf. Re-Arm-Sperre: nur wenn idle ODER seit letztem Anker
+      >=0,5 kWh netto entnommen (verhindert Mehrfach-Reset im Ladeschluss-Flattern).
+    mode: single
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.byd_leistung
+        above: -300
+        for: "00:05:00"
+    conditions:
+      - condition: state
+        entity_id: input_boolean.byd_top_erreicht
+        state: "on"
+      - condition: numeric_state
+        entity_id: sensor.byd_soc
+        above: 94
+      - condition: state
+        entity_id: binary_sensor.byd_daten_frisch
+        state: "on"
+      - condition: template
+        value_template: >
+          {{ is_state('input_select.byd_knie_zyklus_status','idle')
+             or states('sensor.byd_netto_energie_seit_voll')|float(0) >= 0.5 }}
+    actions:
+      - action: utility_meter.reset
+        target:
+          entity_id:
+            - sensor.byd_geladen_seit_voll
+            - sensor.byd_entladen_seit_voll
+      - action: input_number.set_value
+        target: { entity_id: input_number.byd_knie_ref_frozen }
+        data:
+          value: "{{ states('input_number.byd_knie_referenzspannung')|float(3.20) }}"
+      - action: input_boolean.turn_off
+        target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
+      - action: input_text.set_value
+        target: { entity_id: input_text.byd_knie_cycle_id }
+        data: { value: "{{ now().isoformat() }}" }
+      - action: input_datetime.set_datetime
+        target: { entity_id: input_datetime.byd_voll_anker_zeit }
+        data: { datetime: "{{ now().isoformat() }}" }
+      - action: input_select.select_option
+        target: { entity_id: input_select.byd_knie_zyklus_status }
+        data: { option: "armed" }
+      - action: input_boolean.turn_on
+        target: { entity_id: input_boolean.byd_knie_armed }
+      - action: input_boolean.turn_off
+        target: { entity_id: input_boolean.byd_top_erreicht }
+
 # ---------------------------------------------------------------------------
 # Modul-2 Fruehwarnung: Helfer fuer den Knie-Zyklus-Statemachine
 # (idle -> armed -> latched, jederzeit -> invalid). Details: docs/byd-modul2-fruehwarnung-plan.md

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -361,6 +361,22 @@ template:
                          states('sensor.byd_modul_5_temp_min')|float(99)] | min %}
           {{ (tmax - tmin) | round(0) }}
 
+      # Modul-2 Fruehwarnung: Nettoenergie seit dem letzten Voll-Anker
+      # (entladen - geladen, kWh). Kann bei PV-Ueberschussladung zwischen
+      # Ankern sinken - deshalb measurement statt total_increasing.
+      # Details: docs/byd-modul2-fruehwarnung-plan.md (Task 3).
+      - unique_id: byd_netto_energie_seit_voll
+        name: "BYD Nettoenergie seit Voll"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: measurement          # NICHT total_increasing (darf bei PV-Ladung sinken)
+        icon: mdi:battery-minus-outline
+        availability: >
+          {{ has_value('sensor.byd_entladen_seit_voll') and has_value('sensor.byd_geladen_seit_voll') }}
+        state: >
+          {{ (states('sensor.byd_entladen_seit_voll')|float
+              - states('sensor.byd_geladen_seit_voll')|float) | round(3) }}
+
   # ---------------------------------------------------------------------------
   # Ruhe-Spreizung: aktualisiert NUR, wenn der Akku (nahezu) lastfrei ist
   # (|Leistung| < 300 W) UND der SoC im flachen Teil der LFP-Kennlinie liegt
@@ -651,3 +667,19 @@ input_datetime:
     name: "BYD Voll-Anker Zeit"
     has_date: true
     has_time: true
+
+# ---------------------------------------------------------------------------
+# Modul-2 Fruehwarnung: Energie-Zaehler seit dem letzten Voll-Anker (Reset
+# durch die Voll-Anker-Automation via utility_meter.reset). Quelle ist
+# total_increasing, kein Zyklus-Reset noetig -> periodically_resetting: false.
+# Details: docs/byd-modul2-fruehwarnung-plan.md (Task 3).
+# ---------------------------------------------------------------------------
+utility_meter:
+  byd_geladen_seit_voll:
+    source: sensor.byd_geladen_gesamt
+    name: "BYD geladen seit Voll"
+    periodically_resetting: false      # Quelle ist total_increasing, kein Zyklus-Reset
+  byd_entladen_seit_voll:
+    source: sensor.byd_entladen_gesamt
+    name: "BYD entladen seit Voll"
+    periodically_resetting: false

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -476,6 +476,37 @@ template:
             {{ ns.idx }}
 
 # ---------------------------------------------------------------------------
+# Modul-2 Fruehwarnung: Latch-Sensor - snapshottet die Nettoenergie seit Voll
+# (und Begleitwerte) im Moment, in dem der Knie-Zyklus-Status nach "latched"
+# wechselt. Details: docs/byd-modul2-fruehwarnung-plan.md (Task 5).
+# ---------------------------------------------------------------------------
+  - triggers:
+      - trigger: state
+        entity_id: input_select.byd_knie_zyklus_status
+        to: "latched"
+    sensor:
+      - unique_id: byd_modul2_netto_bis_knie
+        name: "BYD Modul-2 Nettoenergie bis Knie"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: measurement
+        icon: mdi:battery-alert-variant-outline
+        state: "{{ states('sensor.byd_netto_energie_seit_voll') }}"
+        attributes:
+          netto_kwh: "{{ states('sensor.byd_netto_energie_seit_voll') }}"
+          geladen_inkrement_kwh: "{{ states('sensor.byd_geladen_seit_voll') }}"
+          entladen_inkrement_kwh: "{{ states('sensor.byd_entladen_seit_voll') }}"
+          a_absackung_mv: "{{ states('sensor.byd_modul2_absackung') }}"
+          soc: "{{ states('sensor.byd_soc') }}"
+          leistung_w: "{{ states('sensor.byd_leistung') }}"
+          modul2_volt: "{{ states('sensor.byd_modul_2_zellspannung_min') }}"
+          modul_temp_c: "{{ states('sensor.byd_modul_2_temp_max') }}"
+          ref_verwendet_v: "{{ states('input_number.byd_knie_ref_frozen') }}"
+          cycle_id: "{{ states('input_text.byd_knie_cycle_id') }}"
+          sauberer_zyklus: "{{ states('sensor.byd_geladen_seit_voll')|float(0) < 0.5 }}"
+          gemessen: "{{ now().isoformat() }}"
+
+# ---------------------------------------------------------------------------
 # Alarme: deterministische Gesundheits-Alarme aus den BMU-Daten.
 # Schwellen liegen bewusst VOR den BMS-Schutzgrenzen (2,75/3,65 V).
 #

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -448,7 +448,10 @@ template:
         unit_of_measurement: "mV"
         state_class: measurement
         icon: mdi:arrow-down-bold-box
-        availability: "{{ is_state('binary_sensor.byd_daten_frisch','on') }}"
+        availability: >
+          {{ has_value('sensor.byd_modul_1_zellspannung_min') and has_value('sensor.byd_modul_2_zellspannung_min')
+             and has_value('sensor.byd_modul_3_zellspannung_min') and has_value('sensor.byd_modul_4_zellspannung_min')
+             and has_value('sensor.byd_modul_5_zellspannung_min') }}
         state: >
           {% set peers = [states('sensor.byd_modul_1_zellspannung_min')|float,
                           states('sensor.byd_modul_3_zellspannung_min')|float,
@@ -731,7 +734,7 @@ automation:
         target: { entity_id: input_number.byd_knie_ref_frozen }
         data:
           value: "{{ states('input_number.byd_knie_referenzspannung')|float(3.20) }}"
-      - action: input_boolean.turn_off
+      - action: input_boolean.turn_on
         target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
       - action: input_text.set_value
         target: { entity_id: input_text.byd_knie_cycle_id }
@@ -841,7 +844,8 @@ automation:
                  and trigger.from_state is not none and trigger.to_state is not none
                  and trigger.from_state.state not in ['unknown','unavailable']
                  and trigger.to_state.state not in ['unknown','unavailable']
-                 and (trigger.to_state.state|float - trigger.from_state.state|float)|abs > 3 }}
+                 and (trigger.to_state.state|float - trigger.from_state.state|float) > 3
+                 and (now().timestamp() - state_attr('input_datetime.byd_voll_anker_zeit','timestamp')|float(0)) > 120 }}
     actions:
       - action: input_select.select_option
         target: { entity_id: input_select.byd_knie_zyklus_status }

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -398,6 +398,31 @@ template:
           gemessen: "{{ now().isoformat() }}"
 
 # ---------------------------------------------------------------------------
+# Modul-2 Fruehwarnung: Frische- und Entladeband-Guards fuer die Knie-
+# Statemachine. Details: docs/byd-modul2-fruehwarnung-plan.md (Task 2).
+# ---------------------------------------------------------------------------
+  - binary_sensor:
+      - unique_id: byd_daten_frisch
+        name: "BYD Daten frisch"
+        device_class: connectivity
+        icon: mdi:database-check
+        state: >
+          {{ has_value('sensor.byd_soc') and has_value('sensor.byd_leistung')
+             and has_value('sensor.byd_modul_1_zellspannung_min')
+             and has_value('sensor.byd_modul_2_zellspannung_min')
+             and has_value('sensor.byd_modul_3_zellspannung_min')
+             and has_value('sensor.byd_modul_4_zellspannung_min')
+             and has_value('sensor.byd_modul_5_zellspannung_min')
+             and has_value('sensor.byd_geladen_seit_voll')
+             and has_value('sensor.byd_entladen_seit_voll') }}
+      - unique_id: byd_entladeband
+        name: "BYD Entladeband"
+        icon: mdi:speedometer-slow
+        state: >
+          {% set p = states('sensor.byd_leistung')|float(0) %}
+          {{ has_value('sensor.byd_leistung') and 500 <= p <= 1500 }}
+
+# ---------------------------------------------------------------------------
 # Alarme: deterministische Gesundheits-Alarme aus den BMU-Daten.
 # Schwellen liegen bewusst VOR den BMS-Schutzgrenzen (2,75/3,65 V).
 #

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -570,3 +570,59 @@ automation:
               Temperatur-Spreizung: {{ states('sensor.byd_temperatur_spreizung') }} K
               Balancing aktiv: {{ states('binary_sensor.byd_balancing_aktiv') }}
               Steuerungs-Modus: {{ states('input_select.akkusteuerung_modus') }}
+
+# ---------------------------------------------------------------------------
+# Modul-2 Fruehwarnung: Helfer fuer den Knie-Zyklus-Statemachine
+# (idle -> armed -> latched, jederzeit -> invalid). Details: docs/byd-modul2-fruehwarnung-plan.md
+# ---------------------------------------------------------------------------
+input_number:
+  byd_knie_referenzspannung:
+    name: "BYD Knie-Referenzspannung"
+    min: 3.05
+    max: 3.35
+    step: 0.005
+    initial: 3.20          # nur beim allerersten Start; danach restore
+    unit_of_measurement: "V"
+    mode: box
+    icon: mdi:sine-wave
+  byd_knie_ref_frozen:
+    name: "BYD Knie-Referenz (eingefroren)"
+    min: 3.05
+    max: 3.35
+    step: 0.001
+    initial: 3.20
+    unit_of_measurement: "V"
+    mode: box
+    icon: mdi:snowflake
+
+input_boolean:
+  byd_knie_armed:
+    name: "BYD Knie scharf"
+    icon: mdi:target
+  byd_knie_ueberschwelle_gesehen:
+    name: "BYD Knie Ueberschwelle gesehen"
+    icon: mdi:arrow-up-bold
+  byd_top_erreicht:
+    name: "BYD Ladeschluss erreicht"
+    icon: mdi:arrow-collapse-up
+
+input_select:
+  byd_knie_zyklus_status:
+    name: "BYD Knie Zyklus-Status"
+    options: ["idle", "armed", "latched", "invalid"]
+    initial: idle
+    icon: mdi:state-machine
+
+input_text:
+  byd_knie_cycle_id:
+    name: "BYD Knie Cycle-ID"
+    max: 40
+  byd_knie_invalid_grund:
+    name: "BYD Knie Invalid-Grund"
+    max: 120
+
+input_datetime:
+  byd_voll_anker_zeit:
+    name: "BYD Voll-Anker Zeit"
+    has_date: true
+    has_time: true


### PR DESCRIPTION
## Was das ist
Frühwarn-Schicht fürs schwächste BYD-HVS-Modul (Modul 2), rein beobachtend, keine Steuerwirkung.

**Zwei Kennzahlen (Design Codex-gehärtet, `docs/byd-modul2-fruehwarnung-design.md`):**
- `sensor.byd_modul_2_absackung` (mV) - Peer-Median der 4 Nachbarmodule − Modul-2-min. Alltags-Diagnose.
- `sensor.byd_modul_2_nettoenergie_bis_knie` (kWh) - Nettoenergie ab Ladeabschluss bis Modul-2-min zuerst 3,20 V erreicht (Lastband +500..1500 W). Zustandsautomat idle→armed→latched, Voll-Anker via Zellmax≥3,55 V + Ladeende, `utility_meter`-Paar netto, Gültigkeitslogik. **Kein Alarm** bis 4-8 gültige Zyklen.

**Zell-ID-Tracking:** `MinVoltID`/`MaxVoltID` → `sensor.byd_modul_N_min/max_zell_id` = Zellnummer der schwächsten/stärksten Zelle je Modul. Hängt am Latch + Sensor A → beantwortet über Wochen: sackt am Knie *immer dieselbe* Zelle in Modul 2 ab? (Codex' Kernfrage, schärfstes Defekt-Indiz.)

## Reviews
- Design: Codex adversarial (Netto-Zähler-Methodik, Lastabhängigkeit, Voll-Anker, Prellen) - eingearbeitet.
- Implementierung: Opus Whole-Branch-Review fand 1 Critical (Latch feuerte nie - flankengetriggertes Guard-Flag) + 1 Important (utility_meter-Reset triggerte Invalidator) → beide gefixt.

## Deploy-Status
- **LIVE deployed 15.7.** (als separates Package `byd_modul2_fruehwarnung.yaml` + `mqtt.yaml`-VoltID-Sensoren; Live-Divergenz zu diesem Repo-gebündelten Stand ist bekannt/dokumentiert).
- `ha core check` grün. Sensor A + Zell-IDs live verifiziert (Modul 2 schwächste Zelle = #6).

## ⚠️ NICHT MERGEN bis live-getestet
E2E Anker→Latch ist erst am nächsten Voll- + tiefen Entlade-Zyklus (~1-3 Tage, SoC-Tief <~22 %) beobachtbar. Draft bis Livetest-Protokoll vorliegt.

## Base
Gestackt auf `feat/byd-bmu-monitoring` (PR #39) - dort liegt das byd_bmu-Package. Nach #39-Merge auf main umhängen.