### PR TITLE
fix(byd): Ruhe-Spreizungs-Gate unteres Limit 15->25 %

### DIFF
--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -364,10 +364,11 @@ template:
   # ---------------------------------------------------------------------------
   # Ruhe-Spreizung: aktualisiert NUR, wenn der Akku (nahezu) lastfrei ist
   # (|Leistung| < 300 W) UND der SoC im flachen Teil der LFP-Kennlinie liegt
-  # (15-85 %). Unter Last steigt die Spreizung durch Innenwiderstands-
+  # (25-85 %). Unter Last steigt die Spreizung durch Innenwiderstands-
   # Unterschiede, am oberen/unteren Kennlinien-Knie (Ladeschluss/Tiefentladung)
   # laeuft sie kennlinienbedingt hoch (beobachtet 11.7.: 292 mV bei SoC 99 %,
-  # 1-4 mV bei Mittel-SoC) - beides ist nicht vergleichbar. Erst dieser
+  # 1-4 mV bei Mittel-SoC; 16.7.: 34-38 mV bei SoC ~17 % am unteren Knie -
+  # deshalb unteres Gate von 15 auf 25 % angehoben) - beides ist nicht vergleichbar. Erst dieser
   # gefilterte Sensor macht Wochen-Trends und den spaeteren Bedarfs-Balancing-
   # Trigger moeglich. Haelt zwischen Ruhephasen den letzten Wert (RestoreEntity).
   # ---------------------------------------------------------------------------
@@ -381,7 +382,7 @@ template:
         below: 300
       - condition: numeric_state
         entity_id: sensor.byd_soc
-        above: 15
+        above: 25
         below: 85
       - condition: template
         value_template: "{{ has_value('sensor.byd_zellspreizung') }}"

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -559,7 +559,7 @@ automation:
               Datenquelle: bydlogc via MQTT (Abtastung ~60 s). BMS-Schutzgrenzen
               2,75/3,65 V - die Alarme liegen bewusst davor. Zellspannungs-Alarme
               sind SoC-gegated (<90 %), am Ladeschluss zaehlt nur die BMS-Grenze.
-              Zellspreizung ist nur in Ruhe und bei SoC 15-85 % vergleichbar.
+              Zellspreizung ist nur in Ruhe und bei SoC 25-85 % vergleichbar.
             daten: >-
               Ausgeloest durch Regel: {{ trigger.id }}
               {{ alarm_text }}


### PR DESCRIPTION
Der Ruhe-Spreizungs-Sensor (`sensor.byd_zellspreizung_ruhe`) hatte sein unteres SoC-Gate bei 15 %. Am 16.7. zeigte er bei SoC ~17 % (nach Tiefentladung über Nacht) 34-38 mV, obwohl die Plateau-Ruhespreizung am Vorabend nur 3 mV war - reine LFP-Knie-Inflation am unteren Ende, kein Zellzustand.

Unteres Gate 15 -> 25 %, damit der Ruhe-Wert nur den flachen Kennlinienbereich misst (oberes Knie war über 85-%-Gate schon ausgeschlossen). Kostet praktisch keine Datenpunkte (Ruhe-Fenster liegen meist bei 40-80 % SoC).

Live bereits deployed (ha core check ok, template.reload ok, Backup .bak-ruhegate-20260716 auf dem HA-Host).