### PR TITLE
feat(byd): Monitoring-Härtung + Modul-2-Frühwarnung ins Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Der Minimalpfad. Voller Ablauf mit beiden Einspiel-Varianten, allen Erststart-We
 | `packages/sma_statistik.yaml` | Gleitende Mittelwert-Sensoren für Verbrauch & Batterielast |
 | `packages/opti_ki_analyse.yaml` | **optional** - täglicher KI-Tagesreport (rein lesend) |
 | `packages/byd_bmu.yaml` | **optional** - BYD-Zell-Monitoring via bydlogc→MQTT (→ [docs/byd-bmu-monitoring.md](docs/byd-bmu-monitoring.md)) |
+| `packages/byd_modul2_fruehwarnung.yaml` | **optional** - Degradations-Frühwarnung fürs schwächste BYD-Modul, setzt `byd_bmu.yaml` voraus (→ [docs/byd-modul2-fruehwarnung.md](docs/byd-modul2-fruehwarnung.md)) |
 | `packages/opti_ev_sperre.yaml` | **optional** - EV-Schnelllade-Entladesperre (Hausakku entlädt nicht ins Auto, wenn evcc im Modus now/minpv lädt); braucht HACS `evcc_intg` + Ladepunkt-Block im Mapping → [docs/strategie-logik.md](docs/strategie-logik.md) (Option 13) |
 | `automations/opti_strategie.yaml` | Strategie-Automation (editierbar, kein Blueprint) |
 

--- a/docs/byd-bmu-monitoring.md
+++ b/docs/byd-bmu-monitoring.md
@@ -133,19 +133,25 @@ Be-Connect-App oder BYD-Logger-GUI nie parallel zum Container laufen lassen; fü
 
 ## MQTT-Topics und HA-Package
 
-Das Tool publisht unter `Battery/BYD/BMS_1/...`: SOC, SOH, Min/Max/AvCellVolt, Power, Status1/2, Balancing, BalanceData, ChargedkWh/DischargedkWh sowie je Modul MinCellVolt/MaxCellVolt/ModuleVolt/MinTemp/MaxTemp.
-`packages/byd_bmu.yaml` mappt diese Topics auf `sensor.byd_*`-Entities (`expire_after: 300` als Ausfall-Erkennung) und ergänzt zwei abgeleitete Sensoren:
+Das Tool publisht unter `Battery/BYD/BMS_1/...`: SOC, SOH, Min/Max/AvCellVolt, Power, Status1/2, Balancing, BalanceData, ChargedkWh/DischargedkWh sowie je Modul MinCellVolt/MaxCellVolt/MinVoltID/MaxVoltID/ModuleVolt/MinTemp/MaxTemp.
+`packages/byd_bmu.yaml` mappt diese Topics auf `sensor.byd_*`-Entities (`expire_after: 300` als Ausfall-Erkennung; die VoltID-Topics als Zell-Nummern-Diagnose je Modul) und ergänzt abgeleitete Sensoren:
 
 - `sensor.byd_zellspreizung` (mV, max - min über den ganzen Turm),
-- `sensor.byd_zellspreizung_ruhe` (aktualisiert nur bei |Leistung| < 300 W - unter Last ist die Spreizung durch Innenwiderstands-Unterschiede nicht vergleichbar; erst dieser Wert taugt für Wochen-Trends),
-- `sensor.byd_temperatur_spreizung` (K, über die Module).
+- `sensor.byd_zellspreizung_ruhe` - aktualisiert nur, wenn der Akku nahezu lastfrei ist (|Leistung| < 300 W) UND der SoC im flachen Teil der LFP-Kennlinie liegt (25-85 %).
+  Unter Last verzerren Innenwiderstands-Unterschiede die Spreizung, am oberen wie unteren Kennlinien-Knie läuft sie kennlinienbedingt hoch; beides ist nicht vergleichbar.
+  Der Zustand ist der Median der letzten 5 Gate-Messungen (Attribut `messreihe`), damit ein einzelner verzerrter Wert (die Min/Max-Topics kommen ~60 s versetzt an) nicht gelatcht wird.
+  Erst dieser Wert taugt für Wochen-Trends,
+- `sensor.byd_temperatur_spreizung` (K, über die Module, negativ auf 0 geklemmt).
+
+Auf diesen Sensoren baut optional die Modul-2-Frühwarnung auf (Degradations-Monitoring des schwächsten Moduls, eigenes Package): siehe [byd-modul2-fruehwarnung.md](byd-modul2-fruehwarnung.md).
 
 Package nach `packages/` kopieren (Packages-Include vorausgesetzt, siehe README) und HA neu starten.
 Hinweis für Setups mit bestehendem top-level `mqtt: !include`: siehe Einbau-Hinweis im Package-Kopf.
 
 ## Interpretations-Hinweise (LFP)
 
-- Die Zellspreizung ist nur im Ruhezustand und bei hohem SoC aussagekräftig; im LFP-Flachplateau (ca. 30-70 % SoC) sagt sie wenig über echte Ladungs-Imbalance.
+- Die Zellspreizung ist nur im Ruhezustand und im flachen Kennlinienbereich (ca. 25-85 % SoC) über die Zeit vergleichbar.
+  Am Ladeschluss und am unteren Knie läuft sie kennlinienbedingt hoch (beobachtet: 292 mV bei SoC 99 %, 34-38 mV bei SoC ~17 %, 1-4 mV bei Mittel-SoC) - das ist kein Balancing-Befund.
 - SoH-Änderungen von Tag zu Tag sind Rauschen - nur der Langzeittrend zählt.
 - Das Verhältnis der kWh-Lebenszähler ist KEIN Wirkungsgrad (Standby- und Wandlungsverluste stecken mit drin).
 - Sinnvolle Alarm-Startwerte (keine Herstellerangaben): Zellspannung >3,55 V bzw. <2,90 V, Zelltemperatur >45 °C, Modul-Temperaturdifferenz >10 K, Ruhe-Spreizung dauerhaft >50 mV.

--- a/docs/byd-modul2-fruehwarnung-design.md
+++ b/docs/byd-modul2-fruehwarnung-design.md
@@ -1,0 +1,254 @@
+# BYD Modul-2 Frühwarnung - Design
+
+Stand: 2026-07-15.
+Branch: `feat/byd-modul2-fruehwarnung` (abgezweigt von `feat/byd-bmu-monitoring`, PR #39).
+Reviewer: Codex (adversarial Design-Review am 2026-07-15 eingearbeitet).
+
+## 1. Kontext und Ziel
+
+Das schwächste Modul der BYD Battery-Box Premium HVS 12.8 (Modul 2) sackt am unteren LFP-Entlade-Knie reproduzierbar unter die anderen vier Module.
+Diagnose (Codex + Photovoltaikforum-Vergleich): das ist die klassische Signatur des schwächsten Glieds, kein Defekt - der Pack streut sogar enger als vergleichbare HVS im Feld.
+Entscheidend für die Defekt-Früherkennung ist nicht ein einzelner mV-Wert, sondern der **Trend über Wochen**.
+
+Ziel dieses Features: zwei abgeleitete Größen dauerhaft und belastbar loggen, sodass eine echte Degradation von normaler Streuung unterscheidbar wird, ohne dass Last, SoC-Drift, MQTT-Aussetzer oder Zähler-Artefakte den Trend verfälschen.
+
+Zwei Kennzahlen (Ben hat "beides, voll gehärtet" gewählt):
+
+- **Sensor A - Relative Zell-Absackung** (mV, Alltags-Diagnose, immer an): wie weit Modul 2 unter dem Feld liegt.
+- **Sensor B - Nettoenergie bis Knie** (kWh, Wochen-Metrik): wie viel Nettoenergie ab Ladeabschluss entnommen wurde, bis Modul 2 unter definierter Last eine Referenzspannung erreicht.
+
+Die Metrik heißt bewusst **Nettoenergie**, nicht Kapazität: ohne Ah-/Strom-Zählung wird nutzbare Energie gemessen, nicht Zellkapazität in Ah.
+
+## 2. Nicht-Ziele (YAGNI)
+
+- **Kein Alarm/Schwellwert** in dieser Ausbaustufe. Erst nach 4-8 gültigen, vergleichbaren Zyklen Baseline bilden, dann in einem Folge-PR eine Warnschwelle festlegen.
+- Kein Wirkungsgrad-Korrekturfaktor. Saubere und gemischte Zyklen werden getrennt ausgewertet, nicht rechnerisch korrigiert.
+- Keine parallelen Hilfssensoren für Median/Max/Ruhe über mehrere SoC-Bänder. Der am Latch festgehaltene Wert normiert bereits.
+- Keine Zelleinzel-Auflösung (die liefert nur Be Connect Plus, manuell). Wir arbeiten mit dem Modul-Minimum.
+
+## 3. Datenquellen und verifizierte Fakten
+
+Quelle: `bydlogc` via MQTT, Abtastung ~60 s, gemappt in `packages/byd_bmu.yaml`.
+
+- Pro Modul 1-5: `sensor.byd_modul_N_zellspannung_min` / `_max`, `_temp_min` / `_temp_max` (V bzw. °C, `expire_after: 300`).
+- Gesamt: `sensor.byd_soc` (%), `sensor.byd_leistung` (W), `sensor.byd_zellspannung_max`, `binary_sensor.byd_balancing_aktiv`.
+- Zähler: `sensor.byd_geladen_gesamt`, `sensor.byd_entladen_gesamt` (kWh, `total_increasing`).
+
+Verifizierte Fakten:
+
+- **Zähler-Auflösung 0,001 kWh** (beobachtete Rohwerte z. B. `6106.158` / `4768.690`).
+  Codex' Sorge einer 0,1-kWh-Quantisierung entfällt damit - die Auflösung trägt den Trend.
+- Die Zähler sind als **Absolutpaar inkonsistent** (unterschiedliche Epochen, Residuum ~1300 kWh), ihre **Inkremente über Stunden** sind aber brauchbar (Befund 12.7.).
+- **Kein direkter Stromsensor (A).** Deshalb Energie statt Ah; Strom ließe sich nur als `Leistung / Packspannung` schätzen (nicht Teil dieses Designs).
+
+Empirisch verifiziert (2026-07-15, Live-Historie):
+
+- **Vorzeichen von `sensor.byd_leistung`: positiv = Entladen, negativ = Laden.**
+  Belegt: bei SoC 90 %, `zellmax` steigend, Balancing on war die Leistung −1030 W (= Laden); nachts konstant +700 W (= Hausentladung), tagsüber negativ (= PV-Ladung).
+  Das Lastband (§6.3) ist damit `sensor.byd_leistung` im Bereich **+500…+1500 W**.
+- **3,20-V-Trigger-Frequenz: sparsam.** Modul-2-min erreichte 3,20 V nur am tiefen Tag (SoC 21 %, min 3,178 V), an flachen Tagen ~3,24 V.
+  Der Latch feuert also nur an Tagen mit tiefer Entladung (~1 von 3 beim aktuellen Zyklen-Niveau). Valide, aber selten; bei zu wenigen Datenpunkten Referenz auf 3,24 V anheben (Regler vorhanden).
+
+## 4. Architektur-Überblick
+
+Alles rein beobachtend, keine Steuerwirkung. Erweitert `packages/byd_bmu.yaml`.
+
+Entitäten:
+
+- **Helfer**
+  - `input_number.byd_knie_referenzspannung` - vom Nutzer einstellbare Referenz (Default 3,20 V, 3,05-3,35, Schritt 0,005).
+  - `input_number.byd_knie_ref_frozen` - beim Scharfschalten eingefrorene Referenz des laufenden Zyklus (verhindert, dass eine Schieberei am Regler mitten im Zyklus selbst eine Kreuzung erzeugt).
+  - `input_select.byd_knie_zyklus_status` - `idle` / `armed` / `latched` / `invalid`.
+  - `input_text.byd_knie_invalid_grund` - Klartext-Grund bei `invalid`.
+  - `input_text.byd_knie_cycle_id` - ID des laufenden Zyklus (ISO-Zeit des Voll-Ankers).
+  - `input_datetime.byd_voll_anker_zeit` - Zeit des letzten Ladeabschluss-Ankers.
+  - `input_boolean.byd_knie_ueberschwelle_gesehen` - seit Anker mind. einmal ein gültiger Wert klar oberhalb der Schwelle gesehen (Neustart-Fehl-Latch-Schutz).
+- **Utility Meter** (persistent, Reset nur am Voll-Anker)
+  - `utility_meter` auf `sensor.byd_geladen_gesamt` -> `sensor.byd_geladen_seit_voll`.
+  - `utility_meter` auf `sensor.byd_entladen_gesamt` -> `sensor.byd_entladen_seit_voll`.
+- **Template-/Binary-Sensoren**
+  - `binary_sensor.byd_daten_frisch` - alle benötigten Quellen numerisch und ≤120 s alt.
+  - `binary_sensor.byd_entladeband` - entlädt UND Leistung im standardisierten Band (s. §6.3).
+  - `sensor.byd_netto_energie_seit_voll` - laufende Nettoenergie (§6.2).
+  - `sensor.byd_modul2_absackung` - Sensor A, roh (§5).
+  - `sensor.byd_modul2_netto_bis_knie` - Sensor B, am Latch festgehalten (§6.4).
+- **Automationen**
+  - `byd_voll_anker` - erkennt Ladeabschluss, setzt Zyklus auf (§6.1).
+  - `byd_ueberschwelle_gesehen` - Arm-Guard (§6.4).
+  - `byd_knie_latch` - Latch beim qualifizierten Knie-Ereignis (§6.4).
+  - `byd_zyklus_invalid` - markiert Zyklus bei Mess-Qualitätsproblemen ungültig (§7).
+
+## 5. Sensor A - Relative Zell-Absackung (Diagnose)
+
+Immer-an-Template-Sensor, Einheit mV.
+
+```
+state = (median(Modul-1/3/4/5-min) − Modul-2-min) × 1000
+```
+
+- **Median der vier Peers**, nicht `min`: ein einzelnes fehlerhaftes Vergleichsmodul würde `min` nach unten ziehen und die Absackung verschleiern.
+- Positiv = Modul 2 ist das schwächste Glied. Negativ = ein anderes Modul liegt tiefer (wird nicht auf 0 geklemmt, damit ein Wandern der Schwäche sichtbar bleibt).
+- **Availability-Gate**: nur rechnen, wenn alle fünf Modul-Minima numerisch und ≤120 s alt sind (`binary_sensor.byd_daten_frisch`). Kein `float(0)`-Fallback.
+- Attribute: `soc`, `leistung_w`, `modul2_volt`, `peer_median_volt`, `schwaechstes_modul`.
+
+Für den Wochen-Trend wird **nicht** das rohe Maximum von A genutzt (empfindlich gegen einen einzigen Last-/MQTT-Ausreißer), sondern der A-Wert **am qualifizierten B2-Latch** (§6.4) - dort sind Zellspannung, Lastklasse und Haltezeit automatisch gleich. Sensor A roh dient der laufenden Sichtprüfung und der Historie.
+
+## 6. Sensor B - Nettoenergie bis Knie (Wochen-Metrik)
+
+### 6.1 Voll-Anker (Ladeabschluss-Event)
+
+`SoC ≥ 99 %` allein ist untauglich (LFP-SoC driftet, springt verzögert, flattert).
+Anker ist ein **Ladeabschluss-Ereignis**, hysteretisch als Episode (genau ein Reset pro Ladeabschluss):
+
+Bedingungen (alle):
+
+- `sensor.byd_zellspannung_max` ≥ 3,55-3,60 V (Primärkriterium; exakten Wert an realen Logs kalibrieren, 3,65 V wäre bei 60-s-Abtastung evtl. zu kurz sichtbar).
+- In den Minuten davor wurde tatsächlich geladen.
+- Danach Ladeleistung < 300-500 W für 5-10 min (Ladeende).
+- Optional, wenn `binary_sensor.byd_balancing_aktiv` zuverlässig: Balancing war aktiv und ist beendet.
+- `sensor.byd_soc` ≥ 94-95 % nur als Plausibilität, nicht als Trigger.
+- `binary_sensor.byd_daten_frisch` = on und beide Zähler zeitlich kohärent.
+
+Aktion am Anker:
+
+- Beide Utility Meter zurücksetzen (`utility_meter.reset`).
+- `byd_knie_ref_frozen` := aktueller `byd_knie_referenzspannung`.
+- `byd_knie_ueberschwelle_gesehen` := **on** (am Anker ist Modul 2 verifiziert hoch; das flankengetriggerte Guard bliebe sonst aus - Review-Fix C1). Die separate Guard-Automation bleibt als redundanter Backup.
+- `byd_knie_cycle_id` := jetzt (ISO), `byd_voll_anker_zeit` := jetzt.
+- `byd_knie_zyklus_status` := `armed`.
+
+**Re-Arm-Sperre**: ein neuer Anker wird erst wieder zugelassen, nachdem der Speicher seit dem letzten Anker unter ~90-95 % gefallen ist ODER ≥ 0,5-1,0 kWh netto entnommen wurden. Verhindert mehrfaches Zurücksetzen im Ladeschluss-Flattern.
+Fällt der physische Ladeabschluss in einen MQTT-/HA-Ausfall, gilt der Zyklus als ungültig - kein nachträglich geschätzter Vollzeitpunkt (falsche Präzision).
+
+### 6.2 Laufende Nettoenergie
+
+`sensor.byd_netto_energie_seit_voll` (kWh):
+
+```
+state = entladen_seit_voll − geladen_seit_voll   (aus den beiden Utility Metern)
+```
+
+- Utility Meter statt Rohsubtraktion: persistent über HA-Neustarts, mit eigener Reset-Behandlung bei Quell-Reset/Rollover; `delta_values` aus (Quellen sind Absolutwerte). Falls die Loggerzähler real zurückgesetzt werden, `periodically_resetting` passend konfigurieren.
+- **Nicht `total_increasing`**: B1 darf bei PV-Zwischenladung real sinken. Nicht auf 0 klemmen.
+- **Availability**: nur gültig, wenn beide Utility Meter `has_value`. Kein `float(0)`.
+- Negative **Quell**-Inkremente werden vom Utility Meter als Reset behandelt, nicht in B1 als Energie eingerechnet.
+- **Plausibilitätswächter**: ein positives Netto-Inkrement größer als ~`15 kW × Δt seit letztem gültigen Wert` (plus Reserve) markiert den Zyklus `invalid` (§7), statt still "repariert" zu werden.
+- Ehrlich als **Nettoenergie-Näherung** deklariert (Lade-/Entladeverluste; ≠ gespeicherte Zellenergie).
+
+### 6.3 Standardisiertes Lastband (Kern gegen Lastabhängigkeit)
+
+Roh gelatcht würde der erste Hochlast-Dip irreversibel eingefroren (30-40 mV Lastabsenkung verschieben die 3,20-V-Kreuzung um mehrere SoC-Prozent bzw. Zehntel-kWh) - der Wochenvergleich wäre unbrauchbar.
+Ein reines Ruhefenster (<300 W) taugt am Knie ebenfalls nicht (tritt evtl. stundenlang nicht auf; die Zelle relaxiert danach wieder über die Schwelle).
+
+`binary_sensor.byd_entladeband` = on, wenn:
+
+- Vorzeichen eindeutig **Entladen** (`sensor.byd_leistung` > 0; verifiziert: positiv = Entladen), UND
+- Entladeleistung im Band **+500…+1500 W** (≈ 1-3 A ≈ 0,04-0,12 C bei ~512 V).
+
+Der Latch verlangt, dass dieses Band über das gesamte Bestätigungsfenster (§6.4) gehalten wurde (Leistung nicht um mehr als ~300-500 W springt).
+Falls das Band real zu selten vorkommt, auf 0,5-2,0 kW erweitern - dann aber Messungen verschiedener Lastklassen **nicht** ungekennzeichnet vergleichen (Lastklasse wird am Latch mitgespeichert).
+
+### 6.4 Latch (Knie-Ereignis)
+
+Arm-Guard `byd_ueberschwelle_gesehen`: sobald seit dem Anker ein gültiger `Modul-2-min` klar oberhalb der Schwelle (≥ `ref_frozen` + 0,03 V) gesehen wird, wird das Flag on gesetzt.
+Nach einem Ladeabschluss ist Modul 2 hoch, das Flag kippt sofort on; nach einem Neustart mitten in niedriger Spannung bleibt der zuvor gesetzte Zustand erhalten (`input_boolean` restored) - ein Fehl-Latch bei schon niedriger Spannung nach Neustart wird verhindert.
+
+`byd_knie_latch` - Trigger: `sensor.byd_modul_2_zellspannung_min` **unter** `input_number.byd_knie_ref_frozen` (numeric_state `below` referenziert die Helfer-Entität) mit `for: 00:03:00` (120-180 s; bei 60-s-Telemetrie ~2-3 gültige Samples).
+
+Bedingungen (alle, und über die Haltezeit gültig):
+
+- `byd_knie_zyklus_status` = `armed` und `byd_ueberschwelle_gesehen` = on.
+- `binary_sensor.byd_entladeband` = on `for: 00:03:00` (Lastband über das Fenster gehalten).
+- `binary_sensor.byd_daten_frisch` = on (alle fünf Modul-Spannungen + SoC + Leistung + beide Zähler frisch/kohärent).
+- `sensor.byd_netto_energie_seit_voll` gültig.
+
+Hysterese ±5 mV: Eintritt effektiv ~3,195 V, Rückkehr erst > 3,205 V (verhindert Prellen an der Schwelle). Kein gleitender Mittelwert als Default (verschiebt die Kreuzung/unterdrückt echten Knieabfall); ein Drei-Sample-Median nur, falls reale Einzelsample-Ausreißer auftreten.
+
+Aktion (Latch schreiben, Automation-Modus `single`):
+
+- `sensor.byd_modul2_netto_bis_knie` := aktueller `netto_energie_seit_voll` (trigger-basierter Template-Sensor, RestoreEntity).
+- `byd_knie_zyklus_status` := `latched`; Arm-Flag erst **nach** erfolgreichem Schreiben aus.
+
+`for:` überlebt keinen HA-Neustart/Reload (laufender Countdown verworfen) - bei Neustart nahe am Knie gilt der Zyklus als "nicht sicher gemessen" (`invalid`), was für eine Wochenmetrik vertretbar ist.
+
+### 6.5 Was am Latch gespeichert wird (Attribute)
+
+Damit spätere Auswertung Zwischenladungen und Lastklassen beurteilen kann - nicht nur Netto:
+
+- `netto_kwh`, `geladen_inkrement_kwh`, `entladen_inkrement_kwh` (getrennt).
+- `a_absackung_mv` (Sensor A relativ zum Peer-**Median** zum Latch-Zeitpunkt).
+- `soc`, `last_mittel_w`, `last_min_w`, `last_max_w` über das Bestätigungsfenster.
+- `modul2_volt`, `modul_temp_c` (und Zelltemp, falls verfügbar), `ref_verwendet_v`.
+- `cycle_id`, `gemessen` (Zeit).
+- `sauberer_zyklus` (bool): `geladen_inkrement_kwh` < 0,2-0,5 kWh -> reine Top-nach-Knie-Entladung; sonst getrennt betrachten (pfadabhängig durch Ladeverluste/Hysterese).
+
+## 7. Zyklus-Zustandsautomat und Gültigkeit
+
+`byd_knie_zyklus_status`: `idle` -> (Anker) `armed` -> (Latch) `latched`; jederzeit -> `invalid`.
+
+`byd_zyklus_invalid` setzt `invalid` + `byd_knie_invalid_grund` bei:
+
+- Zähler-Reset/Rollover oder unplausiblem positiven Sprung (§6.2).
+- Datenlücke (`byd_daten_frisch` = off) nahe der Kreuzung.
+- Fehlende zeitliche Kohärenz der beiden Zähler beim Ankern/Latchen.
+- HA-Neustart während eines Knie-Kandidaten (armed und Modul-2-min nahe/unter Schwelle).
+
+Bei `invalid` wird **nicht** gelatcht und **nicht** entwaffnet; der Zyklus wird für die Trendauswertung verworfen. Kollision Anker/Latch durch einen einzigen Zustandsablauf und `single`-Modus vermeiden.
+
+## 8. Auswertung und Trend
+
+- Wochen-Trend = Verlauf von `sensor.byd_modul2_netto_bis_knie` über die `latched`-Ereignisse, gefiltert auf `sauberer_zyklus = true` und vergleichbare Lastklasse/Temperatur (±3 K).
+- Ergänzend der am Latch festgehaltene `a_absackung_mv`.
+- **Degradations-Signal** (Codex): systematisch sinkende Nettoenergie bis Knie über Wochen, aussagekräftiger als roher mV-Abstand.
+- Ticket-würdig (späterer Alarm-PR): deutliche Verschiebung des Knies innerhalb weniger Wochen, nutzbare Energie reproduzierbar > 5 % gesunken, echte Ruhedivergenz > 80-100 mV, oder EC107/EC110/BMS-Leistungsbegrenzung.
+
+Dashboard: `byd_modul2_netto_bis_knie` und `byd_modul2_absackung` (roh) als ApexCharts-Verlauf in die bestehende Sektion "Akku-Gesundheit (BMU)".
+
+## 9. Stellschrauben
+
+- `input_number.byd_knie_referenzspannung` (Default 3,20 V) - live einstellbar; greift erst am **nächsten** Anker (Einfrieren pro Zyklus).
+- Lastband, Voll-Anker-Zellspannung und Re-Arm-Schwelle sind zunächst als Konstanten im Package dokumentiert; werden nach den ersten realen Zyklen kalibriert.
+
+## 10. Fehlerfälle (Zusammenfassung)
+
+| Fall | Behandlung |
+|---|---|
+| Quelle `unavailable` (expire_after 300 s) | `daten_frisch` = off -> kein Anker/Latch; kein `float(0)` |
+| Zähler-Reset/Rollover | Utility Meter fängt es; negatives Quell-Inkrement nicht als Energie |
+| Unplausibler positiver Zählersprung | Zyklus `invalid` (Grund protokolliert) |
+| Zähler-Versatz 60 s | Latch nur bei kohärenten, frischen Zählern |
+| Prellen an 3,20 V | Hysterese ±5 mV + `for: 3 min` |
+| Fehl-Latch nach Neustart bei niedriger Spannung | `ueberschwelle_gesehen`-Guard |
+| Hochlast-Dip | Lastband-Gate 0,5-1,5 kW über das Fenster |
+| SoC-Drift/Flattern | Ladeabschluss-Anker statt SoC≥99 %, Re-Arm-Sperre |
+| `for:` verworfen bei Neustart | Zyklus `invalid` |
+| Defektes Vergleichsmodul | Peer-**Median** statt `min` |
+
+## 11. Deployment
+
+- Alle Entitäten in `packages/byd_bmu.yaml` ergänzen (erweitert PR #39-Feature).
+- Helfer: entweder als YAML im Package oder via UI/`ha_config_set_helper` live anlegen - Weg im Implementierungsplan festlegen (Konsistenz Repo <-> live beachten, bekannte Live-Divergenz).
+- Live in-place deployen (Package-Edit + Reload), analog bisheriger BYD-Arbeit; danach Live-Regressionscheck.
+- MQTT-Rohsensoren bleiben in `mqtt/mqtt.yaml` (Kollisions-Falle top-level `mqtt: !include` beachten).
+- Privacy-Scan vor Push (öffentliches Repo).
+
+## 12. Test und Verifikation
+
+Vor Implementierung:
+
+- **Leistungs-Vorzeichen** an `sensor.byd_leistung`-Historie bestätigen (Laden vs. Entladen).
+- Prüfen, wie oft Modul-2-min real unter 3,20 V geht (Trigger-Frequenz); Referenz ggf. anpassen.
+- Utility-Meter-Reset-Verhalten der Loggerzähler klären (`periodically_resetting`).
+
+Nach Implementierung:
+
+- Anker künstlich testbar? (nicht produktiv erzwingen; an nächster realer Vollladung verifizieren.)
+- Latch an einem realen tiefen Entladezyklus beobachten; Attribute auf Plausibilität prüfen.
+- Neustart-Verhalten: Zustände (`input_*`, Utility Meter, trigger-Sensor) überleben Reload; Zyklus nahe Knie wird `invalid`.
+- Livetest-Protokoll unter `docs/` ablegen (Repo-Konvention).
+
+## 13. Offene Punkte
+
+- Exakte Voll-Anker-Zellspannung (3,55 vs. 3,60 V) - an Logs kalibrieren.
+- Lastband final (0,5-1,5 vs. 0,5-2,0 kW) - nach Häufigkeit realer Latches.
+- Alarm-Schwelle bewusst offen bis 4-8 gültige Zyklen vorliegen (eigener Folge-PR).

--- a/docs/byd-modul2-fruehwarnung.md
+++ b/docs/byd-modul2-fruehwarnung.md
@@ -45,8 +45,8 @@ Ein Modul-Ausbau (Turm läuft offiziell auch mit 4 Modulen) ist erst sinnvoll, w
 
 ## Design-Historie
 
-Das ursprüngliche, Codex-adversarial gehärtete Design samt Umsetzungsplan liegt unter [docs/superpowers/specs/2026-07-15-byd-modul2-fruehwarnung-design.md](superpowers/specs/2026-07-15-byd-modul2-fruehwarnung-design.md) und [docs/superpowers/plans/2026-07-15-byd-modul2-fruehwarnung.md](superpowers/plans/2026-07-15-byd-modul2-fruehwarnung.md).
-Abweichung zum dortigen Stand: das Package liegt separat (nicht in `byd_bmu.yaml` gebündelt, Live-Parität) und die Helfer tragen kein `initial:` mehr (Neustart-Reset-Bug, Codex-Review 16.7.).
+Das ursprüngliche, Codex-adversarial gehärtete Design liegt unter [byd-modul2-fruehwarnung-design.md](byd-modul2-fruehwarnung-design.md).
+Abweichungen zum dortigen Stand: das Package liegt separat (nicht in `byd_bmu.yaml` gebündelt, Live-Parität) und die Helfer tragen kein `initial:` mehr (Neustart-Reset-Bug, Codex-Review 16.7.).
 
 ## Status und offene Punkte
 

--- a/docs/byd-modul2-fruehwarnung.md
+++ b/docs/byd-modul2-fruehwarnung.md
@@ -2,6 +2,7 @@
 
 Dieses optionale Package ([`packages/byd_modul2_fruehwarnung.yaml`](../packages/byd_modul2_fruehwarnung.yaml)) beobachtet das schwächste Modul eines BYD-HVS-Turms auf schleichende Degradation.
 Es baut auf dem BMU-Monitoring ([`packages/byd_bmu.yaml`](../packages/byd_bmu.yaml), Doku: [byd-bmu-monitoring.md](byd-bmu-monitoring.md)) auf und ist rein beobachtend, ohne jede Steuerwirkung.
+Nach der Erstinstallation einmalig `input_number.byd_knie_referenzspannung` auf 3,20 V stellen; die Helfer tragen bewusst kein `initial:`, weil HA das bei jedem Neustart anwenden und Referenz wie Zyklus-Status überschreiben würde.
 
 ## Ausgangslage
 

--- a/docs/byd-modul2-fruehwarnung.md
+++ b/docs/byd-modul2-fruehwarnung.md
@@ -1,0 +1,49 @@
+# BYD Modul-2-Frühwarnung: Degradations-Monitoring für das schwächste Modul
+
+Dieses optionale Package ([`packages/byd_modul2_fruehwarnung.yaml`](../packages/byd_modul2_fruehwarnung.yaml)) beobachtet das schwächste Modul eines BYD-HVS-Turms auf schleichende Degradation.
+Es baut auf dem BMU-Monitoring ([`packages/byd_bmu.yaml`](../packages/byd_bmu.yaml), Doku: [byd-bmu-monitoring.md](byd-bmu-monitoring.md)) auf und ist rein beobachtend, ohne jede Steuerwirkung.
+
+## Ausgangslage
+
+In jedem Serien-Turm stellt genau eine Zelle das Minimum, das ist noch kein Befund.
+Interessant sind Größe und Trend der Abweichung: eine stabil leicht schwächere Zelle ist normale Fertigungsstreuung, eine über Monate wachsende Abweichung ist ein alterndes Modul und ein Fall für die Garantie.
+In diesem Setup ist Modul 2 (Zelle 23) das schwächste Glied, deshalb sind die Templates und Trigger auf Modul 2 verdrahtet.
+Für andere Türme die Modul-Nummer in den Templates und Automationen anpassen.
+
+## Metrik A: relative Zell-Absackung (laufend)
+
+`sensor.byd_modul_2_absackung` misst in mV, wie weit die schwächste Zelle von Modul 2 unter dem Peer-Median der vier Nachbarmodule liegt.
+Der Median (Mittel der beiden mittleren von vier Peer-Werten) ist robust gegen einen einzelnen abweichenden Nachbarn.
+Der Wert ist zustandsabhängig und muss im gleichen Betriebspunkt verglichen werden: im LFP-Plateau in Ruhe liegt er nahe 0 mV, unter Entladelast (Innenwiderstands-Anteil) und am unteren Kennlinien-Knie (Kapazitäts-Anteil) steigt er.
+Attribute liefern Kontext für jede Messung: SoC, Leistung, absolute Modul-2-Spannung, schwächste Zell-ID und welches Modul aktuell das Minimum stellt.
+
+## Metrik B: Nettoenergie bis zum Knie (pro Vollzyklus)
+
+`sensor.byd_modul_2_netto_bis_knie` beantwortet die eigentliche Kapazitätsfrage in kWh statt in mV:
+wie viel Nettoenergie (entladen minus geladen) lässt sich nach einer Vollladung entnehmen, bis die schwächste Zelle ihr unteres Knie erreicht?
+Sinkt dieser Wert über Monate, verliert das Modul messbar Kapazität.
+
+Der Messzyklus läuft als Zustandsmaschine (`input_select.byd_knie_zyklus_status`):
+
+1. **idle → armed (Voll-Anker):** Nach Ladeschluss (Zellmax war >= 3,55 V für 2 min, dann 5 min keine nennenswerte Ladung, SoC > 94 %, Daten frisch) werden die Utility-Meter (`byd_geladen_seit_voll`/`byd_entladen_seit_voll`) genullt, die Knie-Referenzspannung eingefroren (`byd_knie_ref_frozen`, Default 3,20 V) und der Zyklus scharf geschaltet.
+   Eine Re-Arm-Sperre (mindestens 0,5 kWh netto entnommen seit dem letzten Anker) verhindert Mehrfach-Resets im Ladeschluss-Flattern.
+2. **armed → latched (Knie-Latch):** Wenn Modul-2-min die eingefrorene Referenz erstmals 3 min lang unterschreitet, im standardisierten Entladeband (500 bis 1500 W über die Haltezeit), bei frischen Daten und nachdem die Spannung seit dem Anker klar über der Schwelle war (Überschwelle-Guard, ref + 30 mV).
+   Der Latch-Sensor snapshottet in diesem Moment Nettoenergie und Begleitwerte (Absackung, SoC, Temperatur, Zell-IDs, Cycle-ID) als Attribute.
+   Das Entladeband standardisiert den Betriebspunkt, damit die kWh-Werte über Zyklen vergleichbar sind; die 3-min-Haltezeit ersetzt eine explizite mV-Hysterese.
+3. **armed → invalid:** Bei Messqualitäts-Problemen wird der Zyklus verworfen statt falsch gemessen: Datenlücke oder HA-Neustart nahe am Knie (Modul-2-min <= ref + 10 mV) oder ein unplausibler Nettoenergie-Sprung (> 3 kWh zwischen zwei Updates, außerhalb der Anker-Sekunden).
+   Der Grund landet in `input_text.byd_knie_invalid_grund`.
+
+Das Attribut `sauberer_zyklus` markiert Zyklen ohne nennenswerte Zwischenladung (< 0,5 kWh geladen seit Voll); nur diese sind untereinander streng vergleichbar.
+
+## Interpretation
+
+Ein einzelner Latch-Wert sagt wenig, die Zeitreihe über Wochen und Monate ist die Aussage.
+Stabiler Offset bei Metrik A plus stabile kWh bei Metrik B bedeutet Fertigungsstreuung, kein Handlungsbedarf.
+Wachsende Absackung im gleichen Betriebspunkt oder sinkende Nettoenergie-bis-Knie über Monate bedeutet beschleunigte Alterung, dann die Messreihe sichern und den Garantiefall mit Daten belegen (BYD Battery-Box Premium: 10 Jahre mit Kapazitätszusage).
+Ein Modul-Ausbau (Turm läuft offiziell auch mit 4 Modulen) ist erst sinnvoll, wenn das Modul effektiv mehr als seine eigene Kapazität kostet oder aktiv stört, und damit klar hinter Beobachten und Garantiefall die dritte Option.
+
+## Status und offene Punkte
+
+- Live seit 15.07.2026, die Absackungs-Metrik liefert seitdem Daten.
+- Der komplette Latch-Pfad (Voll-Anker bis Knie-Latch) ist noch nicht end-to-end durchlaufen; er braucht eine Vollladung mit anschließender Entladung bis unter die Referenzspannung im Entladeband.
+- Erst nach den ersten sauberen Zyklen lohnt eine Bewertung der Referenzspannung (3,20 V) und des Entladebands.

--- a/docs/byd-modul2-fruehwarnung.md
+++ b/docs/byd-modul2-fruehwarnung.md
@@ -43,6 +43,11 @@ Stabiler Offset bei Metrik A plus stabile kWh bei Metrik B bedeutet Fertigungsst
 Wachsende Absackung im gleichen Betriebspunkt oder sinkende Nettoenergie-bis-Knie über Monate bedeutet beschleunigte Alterung, dann die Messreihe sichern und den Garantiefall mit Daten belegen (BYD Battery-Box Premium: 10 Jahre mit Kapazitätszusage).
 Ein Modul-Ausbau (Turm läuft offiziell auch mit 4 Modulen) ist erst sinnvoll, wenn das Modul effektiv mehr als seine eigene Kapazität kostet oder aktiv stört, und damit klar hinter Beobachten und Garantiefall die dritte Option.
 
+## Design-Historie
+
+Das ursprüngliche, Codex-adversarial gehärtete Design samt Umsetzungsplan liegt unter [docs/superpowers/specs/2026-07-15-byd-modul2-fruehwarnung-design.md](superpowers/specs/2026-07-15-byd-modul2-fruehwarnung-design.md) und [docs/superpowers/plans/2026-07-15-byd-modul2-fruehwarnung.md](superpowers/plans/2026-07-15-byd-modul2-fruehwarnung.md).
+Abweichung zum dortigen Stand: das Package liegt separat (nicht in `byd_bmu.yaml` gebündelt, Live-Parität) und die Helfer tragen kein `initial:` mehr (Neustart-Reset-Bug, Codex-Review 16.7.).
+
 ## Status und offene Punkte
 
 - Live seit 15.07.2026, die Absackungs-Metrik liefert seitdem Daten.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,6 +78,7 @@ kopieren und alle `DEIN_*`-Platzhalter durch echte Entitäts-IDs ersetzen.
 | `sma_statistik.yaml` | gleitende Mittelwerte (Verbrauch, Batterielast) |
 | `opti_ki_analyse.yaml` | **optional** - täglicher KI-Tagesreport per `ai_task.generate_data`, rein lesend; Details siehe [docs/canonical-layer.md](canonical-layer.md#ki-analyse-schicht-optional-phase-1) |
 | `byd_bmu.yaml` | **optional** - BYD-Zell-Monitoring (Spreizung, Temperaturen, Balancing) via bydlogc→MQTT; braucht das BYD-Logger-Tool in Docker/VM, einen MQTT-Broker und ggf. eine Route/SNAT-Regel zur Box → **[docs/byd-bmu-monitoring.md](byd-bmu-monitoring.md)** |
+| `byd_modul2_fruehwarnung.yaml` | **optional** - Degradations-Frühwarnung fürs schwächste BYD-Modul (Absackung + Nettoenergie-bis-Knie), setzt `byd_bmu.yaml` voraus → **[docs/byd-modul2-fruehwarnung.md](byd-modul2-fruehwarnung.md)** |
 | `opti_ev_sperre.yaml` | **optional** - EV-Schnelllade-Entladesperre (evcc im Modus now/minpv); braucht HACS `evcc_intg` + Ladepunkt-Block im Mapping → [docs/strategie-logik.md](strategie-logik.md) (Option 13) |
 
 **4. Home Assistant neu starten** → Helfer, Templates, Statistik & Modbus sind da.

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -415,12 +415,18 @@ template:
         unit_of_measurement: "K"
         state_class: measurement
         icon: mdi:thermometer-alert
-        # Availability prueft min UND max (stichprobenartig Modul 1/5 - die
-        # Topics fallen praktisch nur gemeinsam aus); Negativ-Klemme wie bei
-        # der Zellspreizung gegen Artefakte bei Teil-Ausfaellen.
+        # Availability prueft ALLE 10 Temp-Sensoren: ein einzelnes unavailable
+        # Modul wuerde sonst mit float-Default eingehen und die Spreizung
+        # verfaelschen. Negativ-Klemme wie bei der Zellspreizung.
         availability: >
-          {{ has_value('sensor.byd_modul_1_temp_max') and has_value('sensor.byd_modul_5_temp_max')
-             and has_value('sensor.byd_modul_1_temp_min') and has_value('sensor.byd_modul_5_temp_min') }}
+          {% set ns = namespace(ok=true) %}
+          {% for i in [1, 2, 3, 4, 5] %}
+            {% if not has_value('sensor.byd_modul_' ~ i ~ '_temp_max')
+               or not has_value('sensor.byd_modul_' ~ i ~ '_temp_min') %}
+              {% set ns.ok = false %}
+            {% endif %}
+          {% endfor %}
+          {{ ns.ok }}
         state: >
           {% set tmax = [states('sensor.byd_modul_1_temp_max')|float(0), states('sensor.byd_modul_2_temp_max')|float(0),
                          states('sensor.byd_modul_3_temp_max')|float(0), states('sensor.byd_modul_4_temp_max')|float(0),

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -364,10 +364,11 @@ template:
   # ---------------------------------------------------------------------------
   # Ruhe-Spreizung: aktualisiert NUR, wenn der Akku (nahezu) lastfrei ist
   # (|Leistung| < 300 W) UND der SoC im flachen Teil der LFP-Kennlinie liegt
-  # (15-85 %). Unter Last steigt die Spreizung durch Innenwiderstands-
+  # (25-85 %). Unter Last steigt die Spreizung durch Innenwiderstands-
   # Unterschiede, am oberen/unteren Kennlinien-Knie (Ladeschluss/Tiefentladung)
   # laeuft sie kennlinienbedingt hoch (beobachtet 11.7.: 292 mV bei SoC 99 %,
-  # 1-4 mV bei Mittel-SoC) - beides ist nicht vergleichbar. Erst dieser
+  # 1-4 mV bei Mittel-SoC; 16.7.: 34-38 mV bei SoC ~17 % am unteren Knie -
+  # deshalb unteres Gate von 15 auf 25 % angehoben) - beides ist nicht vergleichbar. Erst dieser
   # gefilterte Sensor macht Wochen-Trends und den spaeteren Bedarfs-Balancing-
   # Trigger moeglich. Haelt zwischen Ruhephasen den letzten Wert (RestoreEntity).
   # ---------------------------------------------------------------------------
@@ -381,7 +382,7 @@ template:
         below: 300
       - condition: numeric_state
         entity_id: sensor.byd_soc
-        above: 15
+        above: 25
         below: 85
       - condition: template
         value_template: "{{ has_value('sensor.byd_zellspreizung') }}"

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -313,6 +313,71 @@ mqtt:
       state_class: measurement
       expire_after: 300
 
+    # ---- Schwaechste/staerkste Zell-Nummer je Modul (MinVoltID/MaxVoltID) ----
+    # Von der Modul-2-Fruehwarnung (packages/byd_modul2_fruehwarnung.yaml) als
+    # Attribut referenziert; auch solo nuetzlich, um zu sehen, ob immer DIESELBE
+    # Zelle das Modul-Minimum stellt (Zell-Problem) oder es wandert (Streuung).
+    - name: "BYD Modul 1 Min-Zell-ID"
+      unique_id: byd_bmu_m1_min_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_1/MinVoltID"
+      icon: mdi:battery-arrow-down
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 1 Max-Zell-ID"
+      unique_id: byd_bmu_m1_max_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_1/MaxVoltID"
+      icon: mdi:battery-arrow-up
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 2 Min-Zell-ID"
+      unique_id: byd_bmu_m2_min_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_2/MinVoltID"
+      icon: mdi:battery-arrow-down
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 2 Max-Zell-ID"
+      unique_id: byd_bmu_m2_max_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_2/MaxVoltID"
+      icon: mdi:battery-arrow-up
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 3 Min-Zell-ID"
+      unique_id: byd_bmu_m3_min_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_3/MinVoltID"
+      icon: mdi:battery-arrow-down
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 3 Max-Zell-ID"
+      unique_id: byd_bmu_m3_max_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_3/MaxVoltID"
+      icon: mdi:battery-arrow-up
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 4 Min-Zell-ID"
+      unique_id: byd_bmu_m4_min_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_4/MinVoltID"
+      icon: mdi:battery-arrow-down
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 4 Max-Zell-ID"
+      unique_id: byd_bmu_m4_max_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_4/MaxVoltID"
+      icon: mdi:battery-arrow-up
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 5 Min-Zell-ID"
+      unique_id: byd_bmu_m5_min_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_5/MinVoltID"
+      icon: mdi:battery-arrow-down
+      entity_category: diagnostic
+      expire_after: 300
+    - name: "BYD Modul 5 Max-Zell-ID"
+      unique_id: byd_bmu_m5_max_volt_id
+      state_topic: "Battery/BYD/BMS_1/Module_5/MaxVoltID"
+      icon: mdi:battery-arrow-up
+      entity_category: diagnostic
+      expire_after: 300
+
   binary_sensor:
     - name: "BYD Balancing aktiv"
       unique_id: byd_bmu_balancing
@@ -331,8 +396,8 @@ template:
       # Min/Max kommen als getrennte MQTT-Topics ~60 s versetzt an - kurz nach
       # einem Update kann max-min deshalb verzerrt oder sogar negativ sein
       # (Artefakt, kein Zellzustand). Negative Werte werden auf 0 geklemmt;
-      # gegen die positiven Transienten schuetzen die Ruhe-/SoC-Gates des
-      # Ruhe-Sensors und die for:-Haltezeiten der Alarme.
+      # gegen die positiven Transienten schuetzen der Median des Ruhe-Sensors
+      # und die for:-Haltezeiten der Alarme.
       - unique_id: byd_bmu_zellspreizung_mv
         name: "BYD Zellspreizung"
         unit_of_measurement: "mV"
@@ -350,8 +415,12 @@ template:
         unit_of_measurement: "K"
         state_class: measurement
         icon: mdi:thermometer-alert
+        # Availability prueft min UND max (stichprobenartig Modul 1/5 - die
+        # Topics fallen praktisch nur gemeinsam aus); Negativ-Klemme wie bei
+        # der Zellspreizung gegen Artefakte bei Teil-Ausfaellen.
         availability: >
-          {{ has_value('sensor.byd_modul_1_temp_max') and has_value('sensor.byd_modul_5_temp_max') }}
+          {{ has_value('sensor.byd_modul_1_temp_max') and has_value('sensor.byd_modul_5_temp_max')
+             and has_value('sensor.byd_modul_1_temp_min') and has_value('sensor.byd_modul_5_temp_min') }}
         state: >
           {% set tmax = [states('sensor.byd_modul_1_temp_max')|float(0), states('sensor.byd_modul_2_temp_max')|float(0),
                          states('sensor.byd_modul_3_temp_max')|float(0), states('sensor.byd_modul_4_temp_max')|float(0),
@@ -359,7 +428,7 @@ template:
           {% set tmin = [states('sensor.byd_modul_1_temp_min')|float(99), states('sensor.byd_modul_2_temp_min')|float(99),
                          states('sensor.byd_modul_3_temp_min')|float(99), states('sensor.byd_modul_4_temp_min')|float(99),
                          states('sensor.byd_modul_5_temp_min')|float(99)] | min %}
-          {{ (tmax - tmin) | round(0) }}
+          {{ [0, (tmax - tmin) | round(0)] | max }}
 
   # ---------------------------------------------------------------------------
   # Ruhe-Spreizung: aktualisiert NUR, wenn der Akku (nahezu) lastfrei ist
@@ -371,6 +440,12 @@ template:
   # deshalb unteres Gate von 15 auf 25 % angehoben) - beides ist nicht vergleichbar. Erst dieser
   # gefilterte Sensor macht Wochen-Trends und den spaeteren Bedarfs-Balancing-
   # Trigger moeglich. Haelt zwischen Ruhephasen den letzten Wert (RestoreEntity).
+  #
+  # Median statt Rohwert (16.7.): Min/Max-Topics kommen ~60 s versetzt an - ein
+  # einzelner verzerrter Spreizungswert im Ruhefenster wuerde sonst gelatcht und
+  # koennte, wenn der Akku das Fenster direkt danach verlaesst, die 1-h-for-Zeit
+  # des Alarms per Stagnation erfuellen. Der Median der letzten 5 Gate-Messungen
+  # (Artefakte betreffen max. 1-2 aufeinanderfolgende Samples) kappt das.
   # ---------------------------------------------------------------------------
   - triggers:
       - trigger: state
@@ -392,8 +467,13 @@ template:
         unit_of_measurement: "mV"
         state_class: measurement
         icon: mdi:arrow-collapse-vertical
-        state: "{{ states('sensor.byd_zellspreizung') }}"
+        state: >
+          {% set reihe = (this.attributes.get('messreihe') or [])[-4:] + [states('sensor.byd_zellspreizung')|float(0)] %}
+          {{ reihe | median | round(0) }}
         attributes:
+          # Rollierende Messreihe der letzten 5 Gate-Messungen (Median-Basis).
+          messreihe: >
+            {{ (this.attributes.get('messreihe') or [])[-4:] + [states('sensor.byd_zellspreizung')|float(0)] }}
           soc: "{{ states('sensor.byd_soc') }}"
           leistung_w: "{{ states('sensor.byd_leistung') }}"
           gemessen: "{{ now().isoformat() }}"
@@ -519,7 +599,7 @@ automation:
               'temp_hoch': 'Zelltemperatur hoch: ' ~ trigger.to_state.state ~ ' C (>45 C, ' ~ trigger.to_state.name ~ ').',
               'temp_kritisch': 'Zelltemperatur KRITISCH: ' ~ trigger.to_state.state ~ ' C (>50 C, ' ~ trigger.to_state.name ~ ') - sofort pruefen!',
               'temp_delta': 'Temperatur-Spreizung zwischen Modulen: ' ~ states('sensor.byd_temperatur_spreizung') ~ ' K (>10 K seit 15 min) - ein Modul weicht ab.',
-              'ruhe_spreizung': 'Zellspreizung in Ruhe dauerhaft hoch: ' ~ states('sensor.byd_zellspreizung_ruhe') ~ ' mV (>50 mV seit 1 h, gemessen im flachen Kennlinienbereich) - Balancing-Bedarf pruefen.',
+              'ruhe_spreizung': 'Zellspreizung in Ruhe dauerhaft hoch: ' ~ states('sensor.byd_zellspreizung_ruhe') ~ ' mV (>50 mV seit 1 h, Median der letzten 5 Ruhe-Messungen im flachen Kennlinienbereich) - Balancing-Bedarf pruefen.',
               'stale': 'Keine BYD-BMU-Daten seit >15 min - bydlogc-Container/MQTT-Strecke pruefen.'
             } %}{{ t.get(trigger.id, 'BYD-Alarm: ' ~ trigger.id) }}
       - alias: "Push"

--- a/packages/byd_bmu.yaml
+++ b/packages/byd_bmu.yaml
@@ -559,7 +559,7 @@ automation:
               Datenquelle: bydlogc via MQTT (Abtastung ~60 s). BMS-Schutzgrenzen
               2,75/3,65 V - die Alarme liegen bewusst davor. Zellspannungs-Alarme
               sind SoC-gegated (<90 %), am Ladeschluss zaehlt nur die BMS-Grenze.
-              Zellspreizung ist nur in Ruhe und bei SoC 15-85 % vergleichbar.
+              Zellspreizung ist nur in Ruhe und bei SoC 25-85 % vergleichbar.
             daten: >-
               Ausgeloest durch Regel: {{ trigger.id }}
               {{ alarm_text }}

--- a/packages/byd_modul2_fruehwarnung.yaml
+++ b/packages/byd_modul2_fruehwarnung.yaml
@@ -23,13 +23,17 @@
 #   byd_geladen_gesamt / byd_entladen_gesamt
 # =============================================================================
 
+# KEIN initial: auf den Helfern - HA wendet initial bei JEDEM Neustart an
+# (nicht nur beim ersten Setup) und wuerde Referenzspannung und Zyklus-Status
+# ueberschreiben; ohne initial restored HA den letzten Wert. Erstinstallation:
+# byd_knie_referenzspannung einmalig auf 3,20 V stellen (ohne gespeicherten
+# Wert startet der Helfer am unteren Skalenende).
 input_number:
   byd_knie_referenzspannung:
     name: "BYD Knie-Referenzspannung"
     min: 3.05
     max: 3.35
     step: 0.005
-    initial: 3.20          # nur beim allerersten Start; danach restore
     unit_of_measurement: "V"
     mode: box
     icon: mdi:sine-wave
@@ -38,7 +42,6 @@ input_number:
     min: 3.05
     max: 3.35
     step: 0.001
-    initial: 3.20
     unit_of_measurement: "V"
     mode: box
     icon: mdi:snowflake
@@ -57,8 +60,8 @@ input_boolean:
 input_select:
   byd_knie_zyklus_status:
     name: "BYD Knie Zyklus-Status"
+    # Erste Option = Startwert bei Erstinstallation; danach restore.
     options: ["idle", "armed", "latched", "invalid"]
-    initial: idle
     icon: mdi:state-machine
 
 input_text:

--- a/packages/byd_modul2_fruehwarnung.yaml
+++ b/packages/byd_modul2_fruehwarnung.yaml
@@ -1,0 +1,361 @@
+# =============================================================================
+# BYD Modul-2 Fruehwarnung (OPTIONAL, setzt packages/byd_bmu.yaml voraus)
+# -----------------------------------------------------------------------------
+# Beobachtet das schwaechste Modul des Turms (hier: Modul 2 mit Zelle 23) auf
+# schleichende Degradation - rein beobachtend, KEINE Steuerwirkung.
+# Fuer andere Tuerme die Modul-Nummer in den Templates/Triggern anpassen.
+#
+# Zwei Metriken (Doku/Design: docs/byd-modul2-fruehwarnung.md):
+#   A) sensor.byd_modul_2_absackung - relative Zell-Absackung in mV gegenueber
+#      dem Peer-Median der 4 Nachbarmodule (laufend).
+#   B) sensor.byd_modul_2_netto_bis_knie - Nettoenergie in kWh von der letzten
+#      Vollladung bis zum LFP-Knie der schwaechsten Zelle (pro Vollzyklus ein
+#      Messwert; DIE Trend-Metrik fuer Kapazitaets-Degradation).
+#
+# Zustandsmaschine (input_select.byd_knie_zyklus_status):
+#   idle -> armed (Voll-Anker nach Ladeschluss) -> latched (Knie erreicht,
+#   Snapshot) bzw. invalid (Messqualitaet unzureichend).
+#
+# Referenzierte Roh-Entitaeten (alle aus packages/byd_bmu.yaml):
+#   sensor.byd_soc / byd_leistung / byd_zellspannung_max /
+#   byd_modul_1..5_zellspannung_min / byd_modul_2_min_zell_id /
+#   byd_modul_2_max_zell_id / byd_modul_2_temp_max /
+#   byd_geladen_gesamt / byd_entladen_gesamt
+# =============================================================================
+
+input_number:
+  byd_knie_referenzspannung:
+    name: "BYD Knie-Referenzspannung"
+    min: 3.05
+    max: 3.35
+    step: 0.005
+    initial: 3.20          # nur beim allerersten Start; danach restore
+    unit_of_measurement: "V"
+    mode: box
+    icon: mdi:sine-wave
+  byd_knie_ref_frozen:
+    name: "BYD Knie-Referenz (eingefroren)"
+    min: 3.05
+    max: 3.35
+    step: 0.001
+    initial: 3.20
+    unit_of_measurement: "V"
+    mode: box
+    icon: mdi:snowflake
+
+input_boolean:
+  byd_knie_armed:
+    name: "BYD Knie scharf"
+    icon: mdi:target
+  byd_knie_ueberschwelle_gesehen:
+    name: "BYD Knie Ueberschwelle gesehen"
+    icon: mdi:arrow-up-bold
+  byd_top_erreicht:
+    name: "BYD Ladeschluss erreicht"
+    icon: mdi:arrow-collapse-up
+
+input_select:
+  byd_knie_zyklus_status:
+    name: "BYD Knie Zyklus-Status"
+    options: ["idle", "armed", "latched", "invalid"]
+    initial: idle
+    icon: mdi:state-machine
+
+input_text:
+  byd_knie_cycle_id:
+    name: "BYD Knie Cycle-ID"
+    max: 40
+  byd_knie_invalid_grund:
+    name: "BYD Knie Invalid-Grund"
+    max: 120
+
+input_datetime:
+  byd_voll_anker_zeit:
+    name: "BYD Voll-Anker Zeit"
+    has_date: true
+    has_time: true
+
+utility_meter:
+  byd_geladen_seit_voll:
+    source: sensor.byd_geladen_gesamt
+    name: "BYD geladen seit Voll"
+    periodically_resetting: false      # Quelle ist total_increasing, kein Zyklus-Reset
+  byd_entladen_seit_voll:
+    source: sensor.byd_entladen_gesamt
+    name: "BYD entladen seit Voll"
+    periodically_resetting: false
+
+template:
+  - binary_sensor:
+      - unique_id: byd_daten_frisch
+        name: "BYD Daten frisch"
+        device_class: connectivity
+        icon: mdi:database-check
+        state: >
+          {{ has_value('sensor.byd_soc') and has_value('sensor.byd_leistung')
+             and has_value('sensor.byd_modul_1_zellspannung_min')
+             and has_value('sensor.byd_modul_2_zellspannung_min')
+             and has_value('sensor.byd_modul_3_zellspannung_min')
+             and has_value('sensor.byd_modul_4_zellspannung_min')
+             and has_value('sensor.byd_modul_5_zellspannung_min')
+             and has_value('sensor.byd_geladen_seit_voll')
+             and has_value('sensor.byd_entladen_seit_voll') }}
+      - unique_id: byd_entladeband
+        name: "BYD Entladeband"
+        icon: mdi:speedometer-slow
+        state: >
+          {% set p = states('sensor.byd_leistung')|float(0) %}
+          {{ has_value('sensor.byd_leistung') and 500 <= p <= 1500 }}
+
+  - sensor:
+      # Nettoenergie seit dem letzten Voll-Anker (entladen - geladen, kWh).
+      # measurement statt total_increasing (darf bei PV-Ladung sinken).
+      - unique_id: byd_netto_energie_seit_voll
+        name: "BYD Nettoenergie seit Voll"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: measurement
+        icon: mdi:battery-minus-outline
+        availability: >
+          {{ has_value('sensor.byd_entladen_seit_voll') and has_value('sensor.byd_geladen_seit_voll') }}
+        state: >
+          {{ (states('sensor.byd_entladen_seit_voll')|float
+              - states('sensor.byd_geladen_seit_voll')|float) | round(3) }}
+
+      # Sensor A: relative Zell-Absackung (mV, Peer-Median der 4 Nachbarmodule
+      # ggue. Modul 2). availability nur an die 5 Modul-Minima gekoppelt.
+      - unique_id: byd_modul2_absackung
+        name: "BYD Modul-2 Absackung"
+        unit_of_measurement: "mV"
+        state_class: measurement
+        icon: mdi:arrow-down-bold-box
+        availability: >
+          {{ has_value('sensor.byd_modul_1_zellspannung_min') and has_value('sensor.byd_modul_2_zellspannung_min')
+             and has_value('sensor.byd_modul_3_zellspannung_min') and has_value('sensor.byd_modul_4_zellspannung_min')
+             and has_value('sensor.byd_modul_5_zellspannung_min') }}
+        state: >
+          {% set peers = [states('sensor.byd_modul_1_zellspannung_min')|float,
+                          states('sensor.byd_modul_3_zellspannung_min')|float,
+                          states('sensor.byd_modul_4_zellspannung_min')|float,
+                          states('sensor.byd_modul_5_zellspannung_min')|float] | sort %}
+          {% set peer_median = (peers[1] + peers[2]) / 2 %}
+          {% set m2 = states('sensor.byd_modul_2_zellspannung_min')|float %}
+          {{ ((peer_median - m2) * 1000) | round(1) }}
+        attributes:
+          soc: "{{ states('sensor.byd_soc') }}"
+          leistung_w: "{{ states('sensor.byd_leistung') }}"
+          modul2_volt: "{{ states('sensor.byd_modul_2_zellspannung_min') }}"
+          schwaechste_zelle_id: "{{ states('sensor.byd_modul_2_min_zell_id') }}"
+          peer_median_volt: >
+            {% set peers = [states('sensor.byd_modul_1_zellspannung_min')|float,
+                            states('sensor.byd_modul_3_zellspannung_min')|float,
+                            states('sensor.byd_modul_4_zellspannung_min')|float,
+                            states('sensor.byd_modul_5_zellspannung_min')|float] | sort %}
+            {{ ((peers[1] + peers[2]) / 2) | round(3) }}
+          schwaechstes_modul: >
+            {% set ns = namespace(min_v=99, idx='?') %}
+            {% for i in [1,2,3,4,5] %}
+              {% set v = states('sensor.byd_modul_' ~ i ~ '_zellspannung_min')|float(99) %}
+              {% if v < ns.min_v %}{% set ns.min_v = v %}{% set ns.idx = i|string %}{% endif %}
+            {% endfor %}
+            {{ ns.idx }}
+
+  # Latch-Sensor: snapshottet Nettoenergie + Begleitwerte im Moment, in dem der
+  # Knie-Zyklus-Status nach "latched" wechselt.
+  - triggers:
+      - trigger: state
+        entity_id: input_select.byd_knie_zyklus_status
+        to: "latched"
+    sensor:
+      - unique_id: byd_modul2_netto_bis_knie
+        name: "BYD Modul-2 Nettoenergie bis Knie"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: measurement
+        icon: mdi:battery-alert-variant-outline
+        state: "{{ states('sensor.byd_nettoenergie_seit_voll') }}"
+        attributes:
+          netto_kwh: "{{ states('sensor.byd_nettoenergie_seit_voll') }}"
+          geladen_inkrement_kwh: "{{ states('sensor.byd_geladen_seit_voll') }}"
+          entladen_inkrement_kwh: "{{ states('sensor.byd_entladen_seit_voll') }}"
+          a_absackung_mv: "{{ states('sensor.byd_modul_2_absackung') }}"
+          soc: "{{ states('sensor.byd_soc') }}"
+          leistung_w: "{{ states('sensor.byd_leistung') }}"
+          modul2_volt: "{{ states('sensor.byd_modul_2_zellspannung_min') }}"
+          modul2_schwaechste_zelle_id: "{{ states('sensor.byd_modul_2_min_zell_id') }}"
+          modul2_staerkste_zelle_id: "{{ states('sensor.byd_modul_2_max_zell_id') }}"
+          modul_temp_c: "{{ states('sensor.byd_modul_2_temp_max') }}"
+          ref_verwendet_v: "{{ states('input_number.byd_knie_ref_frozen') }}"
+          cycle_id: "{{ states('input_text.byd_knie_cycle_id') }}"
+          sauberer_zyklus: "{{ states('sensor.byd_geladen_seit_voll')|float(0) < 0.5 }}"
+          gemessen: "{{ now().isoformat() }}"
+
+automation:
+  - id: byd_top_erreicht_merker
+    alias: "BYD | Ladeschluss-Merker setzen"
+    description: "Merkt sich, dass im laufenden Ladevorgang die Ladeschluss-Zellspannung erreicht wurde (Voll-Anker-Evidenz)."
+    mode: single
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.byd_zellspannung_max
+        above: 3.55
+        for: "00:02:00"
+    conditions: []
+    actions:
+      - action: input_boolean.turn_on
+        target: { entity_id: input_boolean.byd_top_erreicht }
+
+  - id: byd_voll_anker
+    alias: "BYD | Voll-Anker (Ladeabschluss)"
+    description: >-
+      Ladeabschluss-Event: Zellmax war >=3,55 V (Merker), danach Ladeende
+      (Leistung > -300 W = nicht mehr nennenswert Laden) fuer 5 min. Setzt den
+      Knie-Zyklus neu auf. Re-Arm-Sperre: nur wenn idle ODER seit letztem Anker
+      >=0,5 kWh netto entnommen (verhindert Mehrfach-Reset im Ladeschluss-Flattern).
+    mode: single
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.byd_leistung
+        above: -300
+        for: "00:05:00"
+    conditions:
+      - condition: state
+        entity_id: input_boolean.byd_top_erreicht
+        state: "on"
+      - condition: numeric_state
+        entity_id: sensor.byd_soc
+        above: 94
+      - condition: state
+        entity_id: binary_sensor.byd_daten_frisch
+        state: "on"
+      - condition: template
+        value_template: >
+          {{ is_state('input_select.byd_knie_zyklus_status','idle')
+             or states('sensor.byd_nettoenergie_seit_voll')|float(0) >= 0.5 }}
+    actions:
+      - action: utility_meter.reset
+        target:
+          entity_id:
+            - sensor.byd_geladen_seit_voll
+            - sensor.byd_entladen_seit_voll
+      - action: input_number.set_value
+        target: { entity_id: input_number.byd_knie_ref_frozen }
+        data:
+          value: "{{ states('input_number.byd_knie_referenzspannung')|float(3.20) }}"
+      - action: input_boolean.turn_on   # am Anker ist Modul 2 verifiziert hoch -> Flag direkt setzen (Guard-Automation ist redundanter Backup)
+        target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
+      - action: input_text.set_value
+        target: { entity_id: input_text.byd_knie_cycle_id }
+        data: { value: "{{ now().isoformat() }}" }
+      - action: input_datetime.set_datetime
+        target: { entity_id: input_datetime.byd_voll_anker_zeit }
+        data: { datetime: "{{ now().isoformat() }}" }
+      - action: input_select.select_option
+        target: { entity_id: input_select.byd_knie_zyklus_status }
+        data: { option: "armed" }
+      - action: input_boolean.turn_on
+        target: { entity_id: input_boolean.byd_knie_armed }
+      - action: input_boolean.turn_off
+        target: { entity_id: input_boolean.byd_top_erreicht }
+
+  - id: byd_knie_ueberschwelle_gesehen
+    alias: "BYD | Knie Ueberschwelle gesehen"
+    description: "Setzt das Guard-Flag, sobald Modul-2-min seit dem Anker klar (>= ref+30 mV) oberhalb der Schwelle war."
+    mode: single
+    triggers:
+      - trigger: template
+        value_template: >
+          {{ states('sensor.byd_modul_2_zellspannung_min')|float(0)
+             > states('input_number.byd_knie_ref_frozen')|float(3.20) + 0.03 }}
+    conditions:
+      - condition: state
+        entity_id: input_boolean.byd_knie_armed
+        state: "on"
+    actions:
+      - action: input_boolean.turn_on
+        target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
+
+  - id: byd_knie_latch
+    alias: "BYD | Knie-Latch (Nettoenergie festhalten)"
+    description: >-
+      Latcht, wenn Modul-2-min zum ersten Mal seit Voll die eingefrorene Referenz
+      (Default 3,20 V) 3 min lang unterschreitet, im standardisierten Entladeband
+      (+500..1500 W ueber die Haltezeit), bei frischen Daten und gesehener Ueberschwelle.
+      Die 3-min-Haltezeit ersetzt eine explizite mV-Hysterese (starke Entprellung).
+    mode: single
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.byd_modul_2_zellspannung_min
+        below: input_number.byd_knie_ref_frozen
+        for: "00:03:00"
+    conditions:
+      - condition: state
+        entity_id: input_select.byd_knie_zyklus_status
+        state: "armed"
+      - condition: state
+        entity_id: input_boolean.byd_knie_ueberschwelle_gesehen
+        state: "on"
+      - condition: state
+        entity_id: binary_sensor.byd_entladeband
+        state: "on"
+        for: "00:03:00"
+      - condition: state
+        entity_id: binary_sensor.byd_daten_frisch
+        state: "on"
+      - condition: template
+        value_template: "{{ has_value('sensor.byd_nettoenergie_seit_voll') }}"
+    actions:
+      - action: input_select.select_option
+        target: { entity_id: input_select.byd_knie_zyklus_status }
+        data: { option: "latched" }        # der Latch-Sensor snapshottet hierauf
+      - action: input_boolean.turn_off
+        target: { entity_id: input_boolean.byd_knie_armed }
+
+  - id: byd_knie_invalid
+    alias: "BYD | Knie-Zyklus ungueltig markieren"
+    description: >-
+      Markiert den laufenden armed-Zyklus als invalid bei Mess-Qualitaetsproblemen:
+      Datenluecke nahe Knie, Neustart nahe Knie, unplausibler Netto-Sprung.
+    mode: queued
+    max: 5
+    triggers:
+      - trigger: state
+        id: datenluecke
+        entity_id: binary_sensor.byd_daten_frisch
+        to: "off"
+        for: "00:02:00"
+      - trigger: homeassistant
+        id: neustart
+        event: start
+      - trigger: state
+        id: zaehlersprung
+        entity_id: sensor.byd_nettoenergie_seit_voll
+    conditions:
+      - condition: state
+        entity_id: input_select.byd_knie_zyklus_status
+        state: "armed"
+      - condition: or
+        conditions:
+          - condition: and
+            conditions:
+              - condition: trigger
+                id: ["datenluecke", "neustart"]
+              - condition: template
+                value_template: >
+                  {{ states('sensor.byd_modul_2_zellspannung_min')|float(9)
+                     <= states('input_number.byd_knie_ref_frozen')|float(3.20) + 0.01 }}
+          - condition: template
+            value_template: >
+              {{ trigger.id == 'zaehlersprung'
+                 and trigger.from_state is not none and trigger.to_state is not none
+                 and trigger.from_state.state not in ['unknown','unavailable']
+                 and trigger.to_state.state not in ['unknown','unavailable']
+                 and (trigger.to_state.state|float - trigger.from_state.state|float) > 3
+                 and (now().timestamp() - state_attr('input_datetime.byd_voll_anker_zeit','timestamp')|float(0)) > 120 }}
+    actions:
+      - action: input_select.select_option
+        target: { entity_id: input_select.byd_knie_zyklus_status }
+        data: { option: "invalid" }
+      - action: input_text.set_value
+        target: { entity_id: input_text.byd_knie_invalid_grund }
+        data: { value: "{{ trigger.id }} @ {{ now().strftime('%Y-%m-%d %H:%M') }}" }

--- a/tests/ha_harness.py
+++ b/tests/ha_harness.py
@@ -74,6 +74,13 @@ def _as_local(value):
     return value.astimezone(TZ) if isinstance(value, dt.datetime) else value
 
 
+def _median(values):
+    values = list(values)
+    if not all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in values):
+        raise TypeError(f"median: nicht-numerische Elemente in {values!r}")
+    return statistics.median(values)
+
+
 def _as_timestamp(value, default=None):
     try:
         parsed = dt.datetime.fromisoformat(str(value))
@@ -98,8 +105,10 @@ def _setup(env, hass):
         "as_datetime": _as_datetime, "as_local": _as_local,
         "round": lambda v, n=0: round(float(v), n),
         # HA-median: ungerade Anzahl -> mittleres Element, gerade -> Mittelwert
-        # der beiden mittleren (wie statistics.median).
-        "median": lambda v: statistics.median(float(x) for x in v),
+        # der beiden mittleren (wie statistics.median). Bewusst OHNE stille
+        # float-Konvertierung: nicht-numerische Elemente sollen wie in HA
+        # krachen statt false-green durchzurutschen.
+        "median": _median,
     })
     return env
 

--- a/tests/ha_harness.py
+++ b/tests/ha_harness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import pathlib
+import statistics
 import types
 from ast import literal_eval
 from zoneinfo import ZoneInfo
@@ -96,6 +97,9 @@ def _setup(env, hass):
         "float": _float, "int": _int,
         "as_datetime": _as_datetime, "as_local": _as_local,
         "round": lambda v, n=0: round(float(v), n),
+        # HA-median: ungerade Anzahl -> mittleres Element, gerade -> Mittelwert
+        # der beiden mittleren (wie statistics.median).
+        "median": lambda v: statistics.median(float(x) for x in v),
     })
     return env
 

--- a/tests/test_byd_bmu.py
+++ b/tests/test_byd_bmu.py
@@ -1,7 +1,8 @@
 """Tests fuer die BYD-Monitoring-Templates (byd_bmu.yaml + byd_modul2_fruehwarnung.yaml):
 Zellspreizung-Klemme, Ruhe-Median gegen Einzel-Ausreisser, Temp-Spreizung, Absackung."""
 
-from .ha_harness import REPO, FakeHass, find_template_entity, load_yaml, render
+from .ha_harness import (REPO, FakeHass, find_template_entity, load_yaml, render,
+                         render_native)
 
 
 def _bmu_entity(kind, unique_id):
@@ -74,6 +75,26 @@ def test_ruhe_messreihe_rolliert_auf_fuenf():
     assert reihe == "[2.0, 3.0, 4.0, 5.0, 6.0]"
 
 
+def test_ruhe_median_ueber_mehrere_trigger_zyklen():
+    # Simuliert aufeinanderfolgende Gate-Updates: das messreihe-Attribut des
+    # Zyklus n wird (wie HAs this-Snapshot) zum Input von Zyklus n+1.
+    entity = _ruhe_entity()
+    messreihe = []
+    verlauf = []
+    for roh in ["2", "3", "40", "3", "2", "2", "2", "2"]:
+        hass = FakeHass(states={"sensor.byd_zellspreizung": roh},
+                        this_attributes={"messreihe": messreihe})
+        verlauf.append(float(render(hass, entity["state"])))
+        messreihe = render_native(hass, entity["attributes"]["messreihe"])
+        assert isinstance(messreihe, list)
+        assert all(isinstance(v, float) for v in messreihe)
+    # Der 40er-Ausreisser drueckt nie durch (max. Median des echten Umfelds);
+    # nach 5 weiteren Messungen ist er aus dem Fenster. round(0) = Bankers
+    # wie in HA (2.5 -> 2.0).
+    assert verlauf == [2.0, 2.0, 3.0, 3.0, 3.0, 3.0, 2.0, 2.0]
+    assert messreihe == [3.0, 2.0, 2.0, 2.0, 2.0]
+
+
 # ---------------------------------------------------------------------------
 # Temperatur-Spreizung: Klemme + Availability auf min UND max
 # ---------------------------------------------------------------------------
@@ -103,6 +124,16 @@ def test_temp_spreizung_negativ_geklemmt():
 def test_temp_spreizung_unavailable_ohne_min_sensoren():
     states = _temp_states(33, 27)
     del states["sensor.byd_modul_1_temp_min"]
+    hass = FakeHass(states=states)
+    entity = _bmu_entity("sensor", "byd_bmu_temp_spreizung_k")
+    assert render(hass, entity["availability"]) == "False"
+
+
+def test_temp_spreizung_unavailable_bei_mittlerem_modul():
+    # Teil-Ausfall eines mittleren Moduls darf nicht mit float-Default
+    # weitergerechnet werden (Codex-Review-Finding).
+    states = _temp_states(33, 27)
+    del states["sensor.byd_modul_3_temp_max"]
     hass = FakeHass(states=states)
     entity = _bmu_entity("sensor", "byd_bmu_temp_spreizung_k")
     assert render(hass, entity["availability"]) == "False"

--- a/tests/test_byd_bmu.py
+++ b/tests/test_byd_bmu.py
@@ -1,0 +1,144 @@
+"""Tests fuer die BYD-Monitoring-Templates (byd_bmu.yaml + byd_modul2_fruehwarnung.yaml):
+Zellspreizung-Klemme, Ruhe-Median gegen Einzel-Ausreisser, Temp-Spreizung, Absackung."""
+
+from .ha_harness import REPO, FakeHass, find_template_entity, load_yaml, render
+
+
+def _bmu_entity(kind, unique_id):
+    return find_template_entity(load_yaml(REPO / "packages" / "byd_bmu.yaml"), kind, unique_id)
+
+
+def _fw_entity(kind, unique_id):
+    return find_template_entity(
+        load_yaml(REPO / "packages" / "byd_modul2_fruehwarnung.yaml"), kind, unique_id)
+
+
+# ---------------------------------------------------------------------------
+# Zellspreizung: max - min in mV, negativ auf 0 geklemmt
+# ---------------------------------------------------------------------------
+
+def test_zellspreizung_normal():
+    hass = FakeHass(states={"sensor.byd_zellspannung_max": "3.300",
+                            "sensor.byd_zellspannung_min": "3.280"})
+    entity = _bmu_entity("sensor", "byd_bmu_zellspreizung_mv")
+    assert float(render(hass, entity["state"])) == 20.0
+    assert render(hass, entity["availability"]) == "True"
+
+
+def test_zellspreizung_negativ_geklemmt():
+    # MQTT-Skew-Artefakt: min-Topic frischer als max -> rechnerisch negativ.
+    hass = FakeHass(states={"sensor.byd_zellspannung_max": "3.280",
+                            "sensor.byd_zellspannung_min": "3.300"})
+    entity = _bmu_entity("sensor", "byd_bmu_zellspreizung_mv")
+    assert float(render(hass, entity["state"])) == 0.0
+
+
+def test_zellspreizung_unavailable_ohne_min():
+    hass = FakeHass(states={"sensor.byd_zellspannung_max": "3.300"})
+    entity = _bmu_entity("sensor", "byd_bmu_zellspreizung_mv")
+    assert render(hass, entity["availability"]) == "False"
+
+
+# ---------------------------------------------------------------------------
+# Ruhe-Spreizung: Median der letzten 5 Gate-Messungen (this.attributes.messreihe)
+# ---------------------------------------------------------------------------
+
+def _ruhe_entity():
+    return _bmu_entity("sensor", "byd_bmu_zellspreizung_ruhe_mv")
+
+
+def test_ruhe_median_kappt_einzel_ausreisser():
+    # Historie unauffaellig (2-3 mV), ein Skew-Artefakt von 40 mV kommt rein:
+    # Median bleibt bei 3 statt den Ausreisser zu latchen.
+    hass = FakeHass(states={"sensor.byd_zellspreizung": "40"},
+                    this_attributes={"messreihe": [2.0, 3.0, 2.0, 3.0]})
+    assert float(render(hass, _ruhe_entity()["state"])) == 3.0
+
+
+def test_ruhe_median_laesst_echte_hohe_spreizung_durch():
+    # Persistent hohe Werte in der Historie: der Median folgt dem echten Niveau.
+    hass = FakeHass(states={"sensor.byd_zellspreizung": "61"},
+                    this_attributes={"messreihe": [30.0, 60.0, 55.0, 58.0]})
+    assert float(render(hass, _ruhe_entity()["state"])) == 58.0
+
+
+def test_ruhe_median_erste_messung_ohne_historie():
+    hass = FakeHass(states={"sensor.byd_zellspreizung": "4"}, this_attributes={})
+    assert float(render(hass, _ruhe_entity()["state"])) == 4.0
+
+
+def test_ruhe_messreihe_rolliert_auf_fuenf():
+    hass = FakeHass(states={"sensor.byd_zellspreizung": "6"},
+                    this_attributes={"messreihe": [1.0, 2.0, 3.0, 4.0, 5.0]})
+    reihe = render(hass, _ruhe_entity()["attributes"]["messreihe"])
+    assert reihe == "[2.0, 3.0, 4.0, 5.0, 6.0]"
+
+
+# ---------------------------------------------------------------------------
+# Temperatur-Spreizung: Klemme + Availability auf min UND max
+# ---------------------------------------------------------------------------
+
+def _temp_states(tmax, tmin):
+    states = {}
+    for i in range(1, 6):
+        states[f"sensor.byd_modul_{i}_temp_max"] = str(tmax)
+        states[f"sensor.byd_modul_{i}_temp_min"] = str(tmin)
+    return states
+
+
+def test_temp_spreizung_normal():
+    hass = FakeHass(states=_temp_states(33, 27))
+    entity = _bmu_entity("sensor", "byd_bmu_temp_spreizung_k")
+    assert float(render(hass, entity["state"])) == 6.0
+    assert render(hass, entity["availability"]) == "True"
+
+
+def test_temp_spreizung_negativ_geklemmt():
+    # Teil-Ausfall-Artefakt: min-Werte ueber max-Werten -> 0 statt negativ.
+    hass = FakeHass(states=_temp_states(20, 25))
+    entity = _bmu_entity("sensor", "byd_bmu_temp_spreizung_k")
+    assert float(render(hass, entity["state"])) == 0.0
+
+
+def test_temp_spreizung_unavailable_ohne_min_sensoren():
+    states = _temp_states(33, 27)
+    del states["sensor.byd_modul_1_temp_min"]
+    hass = FakeHass(states=states)
+    entity = _bmu_entity("sensor", "byd_bmu_temp_spreizung_k")
+    assert render(hass, entity["availability"]) == "False"
+
+
+# ---------------------------------------------------------------------------
+# Fruehwarnung: Absackung (Peer-Median) + Entladeband
+# ---------------------------------------------------------------------------
+
+def _modul_min_states():
+    return {"sensor.byd_modul_1_zellspannung_min": "3.212",
+            "sensor.byd_modul_2_zellspannung_min": "3.189",
+            "sensor.byd_modul_3_zellspannung_min": "3.212",
+            "sensor.byd_modul_4_zellspannung_min": "3.211",
+            "sensor.byd_modul_5_zellspannung_min": "3.209"}
+
+
+def test_absackung_gegen_peer_median():
+    # Peers sortiert [3.209, 3.211, 3.212, 3.212] -> Median 3.2115;
+    # (3.2115 - 3.189) * 1000 = 22.5 mV.
+    hass = FakeHass(states=_modul_min_states())
+    entity = _fw_entity("sensor", "byd_modul2_absackung")
+    assert float(render(hass, entity["state"])) == 22.5
+    assert render(hass, entity["availability"]) == "True"
+
+
+def test_absackung_schwaechstes_modul_attribut():
+    hass = FakeHass(states=_modul_min_states())
+    entity = _fw_entity("sensor", "byd_modul2_absackung")
+    assert render(hass, entity["attributes"]["schwaechstes_modul"]) == "2"
+
+
+def test_entladeband_grenzen():
+    entity = _fw_entity("binary_sensor", "byd_entladeband")
+    assert render(FakeHass(states={"sensor.byd_leistung": "500"}), entity["state"]) == "True"
+    assert render(FakeHass(states={"sensor.byd_leistung": "1500"}), entity["state"]) == "True"
+    assert render(FakeHass(states={"sensor.byd_leistung": "499"}), entity["state"]) == "False"
+    assert render(FakeHass(states={"sensor.byd_leistung": "-800"}), entity["state"]) == "False"
+    assert render(FakeHass(states={}), entity["state"]) == "False"


### PR DESCRIPTION
## Was

Portiert die bisher nur live existierende Zellspannungs-Überwachung ins Repo und härtet die Spreizungs-Sensorik (Follow-up aus dem Monitoring-Review vom 16.7.).

- **Modul-2-Frühwarnung portiert**: `packages/byd_modul2_fruehwarnung.yaml` (Absackung gegen Peer-Median, Knie-Zustandsmaschine idle/armed/latched/invalid, Nettoenergie-bis-Knie) + Doku `docs/byd-modul2-fruehwarnung.md`
- **10 Zell-ID-Sensoren** (MinVoltID/MaxVoltID je Modul) in `byd_bmu.yaml` ergänzt (fehlten im Repo, live vorhanden; die Frühwarnung referenziert sie)
- **Ruhe-Spreizung: Median der letzten 5 Gate-Messungen** statt Rohwert-Latch. Ein einzelner MQTT-Skew-Ausreißer im Ruhefenster konnte sonst latchen und die 1-h-for-Zeit des Alarms per Stagnation erfüllen
- **Temp-Spreizung**: Negativ-Klemme + Availability über alle 10 Temp-Sensoren
- **Doku**: SoC-Gate 25-85 % + Median in `byd-bmu-monitoring.md`, Package-Tabellen in README/Installation
- **Tests**: `tests/test_byd_bmu.py` (15 neue), `median`-Filter im Harness

## Codex-Review (Cross-Family) eingearbeitet

- **P2**: `initial:` von allen Frühwarnungs-Helfern entfernt - HA wendet `initial` bei **jedem** Neustart an (nicht nur beim Setup); Referenzspannung und Zyklus-Status wären bei jedem Restart zurückgesetzt worden, die Neustart→invalid-Erkennung hätte nie gegriffen. Auch live gefixt.
- **P2**: Temp-Availability von Stichprobe (Modul 1/5) auf alle 10 Sensoren erweitert
- P3-Empfehlungen (strikter Median-Filter im Harness, Multi-Zyklus-Roundtrip-Test) übernommen; Automations-Übergangstests (Voll-Anker/Latch) bewusst zurückgestellt - der Latch-Pfad wird beim ersten Vollzyklus live E2E verifiziert

## Live-Status

Alle Änderungen sind bereits live deployed (in-place, Backups `.bak-*-20260716`) und nach HA-Restart verifiziert: Ruhe-Wert restored, Helfer überleben Restart ohne Reset, Alarm-Automation aktiv, Absackung liefert. 219 Tests grün, Jinja-Parse-Check sauber.

## Hinweis

Stackt auf `fix/byd-ruhe-gate` (#49) - erst #49 mergen, dann diesen.