### PR TITLE
docs: MIT-Lizenz + Lizenz-Abschnitt in der README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Optic00
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -171,3 +171,9 @@ Dieses Projekt lebt von der Community. Besonderer Dank geht an:
 **Weitere Geräte & Versionen**
 - [ ] SBS-Unterstützung (suche Tester → [Issue öffnen](https://github.com/Optic00/ha-opti-akkusteuerung/issues))
 - [ ] English version?
+
+---
+
+## Lizenz
+
+[MIT](LICENSE) - frei nutzbar, anpassbar und weiterverteilbar, solange der Copyright- und Lizenzhinweis erhalten bleibt. Nutzung auf eigene Gefahr, ohne Gewähr (siehe Disclaimer oben).


### PR DESCRIPTION
Ergänzt eine explizite Lizenz für das öffentliche Repo.

- `LICENSE`: MIT (Copyright Optic00, 2026)
- `README.md`: neuer `## Lizenz`-Abschnitt am Ende, verlinkt auf die LICENSE

Hintergrund: Das Repo hatte bisher keine LICENSE-Datei. MIT passt zum Charakter (HA-Config/Packages, maximale Nachnutzbarkeit für die Community); Apache-2.0 wäre die Wahl für ein künftiges eigenständiges Integrations-Code-Repo.