### PR TITLE
feat(byd): Akku-Alarme + Monitoring nativ auf Modbus (byd_battery_box)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Der Minimalpfad. Voller Ablauf mit beiden Einspiel-Varianten, allen Erststart-We
      packages: !include_dir_named packages/
    ```
 2. **Hardware-Mapping:** `opti_mapping.example.yaml` → `packages/opti_mapping.yaml` kopieren, alle `DEIN_*`-Platzhalter durch echte Entitäts-IDs ersetzen (→ [docs/canonical-layer.md](docs/canonical-layer.md)).
-3. **Package-Dateien** aus [`packages/`](packages/) ins HA-`packages/`-Verzeichnis kopieren (Überblick unter [Dateien](#dateien); `sma_templates.yaml`/`opti_ki_analyse.yaml`/`byd_bmu.yaml` sind optional). In `sma_modbus.yaml` die **WR-IP** anpassen - oder die Datei weglassen, falls der Modbus-Hub schon aus dem Adapter-Repo kommt (siehe „Nur aus einer Quelle" unten).
+3. **Package-Dateien** aus [`packages/`](packages/) ins HA-`packages/`-Verzeichnis kopieren (Überblick unter [Dateien](#dateien); `sma_templates.yaml`/`opti_ki_analyse.yaml`/`byd_monitoring.yaml` sind optional; `legacy/` bleibt draußen). In `sma_modbus.yaml` die **WR-IP** anpassen - oder die Datei weglassen, falls der Modbus-Hub schon aus dem Adapter-Repo kommt (siehe „Nur aus einer Quelle" unten).
 4. **Home Assistant neu starten.**
 5. ✅ **Verify-Gate - erst prüfen, dann scharf schalten:** In den Entwicklertools sicherstellen, dass `sensor.opti_target_soc`, `sensor.opti_charge_power_w` und `sensor.opti_price_level` plausible Werte zeigen und **nicht** `unavailable`/`unknown` sind. Stimmt etwas nicht → zuerst das Mapping korrigieren, nicht weitergehen.
 6. **Adapter-Blueprint importieren** aus [`ha-modbus-akku-adapter`](https://github.com/Optic00/ha-modbus-akku-adapter) und die Eingaben auf deine Entitäten mappen (Modbus-Hub, WR-Status, `input_select.akkusteuerung_modus`, `sensor.opti_charge_power_w`, dazu `battery_capacity_sensor` und `inverter_ok_states` - die Blueprint-Vorschlagswerte prüfen, nicht ungeprüft übernehmen).
@@ -105,8 +105,8 @@ Der Minimalpfad. Voller Ablauf mit beiden Einspiel-Varianten, allen Erststart-We
 | `packages/sma_templates.yaml` | Legacy-Template-Sensoren - teils durch `opti_derived.yaml` abgelöst, teils noch ohne Canonical-Äquivalent (Sollkurve/P-Regler, Abregelung) |
 | `packages/sma_statistik.yaml` | Gleitende Mittelwert-Sensoren für Verbrauch & Batterielast |
 | `packages/opti_ki_analyse.yaml` | **optional** - täglicher KI-Tagesreport (rein lesend) |
-| `packages/byd_bmu.yaml` | **optional** - BYD-Zell-Monitoring via bydlogc→MQTT (→ [docs/byd-bmu-monitoring.md](docs/byd-bmu-monitoring.md)) |
-| `packages/byd_modul2_fruehwarnung.yaml` | **optional** - Degradations-Frühwarnung fürs schwächste BYD-Modul, setzt `byd_bmu.yaml` voraus (→ [docs/byd-modul2-fruehwarnung.md](docs/byd-modul2-fruehwarnung.md)) |
+| `packages/byd_monitoring.yaml` | **optional** - BYD-Zell-Monitoring + Akku-Alarme über die native Modbus-Integration (→ [docs/byd-monitoring-nativ.md](docs/byd-monitoring-nativ.md)) |
+| `legacy/` | Abgelöste Packages (BYD via bydlogc→MQTT, Modul-2-Frühwarnung) - **nicht mehr einbauen**, siehe Deprecation-Header in den Dateien |
 | `packages/opti_ev_sperre.yaml` | **optional** - EV-Schnelllade-Entladesperre (Hausakku entlädt nicht ins Auto, wenn evcc im Modus now/minpv lädt); braucht HACS `evcc_intg` + Ladepunkt-Block im Mapping → [docs/strategie-logik.md](docs/strategie-logik.md) (Option 13) |
 | `automations/opti_strategie.yaml` | Strategie-Automation (editierbar, kein Blueprint) |
 

--- a/automations/opti_ki_analyse.yaml
+++ b/automations/opti_ki_analyse.yaml
@@ -76,7 +76,7 @@
               "ruhe_spreizung_mv": {{ num('sensor.byd_zellspreizung_ruhe', 0) }},
               "ruhe_spreizung_max_24h_mv": {{ num('sensor.opti_ki_ruhe_spreizung_max_24h', 0) }},
               "temp_spreizung_k": {{ num('sensor.byd_temperatur_spreizung', 0) }},
-              "soh_prozent": {{ num('sensor.byd_soh', 0) }},
+              "soh_prozent": {{ num('sensor.bms_1_state_of_health', 0) }},
               "balancing_dauer_h": {{ num('sensor.opti_ki_balancing_dauer_h', 2) }}
             }
           }

--- a/automations/opti_ki_analyse.yaml
+++ b/automations/opti_ki_analyse.yaml
@@ -31,7 +31,12 @@
           {% macro num(eid, digits=1) -%}
             {{ (states(eid) | float(0) | round(digits)) if has_value(eid) else ('"' ~ nv ~ '"') }}
           {%- endmacro %}
-          {% set byd_da = has_value('sensor.byd_zellspreizung_ruhe') %}
+          {# byd_da nicht nur has_value: sensor.byd_zellspreizung_ruhe haelt
+             seinen letzten Wert (RestoreEntity) auch bei Datenausfall. Zusaetzlich
+             die Zelldaten-Frische, sonst meldet der Report eingefrorene
+             SoH/Spreizungs-Werte als aktuell (Codex-Review 17.7.). #}
+          {% set byd_da = has_value('sensor.byd_zellspreizung_ruhe')
+             and is_state('binary_sensor.byd_zelldaten_frisch', 'on') %}
           {
             "datum": "{{ now().strftime('%Y-%m-%d') }}",
             "modi": {

--- a/docs/byd-bmu-monitoring.md
+++ b/docs/byd-bmu-monitoring.md
@@ -1,8 +1,13 @@
 # BYD-BMU-Monitoring (optional): Zellspannungen, Spreizung und Balancing in Home Assistant
 
+> ⛔ **Überholt seit 17.7.2026.**
+> Dieser bydlogc-/MQTT-Weg ist durch die native Modbus-Integration abgelöst: **[byd-monitoring-nativ.md](byd-monitoring-nativ.md)** (Package [`packages/byd_monitoring.yaml`](../packages/byd_monitoring.yaml)).
+> Das Package liegt nur noch als Rollback-Option unter [`legacy/byd_bmu.yaml`](../legacy/byd_bmu.yaml) und wird im Abbau-PR gelöscht.
+> Diese Datei bleibt erhalten, weil die Abschnitte zur **Hairpin-Falle** und zu den **LFP-Interpretations-Hinweisen** weiterhin gelten - die Netz-Route zur Box braucht auch die native Integration.
+
 Dieses optionale Modul liest die BMU/BMS-Daten einer BYD Battery-Box Premium HVS aus und macht sie in Home Assistant sichtbar: Einzelmodul-Zellspannungen, Zell-Spreizung, Temperaturen, SoH, Balancing-Status.
 Es ist rein beobachtend und hat keinerlei Steuerfunktion.
-Das zugehörige HA-Package ist [`packages/byd_bmu.yaml`](../packages/byd_bmu.yaml).
+Das zugehörige HA-Package ist [`legacy/byd_bmu.yaml`](../legacy/byd_bmu.yaml).
 
 Die Datenquelle ist das Windows-/Linux-Tool **BYD-Logger** (`bydlogc`) von "olli" aus dem Photovoltaikforum.
 Das Tool wird hier **nicht** mitverteilt - die Binaries gibt es beim Autor im entsprechenden Forums-Thread.
@@ -20,7 +25,7 @@ bydlogc (Linux-Binary) in Docker-Container oder VM
 MQTT-Broker (z. B. Mosquitto-App in HA)
         │
         ▼
-packages/byd_bmu.yaml  →  sensor.byd_* in Home Assistant
+legacy/byd_bmu.yaml  →  sensor.byd_* in Home Assistant
 ```
 
 ## Voraussetzungen
@@ -134,7 +139,7 @@ Be-Connect-App oder BYD-Logger-GUI nie parallel zum Container laufen lassen; fü
 ## MQTT-Topics und HA-Package
 
 Das Tool publisht unter `Battery/BYD/BMS_1/...`: SOC, SOH, Min/Max/AvCellVolt, Power, Status1/2, Balancing, BalanceData, ChargedkWh/DischargedkWh sowie je Modul MinCellVolt/MaxCellVolt/MinVoltID/MaxVoltID/ModuleVolt/MinTemp/MaxTemp.
-`packages/byd_bmu.yaml` mappt diese Topics auf `sensor.byd_*`-Entities (`expire_after: 300` als Ausfall-Erkennung; die VoltID-Topics als Zell-Nummern-Diagnose je Modul) und ergänzt abgeleitete Sensoren:
+`legacy/byd_bmu.yaml` mappt diese Topics auf `sensor.byd_*`-Entities (`expire_after: 300` als Ausfall-Erkennung; die VoltID-Topics als Zell-Nummern-Diagnose je Modul) und ergänzt abgeleitete Sensoren:
 
 - `sensor.byd_zellspreizung` (mV, max - min über den ganzen Turm),
 - `sensor.byd_zellspreizung_ruhe` - aktualisiert nur, wenn der Akku nahezu lastfrei ist (|Leistung| < 300 W) UND der SoC im flachen Teil der LFP-Kennlinie liegt (25-85 %).

--- a/docs/byd-modul2-fruehwarnung.md
+++ b/docs/byd-modul2-fruehwarnung.md
@@ -1,7 +1,13 @@
 # BYD Modul-2-Frühwarnung: Degradations-Monitoring für das schwächste Modul
 
-Dieses optionale Package ([`packages/byd_modul2_fruehwarnung.yaml`](../packages/byd_modul2_fruehwarnung.yaml)) beobachtet das schwächste Modul eines BYD-HVS-Turms auf schleichende Degradation.
-Es baut auf dem BMU-Monitoring ([`packages/byd_bmu.yaml`](../packages/byd_bmu.yaml), Doku: [byd-bmu-monitoring.md](byd-bmu-monitoring.md)) auf und ist rein beobachtend, ohne jede Steuerwirkung.
+> ⛔ **Überholt seit 17.7.2026 - Neubau als Phase 2 eingeplant.**
+> Dieses Package hängt komplett an den MQTT-Sensoren des abgelösten bydlogc-Wegs und ist seit dem bydlogc-Stopp am 17.7.2026 funktionslos.
+> Es liegt nur noch unter [`legacy/byd_modul2_fruehwarnung.yaml`](../legacy/byd_modul2_fruehwarnung.yaml).
+> Der Neubau auf die nativen Zelldaten ist skizziert in [byd-monitoring-nativ.md](byd-monitoring-nativ.md) (Abschnitt „Phase 2").
+> Fachlich (Metrik-Definitionen, Zustandsmaschine, Interpretations-Hinweise) gilt diese Doku als Vorlage weiter.
+
+Dieses optionale Package ([`legacy/byd_modul2_fruehwarnung.yaml`](../legacy/byd_modul2_fruehwarnung.yaml)) beobachtet das schwächste Modul eines BYD-HVS-Turms auf schleichende Degradation.
+Es baut auf dem BMU-Monitoring ([`legacy/byd_bmu.yaml`](../legacy/byd_bmu.yaml), Doku: [byd-bmu-monitoring.md](byd-bmu-monitoring.md)) auf und ist rein beobachtend, ohne jede Steuerwirkung.
 Nach der Erstinstallation einmalig `input_number.byd_knie_referenzspannung` auf 3,20 V stellen; die Helfer tragen bewusst kein `initial:`, weil HA das bei jedem Neustart anwenden und Referenz wie Zyklus-Status überschreiben würde.
 
 ## Ausgangslage

--- a/docs/byd-monitoring-nativ.md
+++ b/docs/byd-monitoring-nativ.md
@@ -1,0 +1,297 @@
+# BYD-Monitoring nativ: Zelldaten und Akku-Alarme über Modbus
+
+Dieses optionale Modul liest die BMU/BMS-Daten einer BYD Battery-Box Premium HVS **direkt per Modbus** aus und baut darauf deterministische Gesundheits-Alarme.
+Es ist rein beobachtend/alarmierend und hat keinerlei Steuerfunktion.
+Das zugehörige HA-Package ist [`packages/byd_monitoring.yaml`](../packages/byd_monitoring.yaml), die Tests liegen in [`tests/test_byd_monitoring.py`](../tests/test_byd_monitoring.py).
+
+Es löst den bisherigen Weg über das Tool `bydlogc` und MQTT ab ([byd-bmu-monitoring.md](byd-bmu-monitoring.md), Package jetzt unter `legacy/`).
+Gründe für den Wechsel: keine Binary-Redistribution mehr nötig, kein MQTT-Broker im Pfad, atomare Reads statt ~60 s versetzter Einzel-Topics, echte Pro-Zell-Daten (160 Zellen) und native Fehlerbits.
+
+## Architektur
+
+```
+BYD Battery-Box (BMU, WLAN-Modul, Standard-IP 192.168.16.254)
+        │  Modbus TCP, NUR EINE Verbindung
+        ▼
+HACS-Integration byd_battery_box (läuft in HA selbst)
+        │
+        ▼
+packages/byd_monitoring.yaml  →  Template-Layer + Alarme + Watchdog
+```
+
+Der **Netzweg zur Box bleibt identisch** zum alten Setup: statische Route oder SNAT-Regel auf `192.168.16.254/32`.
+Die Hairpin-Falle (UniFi verwirft nach dem ICMP-Redirect alles außer dem ersten Paket) ist unverändert relevant und in [byd-bmu-monitoring.md](byd-bmu-monitoring.md#netzwerk-die-hairpin-falle) beschrieben.
+Ebenso gilt weiter das **Ein-Verbindungs-Limit** der BMU: Be-Connect-App oder BYD-Logger nie parallel laufen lassen.
+
+## Gepinnter Entity-Vertrag
+
+Die Integration liegt **nicht** in diesem Repo, ihre Entity-Namen sind aber die Schnittstelle dieses Packages.
+Deshalb ist der Vertrag hier festgeschrieben - weicht eine neue Integrations-Version davon ab, ist das ein Breaking Change für `byd_monitoring.yaml`.
+
+- **Integration:** [`TimWeyand/byd_battery_box`](https://github.com/TimWeyand/byd_battery_box) (Fork), **v0.1.34, Commit `2cc5762`**.
+- **Anlage im Snapshot:** 1 Turm, 5 Module, 32 Zellen/Modul = 160 Zellen, 12 Temperaturfühler/Modul, Wechselrichter „SMA STP 5.0-10.0 SE HV".
+
+### Zwei Datenebenen
+
+| Ebene | Entities | Kadenz | Auflösung |
+|---|---|---|---|
+| **BMU-Poll** | `sensor.bmu_cell_voltage_max`, `sensor.battery_management_unit_bmu_cell_voltage_min`, `..._bmu_cell_temperature_max`/`_min`, `sensor.bmu_power`, `..._state_of_charge`, `..._errors`, `..._connection_health`, `..._updated` | **30 s** | Spannung 10 mV, Temperatur 1 °C, Leistung ~2 W |
+| **BMS-Detail** | `sensor.battery_management_system_1_bms_1_*` (`cell_voltage_max`/`_min`, `cells_voltage_delta`, `warnings`, `errors`, `updated`), `sensor.bms_1_cells_average_voltage` (Attribut `cell_voltages`), `sensor.bms_1_cells_average_temperature` (Attribut `cell_temps`), `sensor.bms_1_cells_balancing`, `sensor.bms_1_state_of_health` | **~630 s** (10,5 min) | Spannung 1 mV |
+
+### Namens-Falle (nicht „aufräumen")
+
+Die Integration vergibt die entity_ids **asymmetrisch** - max und min heißen nicht gleich aufgebaut:
+
+| Zweck | entity_id |
+|---|---|
+| Zellspannung max (BMU) | `sensor.bmu_cell_voltage_max` (kurz) |
+| Zellspannung min (BMU) | `sensor.battery_management_unit_bmu_cell_voltage_min` (lang) |
+| Leistung | `sensor.bmu_power` (kurz) |
+| SoC | `sensor.battery_management_unit_state_of_charge` (lang) |
+| Zellspannungs-Delta | `sensor.battery_management_system_1_bms_1_cells_voltage_delta` |
+| Balancing-Zähler | `sensor.bms_1_cells_balancing` |
+
+Alle im Package verwendeten IDs sind am 17.7.2026 live gegengeprüft.
+
+### Attribut-Formate
+
+- `cell_voltages` (auf `sensor.bms_1_cells_average_voltage`): `[{"m": 1..5, "v": [32 Ints in mV]}, ...]` - 160 Werte.
+- `cell_temps` (auf `sensor.bms_1_cells_average_temperature`): `[{"m": 1..5, "t": [12 Ints in °C]}, ...]`.
+- `cell_balancing` (auf `sensor.bms_1_cells_balancing`): `[{"m": 1..5, "b": [16 Bit]}, ...]` - 16 Bit auf 32 Zellen, die Zuordnung ist unklar, deshalb wird nur der Zählwert genutzt.
+
+### Vorzeichen und Timestamps (live verifiziert 17.7.)
+
+- **`sensor.bmu_power`: negativ = Laden.** Gleiche Konvention wie das alte `sensor.byd_leistung`, und identisch zu `sensor.bms_1_charge_total_energy`/`_discharge_total_energy` (relevant für Phase 2).
+- Die `*_updated`-Sensoren liefern einen **naiven Lokalzeit-String** (`"2026-07-17 11:45:34.207325"`, `tzinfo` = None).
+  `as_timestamp(states('...'), 0)` interpretiert ihn korrekt als Lokalzeit, also ist `now().timestamp() - as_timestamp(states('...'), 0)` das Alter in Sekunden (gegengeprüft: 17,5 s bei 30-s-Poll, 162 s beim BMS).
+  Bei Müll oder `unavailable` liefert `as_timestamp(x, 0)` den Default `0` → Alter riesig → „nicht frisch".
+  Das ist die gewünschte Fail-Safe-Richtung; eine `as_datetime`-/TZ-Behandlung ist ausdrücklich **nicht** nötig.
+
+### Auflösung der BMU-Ebene (live verifiziert 17.7.)
+
+Das BMU-Register ist **nativ 10-mV-granular**: die Integration rechnet `round(uint16 * 0.01, 2)` (`bydboxclient.py:456`), der `round()` ist also nur kosmetisch.
+Die BMS-Detailebene ist mV-granular (`round(int16 * 0.001, 3)`, Zeile 520).
+
+Ob die BYD-Firmware beim Füllen des 10-mV-Registers **rundet oder abschneidet**, ist von außen **nicht bestimmbar**.
+Konsequenz für die Alarme: der effektive Auslösepunkt der BMU-Regeln verschiebt sich um **bis zu 10 mV nach oben** (die 3,55-V-Regel feuert praktisch ab 3,56 V).
+Bei ~100 mV Abstand zur BMS-Grenze ist das akzeptabel; das kritische Fenster 3,651-3,659 V fängt die präzise BMS-Backstop-Regel ab (siehe Alarm-Tabelle).
+
+### Bekannte Integrations-Mängel (bewusst gemieden)
+
+- `average_latency`/`last_latency`: **Einheiten-Bug** - Sekunden gemessen, als ms deklariert. Nicht für Alarme verwenden.
+- `cell_voltages_max_history`/`_min_history` und `sensor.bms_1_max/min_history_cell_voltage`: zeigen live überlappende, zwischen den Modulen verschobene Wertereihen (Sliding-Window-Artefakt). **Nicht verwenden.**
+- `sensor.battery_management_unit_cells_per_module` (12) und `..._temperature_sensors_per_module` (32) sind offensichtlich **vertauscht** - die echten Attribute zeigen 32 Zellen und 12 Fühler pro Modul. Nur Anzeige, ohne Wirkung auf dieses Package.
+- **Setup-Fehlschlag nach HA-Neustart ohne Retry** (Fork-Issues #14/#15): die Entities starten dann `unavailable` **ohne State-Übergang**, edge-Trigger feuern nie. Das ist das realste Ausfallszenario und der Grund für den zeitbasierten Dead-Man-Watchdog.
+- `connection_health` kennt nur `healthy`/`unhealthy` (unhealthy ab 3 aufeinanderfolgenden Ping-Fehlern oder Latenz ≥ 5 s; eigener Ping alle 60 s auf Register `0x0000`). Der Ping ist **unabhängig** vom BMU-/BMS-Poll: er kann gesund sein, während ein Poll hängt. Deshalb reicht er als Ausfall-Erkennung nicht aus.
+
+## Die zentrale Design-Randbedingung: Werte frieren ein
+
+**Die Integration setzt Entities bei Modbus-Abbruch NIE auf `unavailable`** - `sensor.py` hat keine `available`-Property, `hub.data` friert einfach ein.
+
+Daraus folgt beides:
+
+1. Der alte `stale`-Alarm (Trigger auf den `unavailable`-Übergang der MQTT-Sensoren) hat **kein Äquivalent** - es gibt keinen Übergang, auf den man horchen könnte.
+2. Ein eingefrorener Wert **erfüllt jede `for:`-Haltezeit per Stagnation**. Ein bei 3,66 V eingefrorener Sensor würde den Grenzwächter auslösen, obwohl seit Stunden nichts gemessen wurde.
+
+Antwort darauf ist dreiteilig:
+
+- **Frische-Binaries** als Bedingung in jedem physikalischen Alarm (`for:` allein beweist keine frischen Samples).
+- **Edge-Alarm `verbindung`** für Modbus-/Netzprobleme im laufenden Betrieb.
+- **Dead-Man-Watchdog**, zeitbasiert - erkennt auch den Boot-Setup-Fehlschlag ohne State-Übergang.
+
+Bewusste Konsequenz: die Frische-Bedingung **unterdrückt physikalische Alarme während eines Datenausfalls**.
+Dann weiß man ohnehin nichts Neues - und `verbindung`/Watchdog melden den Ausfall selbst (fail-notified statt fail-silent).
+
+## Abgeleitete Entities (Template-Layer)
+
+| Entity | unique_id | Quelle | Zweck |
+|---|---|---|---|
+| `binary_sensor.byd_ruhefenster` | `byd_ruhefenster` | \|`bmu_power`\| < 300 W UND 25 < SoC < 85 | Gate für die Ruhe-Sensoren |
+| `binary_sensor.byd_bmu_frisch` | `byd_bmu_frisch` | Alter von `..._updated` < 3 min (= 6 verpasste Polls) | Frische-Bedingung BMU-Alarme, Watchdog |
+| `binary_sensor.byd_zelldaten_frisch` | `byd_zelldaten_frisch` | Alter von `..._bms_1_updated` < 25 min (2 verpasste Zyklen + Marge) | Frische-Bedingung BMS-Regeln, Ruhe-Sensoren, Watchdog |
+| `binary_sensor.byd_balancing_aktiv_nativ` | `byd_balancing_aktiv_nativ` | `bms_1_cells_balancing` > 0 | history_stats-Quelle der KI-Analyse |
+| `sensor.byd_zellspreizung_ruhe` | `byd_bmu_zellspreizung_ruhe_mv` (**Carry**) | Median-3 des nativen `cells_voltage_delta`, im Ruhefenster | **Bedarfs-Balancing (Steuerwirkung!)**, KI-Analyse, Alarm |
+| `sensor.byd_temperatur_spreizung` | `byd_bmu_temp_spreizung_k` (**Carry**) | BMU-Temp max - min (ein Poll) | KI-Analyse, `temp_delta`-Alarm |
+| `sensor.byd_zell_ausreisser` | `byd_zell_ausreisser` | max \|Zelle - Median(160)\| aus `cell_voltages` | Diagnose, **kein** Alarm |
+
+### unique_id-Carry: warum die entity_ids gleich bleiben
+
+`byd_bmu_zellspreizung_ruhe_mv` und `byd_bmu_temp_spreizung_k` sind aus dem alten Package **übernommen**, nicht neu vergeben.
+Beide bleiben auf derselben Plattform (`template`), damit behalten `sensor.byd_zellspreizung_ruhe` und `sensor.byd_temperatur_spreizung` ihre entity_id, ihre Registry-Einträge und ihre Historie.
+
+Das ist bewusst so und **nicht** kosmetisch: `sensor.byd_zellspreizung_ruhe` wird in [`packages/opti_derived.yaml`](../packages/opti_derived.yaml) **viermal mit Steuerwirkung** gelesen (Bedarfs-Balancing kann eine Vollladung vorziehen).
+Durch den Carry musste dort **keine Zeile** geändert werden.
+
+> **Zäsur 17.7.2026 in der Zeitreihe von `sensor.byd_zellspreizung_ruhe`:**
+> Die Quelle wechselt von MQTT (`byd_zellspreizung`, aus versetzten Min/Max-Topics gerechnet) auf das native `cells_voltage_delta` (atomarer Read), und das Median-Fenster von 5 auf 3.
+> Die physikalische Größe (Ruhe-Zellspreizung in mV) bleibt dieselbe, deshalb wiegt die Kontinuität für Trends und Konsumenten schwerer als die formale Zäsur.
+> Beim Lesen von Wochen-Trends über dieses Datum hinweg den Bruch mitdenken.
+
+### Ruhe-Spreizung: warum überhaupt noch ein Median
+
+Die **alte** Begründung ist mit Modbus obsolet: die Min/Max-Topics kamen ~60 s versetzt an, ein Einzelwert konnte dadurch verzerrt oder sogar negativ sein.
+Native Reads sind atomar - alle 160 Zellwerte stammen aus einem Detail-Read, das Delta wird integrationsseitig auf demselben Datensatz gerechnet.
+
+Der Median bleibt trotzdem, mit **neuer** Begründung: `sensor.byd_zellspreizung_ruhe` hat Steuerwirkung, und der Alarm hält gelatchte Werte über Stunden.
+Ein einzelnes Sample soll weder eine Vollladung noch einen 1-h-Alarm allein tragen.
+Fenster **3** statt 5 - klein genug, um schnell zu reagieren, groß genug gegen Einzel-Ausreißer.
+
+Gating (gegen Vor-Ruhe-Samples gehärtet):
+
+- **Trigger:** State-Änderung von `..._bms_1_updated` (feuert jeden Detail-Zyklus, auch wenn das Delta numerisch gleich bleibt) und von `..._cells_voltage_delta`.
+- **Bedingung:** `binary_sensor.byd_ruhefenster` seit **≥ 10 min** an, plus `byd_zelldaten_frisch`.
+  Damit ist jedes übernommene Sample innerhalb des Ruhefensters gemessen; Relaxations-Transienten nach Lastende sind draußen, und ein Latch des letzten Lastphasen-Werts ist ausgeschlossen.
+
+Das SoC-Gate 25-85 % bleibt unverändert (LFP-Knie-Inflation, unabhängig vom Skew-Thema).
+
+> **Restrisiko (dokumentiert):** Die Schreib-Reihenfolge von `updated` vs. `delta` innerhalb eines Poll-Zyklus ist nicht garantiert.
+> Im schlimmsten Fall geht ein Sample mit dem Wert des Vorzyklus ein - genau solche Einzelfälle kappt der 3er-Median.
+
+### Zell-Ausreißer (Diagnose)
+
+`sensor.byd_zell_ausreisser` liefert die größte absolute Abweichung einer Einzelzelle vom Median aller 160 Zellen, mit den Attributen `modul` (1-5), `zelle` (**1-32 innerhalb des Moduls**, nicht die globale 1-160-Zählung der nativen `*_number`-Sensoren), `richtung` (`hoch`/`tief`/`keiner`) und `median_mv`.
+
+Das ist die Zell-Identifikation, die dem Spreizungs-Alarm fehlt, plus Langzeit-Trend pro Zelle.
+**Kein eigener Push-Alarm:** `ruhe_spreizung` meldet physikalisch dieselbe Anomalie, ein zweiter Alarm auf derselben Ursache wäre Doppel-Rauschen.
+Revisit nach Wochen: treibt immer dieselbe Zelle das Delta, kann eine gezielte Einzelzell-Regel den Spreizungs-Alarm **ersetzen** statt ergänzen.
+
+## Alarm-Tabelle
+
+Automation `byd_akku_alarme_nativ` (`mode: queued`, `max: 5`).
+Spalte „Frische" = zusätzliche Bedingung auf das jeweilige Frische-Binary.
+
+| Regel-ID | Entity | Schwelle | `for:` | Gating | Frische | Severity |
+|---|---|---|---|---|---|---|
+| `zell_hoch` | `sensor.bmu_cell_voltage_max` | > 3,55 V (eff. ab 3,56) | 2 min | SoC < 90 % | bmu | Push |
+| `zell_kritisch` | `sensor.bmu_cell_voltage_max` | > 3,60 V | 30 s | SoC < 90 % | bmu | Critical |
+| `zell_bms_grenze` | `sensor.bmu_cell_voltage_max` | > 3,65 V | 5 min | - | bmu | Critical |
+| `zell_bms_grenze_praezise` | `..._bms_1_cell_voltage_max` | > 3,65 V (mV-genau) | 21 min | - | zelldaten | Critical |
+| `zell_niedrig` | `..._bmu_cell_voltage_min` | < 2,90 V | 5 min | - | bmu | Push |
+| `temp_hoch` | `..._bmu_cell_temperature_max` | > 45 °C | 5 min | - | bmu | Push |
+| `temp_kritisch` | `..._bmu_cell_temperature_max` | > 50 °C | 1 min | - | bmu | Critical |
+| `temp_delta` | `sensor.byd_temperatur_spreizung` | > 10 K | 15 min | - | bmu | Push |
+| `ruhe_spreizung` | `sensor.byd_zellspreizung_ruhe` | > 50 mV (Median-3) | 1 h | im Sensor | im Sensor | Push |
+| `bms_warnung` | `..._bms_1_warnings` | ≠ Normal/unknown/unavailable | 0 | - | - | **Schattenbetrieb** (nur UI) |
+| `bms_fehler` | `..._bms_1_errors` | ≠ Normal/unknown/unavailable | 0 | - | - | Critical |
+| `bmu_fehler` | `..._battery_management_unit_errors` | ≠ Normal/unknown/unavailable | 0 | - | - | Critical |
+| `verbindung` | `..._connection_health` | → `unhealthy` | 10 min | - | - | Push |
+
+Jeder Alarm stößt wie bisher `script.ki_alarm_kontext` an (`continue_on_error`, existiert nur live).
+
+### SoC-Gating der Zellspannungs-Alarme
+
+Am Ladeschluss (SoC ≥ 90 %, LFP-Knie, Balancing aktiv) laufen Max-Zellspannung und Spreizung kurzzeitig hoch - beobachtet: **3,659 V Peak bei 0 W Ladeleistung**.
+Das ist top-of-charge-normal und würde sonst bei **jeder** Vollladung feuern (der Balancing-Watchdog erzwingt regelmäßige Vollladungen).
+Deshalb gelten `zell_hoch`/`zell_kritisch` nur bei SoC < 90 %; darüber alarmiert nur der Grenzwächter.
+
+### Zweistufiger Grenzwächter
+
+Die 10-mV-Auflösung der schnellen Ebene lässt ein Fenster offen:
+
+- **`zell_bms_grenze`** (BMU, 30 s, `for: 5 min`): fängt eindeutige Überschreitungen ab 3,66 V in Minuten.
+- **`zell_bms_grenze_praezise`** (BMS, 1 mV, `for: 21 min` = 2 bestätigende Detail-Zyklen): fängt anhaltendes **3,651-3,659 V**, das die 10-mV-Ebene gar nicht sieht.
+
+Der normale Kalibrier-Peak (3,659 V, kurz) übersteht **beide** Haltezeiten nicht - die Kalibrierung bleibt ungestört.
+
+### Native warnings/errors
+
+Das BMS meldet dekodierten Klartext (`"Normal"`, wenn nichts anliegt); unbekannte Bits erscheinen als `bit N undefined` und alarmieren mit (fail-visible, 255-Zeichen-Kappung).
+Bewusst **kein `from:`-Filter**: nach einem Restart (`unknown` → aktiver Fehler) muss es feuern.
+Jede String-Änderung (`"A"` → `"A,B"`) feuert erneut - gewollt.
+
+**`bms_warnung` läuft in der Kennenlern-Phase im Schattenbetrieb:** nur `persistent_notification` in der HA-UI, **kein** Mobile-Push.
+Ob das BMS am Ladeschluss/Balancing routinemäßig Warn-Bits setzt (z. B. „Cells imbalance"), ist unbekannt.
+Erst nach **mindestens einer sauberen Vollladung ohne Warn-Rauschen** wird der Push aktiviert - im Package als TODO markiert (`bms_warnung` aus der Schatten-Option entfernen, dann fällt die Regel in den default-Push-Zweig).
+
+Bei `errors` (Hardware-Fehlerbits wie „Main relay failure", „Cells failure") ist ein seltener Fehlalarm das kleinere Übel → sofort Critical.
+
+### Dead-Man-Watchdog
+
+Separate Automation `byd_daten_watchdog`: `time_pattern` alle 30 min, meldet wenn `byd_bmu_frisch` off **oder** `byd_zelldaten_frisch` off **oder** `connection_health` ≠ `healthy` (inkl. unavailable/unknown).
+Drossel: höchstens alle 6 h (Reminder statt Spam, `last_triggered`-basiert; nie gelaufen → `as_timestamp(none, 0)` = 0 → meldet, fail-safe).
+
+Zeitbasiert statt edge-basiert, weil er genau die zwei Fälle abdecken muss, die keinen State-Übergang erzeugen: eingefrorene Werte und den Boot-Setup-Fehlschlag.
+
+`consecutive_failures` wird nicht separat alarmiert (redundant zu `connection_health`), Latenz-Sensoren sind tabu (Einheiten-Bug).
+
+## Bekannte Restrisiken
+
+- **`numeric_state`-Nachfeuer-Schwäche:** Ist die Schwelle bereits überschritten und wird erst danach das Gate wahr (oder lädt HA neu, wodurch `for:`-Timer verworfen werden), feuert der Trigger nicht nach.
+  War im alten Design identisch, bleibt ein akzeptiertes Restrisiko.
+  Option für später: den Watchdog um Schwellen-Checks erweitern.
+- **Watchdog-Latenz:** Detail-Staleness wird schlimmstenfalls erst nach ~30-55 min gemeldet (25-min-Fenster + 30-min-Raster).
+  Für reine Zelldaten akzeptabel, weil alle zeitkritischen Alarme auf der BMU-Ebene mit 3-min-Frische laufen.
+- **Modul-Identifikation im Temperatur-Alarm** ist best-effort aus `cell_temps` und damit bis zu 10,5 min alt (im Alarmtext gekennzeichnet).
+  Bewusster Trade-off für 30-s-Alarm-Latenz statt 10,5 min.
+- **BMU- vs. BMS-SoC** können ~1 % divergieren; für die 90-%- und 25-85-%-Gates egal.
+- Die Integration ist ein **0.1.x-Fork mit 3 Stars**. Mittelfristig sinnvoll: `ConfigEntryNotReady`-Issue beim Fork melden (Setup-Retry).
+
+## Bewusste Auslassungen
+
+- Kein Einzelzell-Push-Alarm (der Diagnose-Sensor reicht, siehe oben).
+- Kein Balancing-Bit-Mapping auf Zellen (16 Bit vs. 32 Zellen, Zuordnung unklar - nur Zählwert).
+- Keine Tieftemperatur-Regel (< 5 °C): Innenaufstellung, das BMS schützt; bei Bedarf im Winter nachrüsten.
+- Keine Alarme auf `_history`-Daten (Datenqualität) und keine Latenz-Alarme (Einheiten-Bug).
+- Keine Auto-Clear-/Entwarnungs-Pushes (ein Alarm ist eine Handlungsaufforderung, kein Zustandskanal).
+- SoH-/Kapazitäts-Trending bleibt beim `opti_capacity`-Vorhaben bzw. Phase 2.
+
+## Interpretations-Hinweise (LFP)
+
+- Die Zellspreizung ist nur im Ruhezustand und im flachen Kennlinienbereich (ca. 25-85 % SoC) über die Zeit vergleichbar.
+  Am Ladeschluss und am unteren Knie läuft sie kennlinienbedingt hoch (beobachtet: 292 mV bei SoC 99 %, 34-38 mV bei SoC ~17 %, 1-4 mV bei Mittel-SoC) - das ist kein Balancing-Befund.
+- SoH-Änderungen von Tag zu Tag sind Rauschen - nur der Langzeittrend zählt.
+- Das Verhältnis der kWh-Lebenszähler ist KEIN Wirkungsgrad (Standby- und Wandlungsverluste stecken mit drin).
+- Die Alarm-Startwerte sind keine Herstellerangaben.
+  Die BMS-Schutzgrenzen (2,75/3,65 V) sind Notgrenzen, keine Automationsziele - die Alarme liegen bewusst davor.
+
+## Cutover- und Rollback-Protokoll
+
+Der Live-Cutover ist **atomar in einem Restart** zu fahren.
+Grund: alte und neue Definition teilen sich zwei unique_ids - gleichzeitig aktiv erzeugt HA `_2`-Suffixe an den entity_ids, und `sensor.byd_zellspreizung_ruhe` hat Steuerwirkung.
+
+**Vorher notieren** (die Frühwarnung geht mit dem Cutover formell außer Betrieb, ihre Helfer tragen den Trend-Zustand):
+
+- `input_number.byd_knie_referenzspannung`
+- `input_number.byd_knie_ref_frozen`
+- `input_select.byd_knie_zyklus_status`
+
+**Cutover:**
+
+1. `packages/byd_monitoring.yaml` nach `/config/packages/` kopieren, `notify.notify` durch den echten Mobile-App-Service ersetzen.
+2. Gleichzeitig `byd_bmu.yaml` und `byd_modul2_fruehwarnung.yaml` nach `.bak-nativcutover-20260717` umbenennen.
+3. `/config/automations.yaml` auf verbliebene `byd`-Referenzen prüfen.
+4. HA neu starten.
+
+**Verifikation:** keine `_2`-Entities, Frische-Binaries `on`, beide Automationen geladen, Log sauber.
+
+**Rollback:** Dateien zurücktauschen und den `bydlogc`-Container wieder starten.
+
+**Danach (Abbau-PR nach mehreren Beobachtungstagen):** `legacy/`, `tests/test_byd_bmu.py` und die Doku-Reste löschen, live die `.bak`-Dateien und die MQTT-Registry-Leichen (UI) entfernen.
+
+## Phase 2: Modul-Frühwarnung neu bauen
+
+Die Modul-2-Frühwarnung ([byd-modul2-fruehwarnung.md](byd-modul2-fruehwarnung.md)) ist bewusst **nicht** Teil dieses Umbaus: die Alarm-Lücke war akut, die Frühwarnung ist Trend-Monitoring.
+Ehrlich benannt: sie ist seit dem bydlogc-Stopp am 17.7. ohnehin funktionslos, der Cutover macht das nur formell.
+Damit kein schleichender Feature-Verlust entsteht, ist der Neubau fest für die nächsten 1-2 Wochen eingeplant (vor der nächsten Referenzdaten-Kampagne).
+
+Skizze:
+
+- **Metrik A präziser:** schwächste Zelle von Modul 2 gegen den Median aller 160 Zellen (aus `cell_voltages`), im Entladeband - identifiziert zusätzlich, ob es noch Zelle 23 ist.
+- **Metrik B (Netto-kWh bis Knie):** Zustandsmaschine portierbar; `utility_meter` auf `sensor.bms_1_charge_total_energy`/`_discharge_total_energy`, Leistung `sensor.bmu_power` (Vorzeichen identisch).
+  Das Modul-Minimum kommt per Template aus dem Attribut (10,5-min-Kadenz), der Knie-Latch braucht deshalb eine Zelldaten-Frische-Bedingung **und** eine Haltezeit ≥ 21 min (2 bestätigende Zyklen - `for:` allein zählt keine Samples).
+
+## Tests
+
+`tests/test_byd_monitoring.py` deckt den Template-Layer ab: Ruhefenster-Grenzen, Frische-Binaries (mit injiziertem `now`), Median-3-Verhalten über mehrere Trigger-Zyklen, Temperatur-Spreizung, Zell-Ausreißer gegen ein realistisches 5x32-Fixture, Balancing-Binary und die beiden unique_id-Carries.
+
+**Grenze der Harness (bewusst):** sie rendert nur Jinja-Templates aus dem YAML.
+Die Trigger-/`for:`-Semantik von HA ist damit **nicht** testbar - weder „eingefrorene Werte erfüllen `for:` per Stagnation" noch das Verwerfen von `for:`-Timern beim Reload noch der Gate-Wechsel nach Schwellen-Überschreitung.
+Genau für diese Klasse existieren die Frische-Bedingungen, der Watchdog und der E2E-Livetest.
+
+### E2E-Livetest (Protokoll nach `docs/`)
+
+- **Push-Pfad:** `automation.trigger` für den normalen und den Critical-Kanal.
+- **Staleness echt:** Modbus zur BMU blockieren (Route/Firewall) → `verbindung`-Alarm + Frische-Binaries kippen.
+  Danach die Integration einmal reloaden **und einen HA-Neustart mit blockierter BMU durchspielen** → der Watchdog muss den Boot-Setup-Fehlschlag melden.
+  Das ist der Fork-Issue-Pfad; ein Reload allein testet ihn nicht.
+- **Negativ-Test:** nächste Vollladung beobachten → **kein** Alarm; `bms_warnung`-Verhalten am Ladeschluss dokumentieren (entscheidet über die Push-Aktivierung der warnings).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -77,8 +77,7 @@ kopieren und alle `DEIN_*`-Platzhalter durch echte Entitäts-IDs ersetzen.
 | `sma_templates.yaml` | **optional** - nur für Sollkurve-/Abregelungs-Anzeige (Legacy), enthält Platzhalter-Entity-IDs: ersetzen oder ganz weglassen |
 | `sma_statistik.yaml` | gleitende Mittelwerte (Verbrauch, Batterielast) |
 | `opti_ki_analyse.yaml` | **optional** - täglicher KI-Tagesreport per `ai_task.generate_data`, rein lesend; Details siehe [docs/canonical-layer.md](canonical-layer.md#ki-analyse-schicht-optional-phase-1) |
-| `byd_bmu.yaml` | **optional** - BYD-Zell-Monitoring (Spreizung, Temperaturen, Balancing) via bydlogc→MQTT; braucht das BYD-Logger-Tool in Docker/VM, einen MQTT-Broker und ggf. eine Route/SNAT-Regel zur Box → **[docs/byd-bmu-monitoring.md](byd-bmu-monitoring.md)** |
-| `byd_modul2_fruehwarnung.yaml` | **optional** - Degradations-Frühwarnung fürs schwächste BYD-Modul (Absackung + Nettoenergie-bis-Knie), setzt `byd_bmu.yaml` voraus → **[docs/byd-modul2-fruehwarnung.md](byd-modul2-fruehwarnung.md)** |
+| `byd_monitoring.yaml` | **optional** - BYD-Zell-Monitoring + Akku-Alarme (Spreizung, Temperaturen, Balancing, native Fehlerbits, Daten-Watchdog); braucht die HACS-Integration [`byd_battery_box`](https://github.com/TimWeyand/byd_battery_box) und eine Route/SNAT-Regel zur Box → **[docs/byd-monitoring-nativ.md](byd-monitoring-nativ.md)** |
 | `opti_ev_sperre.yaml` | **optional** - EV-Schnelllade-Entladesperre (evcc im Modus now/minpv); braucht HACS `evcc_intg` + Ladepunkt-Block im Mapping → [docs/strategie-logik.md](strategie-logik.md) (Option 13) |
 
 **4. Home Assistant neu starten** → Helfer, Templates, Statistik & Modbus sind da.

--- a/legacy/byd_bmu.yaml
+++ b/legacy/byd_bmu.yaml
@@ -1,4 +1,26 @@
 # =============================================================================
+# +++ DEPRECATED (17.7.2026) - NICHT MEHR EINBAUEN +++
+# -----------------------------------------------------------------------------
+# Abgeloest durch packages/byd_monitoring.yaml (Datenquelle: Integration
+# byd_battery_box, Modbus nativ statt bydlogc + MQTT).
+# Doku: docs/byd-monitoring-nativ.md
+#
+# Diese Datei liegt nur noch fuer die Beobachtungsphase / einen Rollback hier
+# und wird im Abbau-PR geloescht.
+#
+# ACHTUNG - NICHT PARALLEL zu packages/byd_monitoring.yaml betreiben: beide
+# definieren dieselben unique_ids (byd_bmu_zellspreizung_ruhe_mv,
+# byd_bmu_temp_spreizung_k). Gleichzeitig aktiv erzeugt HA _2-Suffixe an den
+# entity_ids - und sensor.byd_zellspreizung_ruhe hat STEUERWIRKUNG
+# (Bedarfs-Balancing in packages/opti_derived.yaml kann eine Vollladung
+# ausloesen). Deshalb liegt diese Datei ausserhalb von packages/.
+#
+# byd_modul2_fruehwarnung.yaml (ebenfalls in legacy/) baut auf diesem Package
+# auf und ist seit dem bydlogc-Stopp am 17.7. funktionslos; ihr Neubau auf die
+# nativen Zelldaten ist als Phase 2 eingeplant.
+# =============================================================================
+
+# =============================================================================
 # BYD Battery-Box BMU-Monitoring via bydlogc + MQTT (OPTIONAL)
 # -----------------------------------------------------------------------------
 # Quelle: BYD-Logger cmdline (bydlogc, "olli" im Photovoltaikforum) laeuft als
@@ -314,7 +336,7 @@ mqtt:
       expire_after: 300
 
     # ---- Schwaechste/staerkste Zell-Nummer je Modul (MinVoltID/MaxVoltID) ----
-    # Von der Modul-2-Fruehwarnung (packages/byd_modul2_fruehwarnung.yaml) als
+    # Von der Modul-2-Fruehwarnung (legacy/byd_modul2_fruehwarnung.yaml) als
     # Attribut referenziert; auch solo nuetzlich, um zu sehen, ob immer DIESELBE
     # Zelle das Modul-Minimum stellt (Zell-Problem) oder es wandert (Streuung).
     - name: "BYD Modul 1 Min-Zell-ID"

--- a/legacy/byd_modul2_fruehwarnung.yaml
+++ b/legacy/byd_modul2_fruehwarnung.yaml
@@ -1,5 +1,27 @@
 # =============================================================================
-# BYD Modul-2 Fruehwarnung (OPTIONAL, setzt packages/byd_bmu.yaml voraus)
+# +++ DEPRECATED (17.7.2026) - NICHT MEHR EINBAUEN +++
+# -----------------------------------------------------------------------------
+# Diese Fruehwarnung haengt komplett an den MQTT-Sensoren aus legacy/byd_bmu.yaml
+# (sensor.byd_soc, byd_leistung, byd_modul_*_zellspannung_min, ...) und ist seit
+# dem bydlogc-Stopp am 17.7.2026 funktionslos - der Cutover auf die native
+# Modbus-Integration (packages/byd_monitoring.yaml) macht das nur noch formell.
+#
+# Der Neubau auf die nativen Zelldaten ist als PHASE 2 fest eingeplant
+# (Skizze: docs/byd-monitoring-nativ.md, Abschnitt "Phase 2"):
+#   - Metrik A praeziser: schwaechste Zelle von Modul 2 gegen den Median aller
+#     160 Zellen (Attribut cell_voltages) statt gegen den Peer-Median.
+#   - Metrik B portierbar: utility_meter auf sensor.bms_1_charge_total_energy /
+#     _discharge_total_energy, Leistung sensor.bmu_power (Vorzeichen identisch);
+#     der Knie-Latch braucht dann eine Zelldaten-Frische-Bedingung und eine
+#     Haltezeit >= 21 min (2 bestaetigende Detail-Zyklen).
+#
+# VOR dem Loeschen im Abbau-PR: die Helfer-Werte notieren (Cutover-Protokoll) -
+# input_number.byd_knie_referenzspannung, byd_knie_ref_frozen und
+# input_select.byd_knie_zyklus_status tragen den bisherigen Trend-Zustand.
+# =============================================================================
+
+# =============================================================================
+# BYD Modul-2 Fruehwarnung (OPTIONAL, setzt legacy/byd_bmu.yaml voraus)
 # -----------------------------------------------------------------------------
 # Beobachtet das schwaechste Modul des Turms (hier: Modul 2 mit Zelle 23) auf
 # schleichende Degradation - rein beobachtend, KEINE Steuerwirkung.
@@ -16,7 +38,7 @@
 #   idle -> armed (Voll-Anker nach Ladeschluss) -> latched (Knie erreicht,
 #   Snapshot) bzw. invalid (Messqualitaet unzureichend).
 #
-# Referenzierte Roh-Entitaeten (alle aus packages/byd_bmu.yaml):
+# Referenzierte Roh-Entitaeten (alle aus legacy/byd_bmu.yaml):
 #   sensor.byd_soc / byd_leistung / byd_zellspannung_max /
 #   byd_modul_1..5_zellspannung_min / byd_modul_2_min_zell_id /
 #   byd_modul_2_max_zell_id / byd_modul_2_temp_max /

--- a/packages/byd_monitoring.yaml
+++ b/packages/byd_monitoring.yaml
@@ -82,11 +82,22 @@ template:
       # Ruhewerten nicht vergleichbar (beobachtet: 292 mV bei SoC 99 %,
       # 34-38 mV bei SoC ~17 %, 1-4 mV bei Mittel-SoC).
       # Fehlende Werte -> off (kein Sample statt falschem Sample).
+      #
+      # FRISCHE-BEDINGUNG (Driver-Haertung 17.7., ueber den Plan hinaus):
+      # Die Quellen dieses Gates (bmu_power, SoC) liegen auf der BMU-Ebene
+      # (30-s-Poll), der Ruhe-Sensor triggert aber auf BMS-Zyklen (~630 s).
+      # Faellt NUR der BMU-Poll aus, frieren power/SoC ein und ein stale
+      # "0 W / 53 %" haelt das Fenster offen - der Ruhe-Sensor wuerde dann ein
+      # frisches Delta UNTER LAST als Ruhewert latchen. Das traegt Steuerwirkung
+      # (Bedarfs-Balancing kann eine Vollladung vorziehen) und den 1-h-Alarm.
+      # Entities werden bei Modbus-Abbruch nie unavailable (s. Kopf), deshalb
+      # reicht has_value hier NICHT - es braucht das Frische-Binary.
       - unique_id: byd_ruhefenster
         name: "BYD Ruhefenster"
         icon: mdi:sleep
         state: >
-          {{ has_value('sensor.bmu_power')
+          {{ is_state('binary_sensor.byd_bmu_frisch', 'on')
+             and has_value('sensor.bmu_power')
              and has_value('sensor.battery_management_unit_state_of_charge')
              and (states('sensor.bmu_power')|float(9999))|abs < 300
              and 25 < states('sensor.battery_management_unit_state_of_charge')|float(-1) < 85 }}

--- a/packages/byd_monitoring.yaml
+++ b/packages/byd_monitoring.yaml
@@ -1,0 +1,636 @@
+# =============================================================================
+# BYD Battery-Box Monitoring + Alarme (nativ ueber Modbus)
+# -----------------------------------------------------------------------------
+# Loest das alte bydlogc-/MQTT-Package (legacy/byd_bmu.yaml) ab. Datenquelle ist
+# jetzt die HACS-Integration "byd_battery_box" (Fork TimWeyand/byd_battery_box
+# v0.1.34, Commit 2cc5762), die die BMU direkt per Modbus liest. Rein
+# beobachtend/alarmierend - KEINE Steuerlogik.
+# Doku: docs/byd-monitoring-nativ.md (gepinnter Entity-Vertrag!)
+#
+# ---------------------------------------------------------------------------
+# KADENZ + AUFLOESUNG (die zwei Datenebenen der Integration)
+# ---------------------------------------------------------------------------
+# | Ebene | Entities                              | Kadenz | Aufloesung       |
+# |-------|---------------------------------------|--------|------------------|
+# | BMU   | sensor.bmu_*, battery_management_unit_*| 30 s  | 10 mV / 1 C / ~2 W|
+# | BMS   | ..._bms_1_*, sensor.bms_1_*           | ~630 s | 1 mV             |
+#
+# Grundprinzip 1: alle ZEITKRITISCHEN Alarme laufen auf der 30-s-BMU-Ebene.
+# Die 10,5-min-BMS-Ebene traegt Spreizung, Diagnose und den mV-genauen
+# Grenzwaechter-Backstop.
+#
+# Grundprinzip 2 (DIE zentrale Randbedingung): die Integration setzt Entities
+# bei Modbus-Abbruch NIE auf unavailable - hub.data friert einfach ein. Ein
+# eingefrorener Wert erfuellt jede for:-Haltezeit per Stagnation. Deshalb prueft
+# jeder physikalische Alarm zusaetzlich ein Frische-Binary (byd_bmu_frisch /
+# byd_zelldaten_frisch); for: allein beweist keine frischen Samples.
+#
+# ---------------------------------------------------------------------------
+# ENTITY-NAMENS-FALLE (live verifiziert 17.7., nicht "aufraeumen"!)
+# ---------------------------------------------------------------------------
+# Die Integration vergibt die entity_ids asymmetrisch - max und min heissen
+# NICHT gleich aufgebaut:
+#   sensor.bmu_cell_voltage_max                        (kurz!)
+#   sensor.battery_management_unit_bmu_cell_voltage_min (lang!)
+#   sensor.bmu_power                                   (kurz)
+#   sensor.battery_management_unit_state_of_charge     (lang)
+# Ebenso auf der BMS-Ebene: sensor.battery_management_system_1_bms_1_* neben
+# sensor.bms_1_*. Alle hier verwendeten IDs sind live gegengeprueft.
+#
+# ---------------------------------------------------------------------------
+# VORZEICHEN / TIMESTAMPS
+# ---------------------------------------------------------------------------
+# - sensor.bmu_power: NEGATIV = Laden (gleiche Konvention wie das alte
+#   sensor.byd_leistung).
+# - Die *_updated-Sensoren liefern einen NAIVEN Lokalzeit-String
+#   ("2026-07-17 11:45:34.207325"). as_timestamp(states(...), 0) interpretiert
+#   ihn korrekt als Lokalzeit -> now().timestamp() - as_timestamp(...) = Alter
+#   in Sekunden. Bei Muell/unavailable liefert as_timestamp(x, 0) = 0 -> Alter
+#   riesig -> "nicht frisch". Das ist die gewuenschte Fail-Safe-Richtung.
+#   KEIN as_datetime/TZ-Umbau noetig (live verifiziert 17.7.).
+#
+# ---------------------------------------------------------------------------
+# BEKANNTE INTEGRATIONS-MAENGEL (bewusst gemieden)
+# ---------------------------------------------------------------------------
+# - average_latency/last_latency: Einheiten-Bug (Sekunden gemessen, als ms
+#   deklariert) -> NICHT fuer Alarme verwenden.
+# - cell_voltages_max_history/_min_history und sensor.bms_1_max/min_history_-
+#   cell_voltage: zeigen ueberlappende, zwischen den Modulen verschobene
+#   Wertereihen (Sliding-Window-Artefakt) -> NICHT verwenden.
+# - Setup-Fehlschlag nach HA-Neustart ohne Retry (Fork-Issues #14/#15): die
+#   Entities starten dann unavailable OHNE State-Uebergang, edge-Trigger feuern
+#   nie -> dafuer gibt es den zeitbasierten Dead-Man-Watchdog unten.
+#
+# ---------------------------------------------------------------------------
+# LIVE-ABWEICHUNGEN (dokumentiert, wandern beim Deploy mit)
+# ---------------------------------------------------------------------------
+# - notify.notify wird live durch den echten Mobile-App-Service ersetzt
+#   (kein Geraetename im oeffentlichen Repo).
+# - script.ki_alarm_kontext (KI-Lagebild) existiert nur live - der Aufruf ist
+#   mit continue_on_error abgesichert.
+# =============================================================================
+
+template:
+  # ---------------------------------------------------------------------------
+  # Zustandslose Binaries + Spreizungen (zeitgesteuert reevaluiert)
+  # ---------------------------------------------------------------------------
+  - binary_sensor:
+      # Gate fuer die Ruhe-Sensoren: Akku (nahezu) lastfrei UND SoC im flachen
+      # Teil der LFP-Kennlinie. Unter Last verzerren Innenwiderstands-
+      # Unterschiede die Spreizung, an den Kennlinien-Knien (Ladeschluss /
+      # Tiefentladung) laeuft sie kennlinienbedingt hoch - beides ist mit
+      # Ruhewerten nicht vergleichbar (beobachtet: 292 mV bei SoC 99 %,
+      # 34-38 mV bei SoC ~17 %, 1-4 mV bei Mittel-SoC).
+      # Fehlende Werte -> off (kein Sample statt falschem Sample).
+      - unique_id: byd_ruhefenster
+        name: "BYD Ruhefenster"
+        icon: mdi:sleep
+        state: >
+          {{ has_value('sensor.bmu_power')
+             and has_value('sensor.battery_management_unit_state_of_charge')
+             and (states('sensor.bmu_power')|float(9999))|abs < 300
+             and 25 < states('sensor.battery_management_unit_state_of_charge')|float(-1) < 85 }}
+
+      # Frische-Binary BMU (Poll 30 s): 3 min = 6 verpasste Polls.
+      # Bedingung in ALLEN BMU-basierten Alarmen - ein eingefrorener 3,66-V-Wert
+      # kann so keinen Fehlalarm per Stagnation ausloesen.
+      - unique_id: byd_bmu_frisch
+        name: "BYD BMU-Daten frisch"
+        icon: mdi:clock-check-outline
+        state: >
+          {{ (now().timestamp()
+              - as_timestamp(states('sensor.battery_management_unit_updated'), 0)) < 180 }}
+
+      # Frische-Binary BMS-Detail (Poll ~630 s): 25 min = 2 verpasste Zyklen
+      # plus Marge. Bedingung fuer die praezise BMS-Grenzregel und die
+      # Ruhe-/Diagnose-Sensoren.
+      - unique_id: byd_zelldaten_frisch
+        name: "BYD Zelldaten frisch"
+        icon: mdi:clock-check-outline
+        state: >
+          {{ (now().timestamp()
+              - as_timestamp(states('sensor.battery_management_system_1_bms_1_updated'), 0)) < 1500 }}
+
+      # history_stats-Quelle fuer die KI-Analyse (braucht on/off, keinen
+      # Zaehlwert). Der native Sensor zaehlt die aktuell balancierenden Zellen.
+      - unique_id: byd_balancing_aktiv_nativ
+        name: "BYD Balancing aktiv"
+        icon: mdi:scale-balance
+        availability: "{{ has_value('sensor.bms_1_cells_balancing') }}"
+        state: "{{ states('sensor.bms_1_cells_balancing')|int(0) > 0 }}"
+
+  - sensor:
+      # Temperatur-Spreizung ueber den Turm (max - min aus EINEM BMU-Poll, 30 s).
+      # Dauerhaft >10 K = ein Modul weicht ab (Kuehlung/Kontakt/Zelle pruefen).
+      # Carry der unique_id aus legacy/byd_bmu.yaml -> entity_id
+      # sensor.byd_temperatur_spreizung bleibt registry- und historienstabil.
+      # Anders als frueher kommen max/min aus demselben atomaren Modbus-Read,
+      # die Negativ-Klemme ist damit nur noch Verteidigung gegen Grenzfaelle.
+      - unique_id: byd_bmu_temp_spreizung_k
+        name: "BYD Temperatur-Spreizung"
+        unit_of_measurement: "K"
+        state_class: measurement
+        icon: mdi:thermometer-alert
+        availability: >
+          {{ has_value('sensor.battery_management_unit_bmu_cell_temperature_max')
+             and has_value('sensor.battery_management_unit_bmu_cell_temperature_min') }}
+        state: >
+          {% set tmax = states('sensor.battery_management_unit_bmu_cell_temperature_max')|float(0) %}
+          {% set tmin = states('sensor.battery_management_unit_bmu_cell_temperature_min')|float(0) %}
+          {{ [0, (tmax - tmin) | round(0)] | max }}
+
+  # ---------------------------------------------------------------------------
+  # Ruhe-Spreizung + Zell-Ausreisser: nur echte, im Ruhefenster gemessene
+  # BMS-Detail-Zyklen kommen rein.
+  #
+  # Trigger auf bms_1_updated (feuert JEDEN Detail-Zyklus, auch wenn das Delta
+  # numerisch gleich bleibt) UND auf das Delta selbst.
+  # Gate: Ruhefenster muss seit >= 10 min an sein - damit ist jedes uebernommene
+  # Sample innerhalb des Ruhefensters gemessen und Relaxations-Transienten nach
+  # Lastende sind draussen (ein Latch des letzten Lastphasen-Werts ist damit
+  # ausgeschlossen, weil nur frisch gepollte Zyklen im gehaltenen Fenster
+  # durchkommen).
+  #
+  # Median-3 statt Rohwert: sensor.byd_zellspreizung_ruhe hat STEUERWIRKUNG
+  # (Bedarfs-Balancing in opti_derived kann eine Vollladung vorziehen) und der
+  # Alarm haelt gelatchte Werte ueber Stunden. Ein einzelnes Sample soll weder
+  # eine Vollladung noch einen 1-h-Alarm allein tragen.
+  # (Die alte Median-5-Begruendung - MQTT-Min/Max ~60 s versetzt - ist mit
+  # atomaren Modbus-Reads obsolet; der kleinere Median-3 bleibt als
+  # Einzel-Sample-Robustheit fuer die Steuer-Konsumenten.)
+  #
+  # Restrisiko (dokumentiert): die Schreib-Reihenfolge updated vs. delta
+  # innerhalb eines Poll-Zyklus ist nicht garantiert; im schlimmsten Fall geht
+  # ein Sample mit dem Wert des Vorzyklus ein. Der 3er-Median kappt genau
+  # solche Einzelfaelle.
+  # ---------------------------------------------------------------------------
+  - triggers:
+      - trigger: state
+        entity_id: sensor.battery_management_system_1_bms_1_updated
+      - trigger: state
+        entity_id: sensor.battery_management_system_1_bms_1_cells_voltage_delta
+    conditions:
+      - condition: state
+        entity_id: binary_sensor.byd_ruhefenster
+        state: "on"
+        for: "00:10:00"
+      - condition: state
+        entity_id: binary_sensor.byd_zelldaten_frisch
+        state: "on"
+      - condition: template
+        value_template: "{{ has_value('sensor.battery_management_system_1_bms_1_cells_voltage_delta') }}"
+    sensor:
+      # Carry der unique_id aus legacy/byd_bmu.yaml -> entity_id
+      # sensor.byd_zellspreizung_ruhe bleibt stabil (Konsumenten: opti_derived
+      # Bedarfs-Balancing, KI-Analyse, ruhe_spreizung-Alarm).
+      # Zaesur 17.7.: Quelle MQTT->Modbus, Median-5->Median-3 (docs/).
+      - unique_id: byd_bmu_zellspreizung_ruhe_mv
+        name: "BYD Zellspreizung Ruhe"
+        unit_of_measurement: "mV"
+        state_class: measurement
+        icon: mdi:arrow-collapse-vertical
+        state: >
+          {% set reihe = (this.attributes.get('messreihe') or [])[-2:]
+             + [states('sensor.battery_management_system_1_bms_1_cells_voltage_delta')|float(0)] %}
+          {{ reihe | median | round(0) }}
+        attributes:
+          # Rollierende Messreihe der letzten 3 Gate-Messungen (Median-Basis).
+          messreihe: >
+            {{ (this.attributes.get('messreihe') or [])[-2:]
+               + [states('sensor.battery_management_system_1_bms_1_cells_voltage_delta')|float(0)] }}
+          soc: "{{ states('sensor.battery_management_unit_state_of_charge') }}"
+          leistung_w: "{{ states('sensor.bmu_power') }}"
+          gemessen: "{{ now().isoformat() }}"
+
+      # Diagnose (KEIN Alarm): groesste absolute Abweichung einer Einzelzelle
+      # vom Median aller 160 Zellen, plus Zell-Identifikation - genau das, was
+      # dem Spreizungs-Alarm fehlt. Kein eigener Push, weil ruhe_spreizung
+      # physikalisch dieselbe Anomalie meldet (Doppel-Rauschen vermeiden);
+      # Revisit nach Wochen: treibt IMMER dieselbe Zelle das Delta, kann eine
+      # gezielte Einzelzell-Regel den Spreizungs-Alarm ersetzen.
+      # Attribut zelle = Nummer 1..32 INNERHALB des Moduls (nicht die globale
+      # 1..160-Zaehlung der nativen *_number-Sensoren).
+      - unique_id: byd_zell_ausreisser
+        name: "BYD Zell-Ausreisser"
+        unit_of_measurement: "mV"
+        state_class: measurement
+        icon: mdi:battery-alert-variant-outline
+        availability: >
+          {{ state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') is not none }}
+        state: >
+          {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+          {% set alle = namespace(v=[]) %}
+          {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+          {% set med = alle.v | median %}
+          {% set ns = namespace(max_abw=0.0) %}
+          {% for wert in alle.v %}
+            {% if (wert - med) | abs > ns.max_abw %}{% set ns.max_abw = (wert - med) | abs %}{% endif %}
+          {% endfor %}
+          {{ ns.max_abw | round(1) }}
+        attributes:
+          modul: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set alle = namespace(v=[]) %}
+            {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+            {% set med = alle.v | median %}
+            {% set ns = namespace(max_abw=0.0, modul=0) %}
+            {% for modul in daten %}
+              {% for wert in modul['v'] %}
+                {% if (wert - med) | abs > ns.max_abw %}
+                  {% set ns.max_abw = (wert - med) | abs %}
+                  {% set ns.modul = modul['m'] %}
+                {% endif %}
+              {% endfor %}
+            {% endfor %}
+            {{ ns.modul }}
+          zelle: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set alle = namespace(v=[]) %}
+            {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+            {% set med = alle.v | median %}
+            {% set ns = namespace(max_abw=0.0, zelle=0) %}
+            {% for modul in daten %}
+              {% for wert in modul['v'] %}
+                {% if (wert - med) | abs > ns.max_abw %}
+                  {% set ns.max_abw = (wert - med) | abs %}
+                  {% set ns.zelle = loop.index %}
+                {% endif %}
+              {% endfor %}
+            {% endfor %}
+            {{ ns.zelle }}
+          richtung: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set alle = namespace(v=[]) %}
+            {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+            {% set med = alle.v | median %}
+            {% set ns = namespace(max_abw=0.0, richtung='keiner') %}
+            {% for wert in alle.v %}
+              {% if (wert - med) | abs > ns.max_abw %}
+                {% set ns.max_abw = (wert - med) | abs %}
+                {% set ns.richtung = 'hoch' if wert > med else 'tief' %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.richtung }}
+          median_mv: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set alle = namespace(v=[]) %}
+            {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+            {{ alle.v | median }}
+
+# ---------------------------------------------------------------------------
+# Alarme: deterministische Gesundheits-Alarme aus den nativen Modbus-Daten.
+# Schwellen liegen bewusst VOR den BMS-Schutzgrenzen (2,75/3,65 V).
+#
+# SoC-Gating (Befund 2026-07-11): Am Ladeschluss (SoC >= 90 %, LFP-Kennlinien-
+# Knie, Balancing aktiv) laufen Max-Zellspannung und Spreizung kurzzeitig hoch
+# (beobachtet: 3,659 V Peak bei 0 W Ladeleistung) - das ist top-of-charge-
+# normal und feuert sonst bei JEDER Vollladung (der Balancing-Watchdog
+# erzwingt regelmaessige Vollladungen). Deshalb gelten zell_hoch/zell_kritisch
+# nur bei SoC < 90 %; bei hohem SoC alarmiert nur der Grenzwaechter.
+#
+# Grenzwaechter ZWEISTUFIG (die 10-mV-Aufloesung der BMU-Ebene verschiebt das
+# effektive Ausloesen um max. 10 mV nach oben):
+#   - zell_bms_grenze (schnell, BMU 30 s): faengt eindeutige Ueberschreitungen
+#     ab 3,66 V in Minuten.
+#   - zell_bms_grenze_praezise (BMS, 1 mV): faengt anhaltendes 3,651-3,659 V,
+#     das die 10-mV-Ebene gar nicht sieht. for: 21 min = 2 Detail-Zyklen
+#     muessen bestaetigen.
+# Der normale Kalibrier-Peak (3,659 V, kurz) uebersteht beide Haltezeiten
+# nicht - die Kalibrierung bleibt ungestoert.
+#
+# Bekannte, bewusst uebernommene Alt-Schwaeche: numeric_state-Trigger feuern
+# nicht nach, wenn die Schwelle schon ueberschritten ist und erst danach das
+# Gate wahr wird oder HA neu laedt (for:-Timer werden verworfen). War im alten
+# Design identisch; der Watchdog deckt die Staleness-Klasse ab, fuer die
+# physikalischen Regeln bleibt es ein akzeptiertes Restrisiko.
+# ---------------------------------------------------------------------------
+automation:
+  - id: byd_akku_alarme_nativ
+    alias: "BYD | Akku-Alarme (nativ)"
+    description: >-
+      Deterministische Alarme aus den nativen BMU/BMS-Modbus-Daten: Zellspannung
+      absolut (SoC-gegated, plus zweistufiger BMS-Grenzwaechter), Zelltemperatur,
+      Temperatur-Spreizung, persistierende Ruhe-Spreizung, native BMS/BMU-
+      Fehlerbits und Verbindungsverlust. Jeder physikalische Alarm prueft
+      zusaetzlich die Frische seiner Datenquelle (eingefrorene Werte alarmieren
+      sonst per Stagnation). Schwellen liegen VOR den BMS-Schutzgrenzen.
+    mode: queued
+    max: 5
+    triggers:
+      - trigger: numeric_state
+        id: zell_hoch
+        entity_id: sensor.bmu_cell_voltage_max
+        above: 3.55
+        for: "00:02:00"
+      - trigger: numeric_state
+        id: zell_kritisch
+        entity_id: sensor.bmu_cell_voltage_max
+        above: 3.6
+        for: "00:00:30"
+      - trigger: numeric_state
+        id: zell_bms_grenze
+        entity_id: sensor.bmu_cell_voltage_max
+        above: 3.65
+        for: "00:05:00"
+      - trigger: numeric_state
+        id: zell_bms_grenze_praezise
+        entity_id: sensor.battery_management_system_1_bms_1_cell_voltage_max
+        above: 3.65
+        for: "00:21:00"
+      - trigger: numeric_state
+        id: zell_niedrig
+        entity_id: sensor.battery_management_unit_bmu_cell_voltage_min
+        below: 2.9
+        for: "00:05:00"
+      - trigger: numeric_state
+        id: temp_hoch
+        entity_id: sensor.battery_management_unit_bmu_cell_temperature_max
+        above: 45
+        for: "00:05:00"
+      - trigger: numeric_state
+        id: temp_kritisch
+        entity_id: sensor.battery_management_unit_bmu_cell_temperature_max
+        above: 50
+        for: "00:01:00"
+      - trigger: numeric_state
+        id: temp_delta
+        entity_id: sensor.byd_temperatur_spreizung
+        above: 10
+        for: "00:15:00"
+      - trigger: numeric_state
+        id: ruhe_spreizung
+        entity_id: sensor.byd_zellspreizung_ruhe
+        above: 50
+        for: "01:00:00"
+      # Native Fehler-/Warnbits: State-String, "Normal" wenn nichts anliegt.
+      # Die Bitmaske wird integrationsseitig zu kommaseparierten Klartexten
+      # dekodiert; unbekannte Bits erscheinen als "bit N undefined" und
+      # alarmieren mit (fail-visible). Bewusst KEIN from:-Filter - nach einem
+      # Restart (unknown -> aktiver Fehler) muss es feuern.
+      - trigger: state
+        id: bms_warnung
+        entity_id: sensor.battery_management_system_1_bms_1_warnings
+      - trigger: state
+        id: bms_fehler
+        entity_id: sensor.battery_management_system_1_bms_1_errors
+      - trigger: state
+        id: bmu_fehler
+        entity_id: sensor.battery_management_unit_errors
+      - trigger: state
+        id: verbindung
+        entity_id: sensor.battery_management_unit_connection_health
+        to: "unhealthy"
+        for: "00:10:00"
+    conditions:
+      - condition: or
+        conditions:
+          # Regeln ohne Frische-Bedingung: ruhe_spreizung ist bereits im Sensor
+          # gegated (Ruhefenster + Zelldaten-Frische), verbindung IST die
+          # Ausfallmeldung selbst.
+          - condition: trigger
+            id:
+              - ruhe_spreizung
+              - verbindung
+          # Native Fehler-/Warnbits: alles ausser Normal/unknown/unavailable.
+          - condition: and
+            conditions:
+              - condition: trigger
+                id:
+                  - bms_warnung
+                  - bms_fehler
+                  - bmu_fehler
+              - condition: template
+                value_template: >-
+                  {{ trigger.to_state.state not in ['Normal', 'unknown', 'unavailable'] }}
+          # BMU-Regeln ohne SoC-Gate: nur Frische.
+          - condition: and
+            conditions:
+              - condition: trigger
+                id:
+                  - zell_bms_grenze
+                  - zell_niedrig
+                  - temp_hoch
+                  - temp_kritisch
+                  - temp_delta
+              - condition: state
+                entity_id: binary_sensor.byd_bmu_frisch
+                state: "on"
+          # BMU-Regeln mit SoC-Gate (siehe Kopfkommentar).
+          - condition: and
+            conditions:
+              - condition: trigger
+                id:
+                  - zell_hoch
+                  - zell_kritisch
+              - condition: state
+                entity_id: binary_sensor.byd_bmu_frisch
+                state: "on"
+              - condition: numeric_state
+                entity_id: sensor.battery_management_unit_state_of_charge
+                below: 90
+          # Praezise BMS-Grenzregel: braucht frische Zelldaten.
+          - condition: and
+            conditions:
+              - condition: trigger
+                id: zell_bms_grenze_praezise
+              - condition: state
+                entity_id: binary_sensor.byd_zelldaten_frisch
+                state: "on"
+    actions:
+      - alias: "Alarmtext je Regel"
+        variables:
+          # REIHENFOLGE IST BINDEND: HA rendert variables: sequenziell und
+          # reicht nur die bereits gerenderten Variablen weiter. modul_hinweis
+          # MUSS vor alarm_text stehen, sonst rendert es dort still zu einem
+          # Leerstring (kein Fehler - nur ein kaputter Alarmtext).
+          #
+          # Modul-Identifikation fuer die Temperatur-Alarme: best-effort aus den
+          # BMS-Zelltemperaturen (cell_temps, bis 10,5 min alt - im Alarmtext
+          # als solches gekennzeichnet). Bewusster Rueckschritt gegenueber dem
+          # alten trigger.to_state.name, dafuer 30-s-Alarm-Latenz statt 10,5 min.
+          modul_hinweis: >-
+            {% set temps = state_attr('sensor.bms_1_cells_average_temperature', 'cell_temps') %}
+            {% if temps %}
+              {% set ns = namespace(tmax=-99, modul=0) %}
+              {% for modul in temps %}
+                {% if (modul['t'] | max) > ns.tmax %}
+                  {% set ns.tmax = modul['t'] | max %}
+                  {% set ns.modul = modul['m'] %}
+                {% endif %}
+              {% endfor %}
+              Modul {{ ns.modul }} mit {{ ns.tmax }} C
+            {% else %}unbekannt{% endif %}
+          alarm_text: >-
+            {% set t = {
+              'zell_hoch': 'Zellspannung hoch: ' ~ states('sensor.bmu_cell_voltage_max') ~ ' V (>3,55 V seit 2 min bei SoC ' ~ states('sensor.battery_management_unit_state_of_charge') ~ ' % - unter 90 % eine echte Anomalie). Ladeleistung beobachten/drosseln.',
+              'zell_kritisch': 'Zellspannung KRITISCH: ' ~ states('sensor.bmu_cell_voltage_max') ~ ' V (>3,60 V bei SoC ' ~ states('sensor.battery_management_unit_state_of_charge') ~ ' % - unter 90 %!) - Laden sofort stoppen/pruefen!',
+              'zell_bms_grenze': 'Zellspannung UEBER BMS-GRENZE: ' ~ states('sensor.bmu_cell_voltage_max') ~ ' V (>3,65 V seit 5 min anhaltend, BMU-Ebene - das BMS kappt nicht!) - sofort pruefen!',
+              'zell_bms_grenze_praezise': 'Zellspannung UEBER BMS-GRENZE (mV-genau): ' ~ states('sensor.battery_management_system_1_bms_1_cell_voltage_max') ~ ' V (>3,65 V ueber 2 Detail-Zyklen bestaetigt) - sofort pruefen!',
+              'zell_niedrig': 'Zellspannung niedrig: ' ~ states('sensor.battery_management_unit_bmu_cell_voltage_min') ~ ' V (<2,90 V seit 5 min). Entladung beobachten.',
+              'temp_hoch': 'Zelltemperatur hoch: ' ~ states('sensor.battery_management_unit_bmu_cell_temperature_max') ~ ' C (>45 C seit 5 min). Waermstes Modul (Zelldaten bis 10,5 min alt): ' ~ modul_hinweis ~ '.',
+              'temp_kritisch': 'Zelltemperatur KRITISCH: ' ~ states('sensor.battery_management_unit_bmu_cell_temperature_max') ~ ' C (>50 C) - sofort pruefen! Waermstes Modul (Zelldaten bis 10,5 min alt): ' ~ modul_hinweis ~ '.',
+              'temp_delta': 'Temperatur-Spreizung zwischen Modulen: ' ~ states('sensor.byd_temperatur_spreizung') ~ ' K (>10 K seit 15 min) - ein Modul weicht ab.',
+              'ruhe_spreizung': 'Zellspreizung in Ruhe dauerhaft hoch: ' ~ states('sensor.byd_zellspreizung_ruhe') ~ ' mV (>50 mV seit 1 h, Median der letzten 3 Ruhe-Messungen im flachen Kennlinienbereich) - Balancing-Bedarf pruefen.',
+              'bms_warnung': 'BMS meldet Warnung: ' ~ states('sensor.battery_management_system_1_bms_1_warnings') ~ ' (nativer Warn-Bit-Klartext).',
+              'bms_fehler': 'BMS meldet FEHLER: ' ~ states('sensor.battery_management_system_1_bms_1_errors') ~ ' (nativer Fehler-Bit-Klartext) - sofort pruefen!',
+              'bmu_fehler': 'BMU meldet FEHLER: ' ~ states('sensor.battery_management_unit_errors') ~ ' (nativer Fehler-Bit-Klartext) - sofort pruefen!',
+              'verbindung': 'BYD-Verbindung ungesund seit 10 min (connection_health=' ~ states('sensor.battery_management_unit_connection_health') ~ ') - Modbus-Strecke/Netz zur BMU pruefen.'
+            } %}{{ t.get(trigger.id, 'BYD-Alarm: ' ~ trigger.id) }}
+      - alias: "Push"
+        choose:
+          # Kennenlern-Phase: BMS-Warnungen laufen im SCHATTENBETRIEB - nur
+          # persistent_notification in der HA-UI + Logbuch, KEIN Mobile-Push.
+          # Ob das BMS am Ladeschluss/Balancing routinemaessig Warn-Bits setzt
+          # (z. B. "Cells imbalance"), ist unbekannt.
+          # TODO (nach mindestens einer sauberen Vollladung ohne Warn-Rauschen):
+          # bms_warnung aus dieser Option entfernen -> faellt in den default-
+          # Zweig und pusht dann normal.
+          - alias: "BMS-Warnung: Schattenbetrieb (kein Push)"
+            conditions:
+              - condition: trigger
+                id: bms_warnung
+            sequence:
+              - action: persistent_notification.create
+                data:
+                  notification_id: "byd_bms_warnung"
+                  title: "BYD BMS-Warnung (Schattenbetrieb)"
+                  message: "{{ alarm_text }}"
+          - alias: "Critical-Push"
+            conditions:
+              - condition: trigger
+                id:
+                  - zell_kritisch
+                  - zell_bms_grenze
+                  - zell_bms_grenze_praezise
+                  - temp_kritisch
+                  - bms_fehler
+                  - bmu_fehler
+            sequence:
+              - action: notify.notify
+                data:
+                  title: "🔋🚨 BYD Akku-Alarm"
+                  message: "{{ alarm_text }}"
+                  data:
+                    push:
+                      sound:
+                        name: default
+                        critical: 1
+                        volume: 1
+        default:
+          - action: notify.notify
+            data:
+              title: "🔋 BYD Akku-Alarm"
+              message: "{{ alarm_text }}"
+      - alias: "KI-Lagebild anstossen (fire-and-forget, Skript existiert nur live)"
+        action: script.turn_on
+        continue_on_error: true
+        target:
+          entity_id: script.ki_alarm_kontext
+        data:
+          variables:
+            alarm_titel: "BYD Akku-Alarm"
+            hinweis: >-
+              BYD Battery-Box Premium HVS (LFP, 5 Module, 32 Zellen/Modul =
+              160 Zellen, 12,8 kWh) am SMA WR. Datenquelle: Integration
+              byd_battery_box, Modbus nativ - zwei Ebenen: BMU-Poll alle 30 s
+              (Spannungen 10 mV granular, Temperatur 1 C) und BMS-Detail alle
+              ~10,5 min (Spannungen 1 mV granular). Zeitkritische Alarme laufen
+              auf der 30-s-Ebene, die 10-mV-Aufloesung verschiebt deren
+              Ausloesepunkt um bis zu 10 mV nach oben; der mV-genaue
+              Grenzwaechter auf der BMS-Ebene faengt das Fenster
+              3,651-3,659 V ab. BMS-Schutzgrenzen 2,75/3,65 V - die Alarme
+              liegen bewusst davor. Zellspannungs-Alarme sind SoC-gegated
+              (<90 %), am Ladeschluss zaehlt nur die BMS-Grenze. Zellspreizung
+              ist nur in Ruhe und bei SoC 25-85 % vergleichbar. Die Integration
+              setzt Entities bei Modbus-Abbruch NICHT auf unavailable, sondern
+              friert sie ein - deshalb pruefen die Alarme zusaetzlich
+              Frische-Binaries.
+            daten: >-
+              Ausgeloest durch Regel: {{ trigger.id }}
+              {{ alarm_text }}
+
+              Zellspannung min/max (BMU, 30 s): {{ states('sensor.battery_management_unit_bmu_cell_voltage_min') }} / {{ states('sensor.bmu_cell_voltage_max') }} V
+              Zellspannung min/max (BMS, mV-genau, ~10,5 min): {{ states('sensor.battery_management_system_1_bms_1_cell_voltage_min') }} / {{ states('sensor.battery_management_system_1_bms_1_cell_voltage_max') }} V
+              Zellspreizung: {{ states('sensor.battery_management_system_1_bms_1_cells_voltage_delta') }} mV (Ruhe-Median: {{ states('sensor.byd_zellspreizung_ruhe') }} mV)
+              Zell-Ausreisser: {{ states('sensor.byd_zell_ausreisser') }} mV vom Median ({{ state_attr('sensor.byd_zell_ausreisser', 'richtung') }}, Modul {{ state_attr('sensor.byd_zell_ausreisser', 'modul') }} Zelle {{ state_attr('sensor.byd_zell_ausreisser', 'zelle') }})
+              SoC: {{ states('sensor.battery_management_unit_state_of_charge') }} %, Leistung: {{ states('sensor.bmu_power') }} W (negativ = Laden)
+              Zelltemperatur min/max: {{ states('sensor.battery_management_unit_bmu_cell_temperature_min') }} / {{ states('sensor.battery_management_unit_bmu_cell_temperature_max') }} C
+              Temperatur-Spreizung: {{ states('sensor.byd_temperatur_spreizung') }} K
+              Balancing: {{ states('sensor.bms_1_cells_balancing') }} Zellen aktiv
+              SoH: {{ states('sensor.bms_1_state_of_health') }} %
+              BMS warnings/errors: {{ states('sensor.battery_management_system_1_bms_1_warnings') }} / {{ states('sensor.battery_management_system_1_bms_1_errors') }}
+              BMU errors: {{ states('sensor.battery_management_unit_errors') }}
+              Verbindung: {{ states('sensor.battery_management_unit_connection_health') }}
+              Daten frisch (BMU/Zelldaten): {{ states('binary_sensor.byd_bmu_frisch') }} / {{ states('binary_sensor.byd_zelldaten_frisch') }}
+              Steuerungs-Modus: {{ states('input_select.akkusteuerung_modus') }}
+
+  # -------------------------------------------------------------------------
+  # Dead-Man-Watchdog: ZEITbasiert, nicht edge-basiert.
+  # Ersetzt den alten stale-Trigger (der auf den unavailable-Uebergang der
+  # MQTT-Sensoren horchte). Zwei Gruende:
+  #   1. Die Integration setzt bei Modbus-Abbruch NIE unavailable (Werte
+  #      frieren ein) - es gibt gar keinen Uebergang, auf den man horchen kann.
+  #   2. Beim Fork-Setup-Fehlschlag nach HA-Neustart (Issues #14/#15) starten
+  #      die Entities OHNE State-Uebergang unavailable - edge-Trigger feuern
+  #      dann nie. Ein zeitbasierter Check sieht auch diesen Boot-Fehlschlag.
+  # Drossel 6 h: Reminder statt Spam (der Zustand haelt bis zum Eingriff an).
+  # Bewusste Konsequenz: die Frische-Bedingungen unterdruecken die
+  # physikalischen Alarme waehrend eines Datenausfalls - dann weiss man ohnehin
+  # nichts Neues, und dieser Watchdog meldet den Ausfall selbst
+  # (fail-notified statt fail-silent).
+  # -------------------------------------------------------------------------
+  - id: byd_daten_watchdog
+    alias: "BYD | Daten-Watchdog"
+    description: >-
+      Dead-Man-Watchdog fuer die BYD-Datenstrecke: meldet alle 30 min, wenn die
+      BMU- oder Zelldaten nicht mehr frisch sind oder die Verbindung nicht
+      gesund ist. Zeitbasiert, damit auch der Boot-Setup-Fehlschlag ohne
+      State-Uebergang erkannt wird. Drossel: hoechstens alle 6 h.
+    mode: single
+    triggers:
+      - trigger: time_pattern
+        minutes: "/30"
+    conditions:
+      - condition: or
+        conditions:
+          - condition: state
+            entity_id: binary_sensor.byd_bmu_frisch
+            state: "off"
+          - condition: state
+            entity_id: binary_sensor.byd_zelldaten_frisch
+            state: "off"
+          # not/state deckt auch unavailable + unknown ab.
+          - condition: not
+            conditions:
+              - condition: state
+                entity_id: sensor.battery_management_unit_connection_health
+                state: "healthy"
+      # Drossel 6 h. last_triggered wird erst gesetzt, wenn die Bedingungen
+      # durch sind - also beim letzten echten Alarm. Nie gelaufen ->
+      # as_timestamp(none, 0) = 0 -> Differenz riesig -> meldet (fail-safe).
+      - condition: template
+        value_template: >-
+          {{ (now().timestamp()
+              - as_timestamp(state_attr('automation.byd_daten_watchdog', 'last_triggered'), 0)) > 21600 }}
+    actions:
+      - action: notify.notify
+        data:
+          title: "🔋⚠️ BYD-Daten ausgefallen"
+          message: >-
+            Keine frischen BYD-Daten: BMU frisch={{ states('binary_sensor.byd_bmu_frisch') }},
+            Zelldaten frisch={{ states('binary_sensor.byd_zelldaten_frisch') }},
+            Verbindung={{ states('sensor.battery_management_unit_connection_health') }}.
+            Letzter BMU-Poll: {{ states('sensor.battery_management_unit_updated') }}.
+            Die Akku-Alarme sind waehrenddessen blind - Integration/Modbus-Strecke pruefen.
+      - action: persistent_notification.create
+        data:
+          notification_id: byd_daten_watchdog
+          title: "BYD-Daten ausgefallen"
+          message: >-
+            BMU frisch={{ states('binary_sensor.byd_bmu_frisch') }},
+            Zelldaten frisch={{ states('binary_sensor.byd_zelldaten_frisch') }},
+            Verbindung={{ states('sensor.battery_management_unit_connection_health') }}.
+            Letzter BMU-Poll: {{ states('sensor.battery_management_unit_updated') }},
+            letzter BMS-Detail-Poll: {{ states('sensor.battery_management_system_1_bms_1_updated') }}.
+            Integration byd_battery_box neu laden (Fork-Issues #14/#15: Setup-Fehlschlag
+            nach Neustart ohne Retry) und Netz/Modbus zur BMU pruefen.

--- a/packages/byd_monitoring.yaml
+++ b/packages/byd_monitoring.yaml
@@ -102,25 +102,45 @@ template:
              and (states('sensor.bmu_power')|float(9999))|abs < 300
              and 25 < states('sensor.battery_management_unit_state_of_charge')|float(-1) < 85 }}
 
-      # Frische-Binary BMU (Poll 30 s): 3 min = 6 verpasste Polls.
-      # Bedingung in ALLEN BMU-basierten Alarmen - ein eingefrorener 3,66-V-Wert
-      # kann so keinen Fehlalarm per Stagnation ausloesen.
+      # Frische-Binary BMU (Poll 30 s, gemessen knochenstabil): 90 s = 3
+      # verpasste Polls.
+      #
+      # WARUM 90 UND NICHT 180 (Codex-Review 17.7.):
+      # Das Fenster muss SCHMALER sein als die Haltezeit der Regel, die es
+      # schuetzt - sonst ist der Guard wirkungslos. Friert die BMU ein waehrend
+      # der for:-Timer laeuft, ist bei einer 2-min-Regel das Alter erst 120 s;
+      # mit 180 s Fenster waere das Binary noch "on" und der Alarm feuert auf
+      # eingefrorenen Daten. Mit 90 s greift der Guard ab 2 min sauber.
+      # Untergrenze: das Fenster muss BREITER als das Poll-Intervall (30 s)
+      # sein, sonst flattert es im Normalbetrieb. 90 s ist das Optimum.
+      #
+      # PRINZIPBEDINGT UNGESCHUETZT bleiben Regeln mit for: <= 90 s, also
+      # zell_kritisch (30 s) und temp_kritisch (60 s): ihr Fenster muesste
+      # kleiner als das Poll-Intervall sein, das geht nicht. Entschaerfend:
+      # numeric_state feuert nur beim UEBERSCHREITEN - das erste Sample ist
+      # also immer echt, der Alarm stuetzt sich dann auf 1 echtes Sample plus
+      # eingefrorene Bestaetigung. Das irrt Richtung "lieber alarmieren" und
+      # ist fuer kritische Regeln die sichere Fehlerrichtung.
       - unique_id: byd_bmu_frisch
         name: "BYD BMU-Daten frisch"
         icon: mdi:clock-check-outline
         state: >
           {{ (now().timestamp()
-              - as_timestamp(states('sensor.battery_management_unit_updated'), 0)) < 180 }}
+              - as_timestamp(states('sensor.battery_management_unit_updated'), 0)) < 90 }}
 
-      # Frische-Binary BMS-Detail (Poll ~630 s): 25 min = 2 verpasste Zyklen
-      # plus Marge. Bedingung fuer die praezise BMS-Grenzregel und die
-      # Ruhe-/Diagnose-Sensoren.
+      # Frische-Binary BMS-Detail (Poll ~630 s): 15 min.
+      # Gleiche Logik wie oben: muss schmaler sein als die 21-min-Haltezeit von
+      # zell_bms_grenze_praezise (sonst Guard wirkungslos) und breiter als der
+      # 630-s-Poll plus Marge (sonst Flattern). 900 s trifft beides.
+      # Bedingung fuer die praezise BMS-Grenzregel und die Ruhe-/Diagnose-
+      # Sensoren. Ein einzelner verpasster Detail-Zyklus (Alter bis 21 min)
+      # markiert bewusst "nicht frisch" - dann meldet der Watchdog.
       - unique_id: byd_zelldaten_frisch
         name: "BYD Zelldaten frisch"
         icon: mdi:clock-check-outline
         state: >
           {{ (now().timestamp()
-              - as_timestamp(states('sensor.battery_management_system_1_bms_1_updated'), 0)) < 1500 }}
+              - as_timestamp(states('sensor.battery_management_system_1_bms_1_updated'), 0)) < 900 }}
 
       # history_stats-Quelle fuer die KI-Analyse (braucht on/off, keinen
       # Zaehlwert). Der native Sensor zaehlt die aktuell balancierenden Zellen.

--- a/packages/byd_monitoring.yaml
+++ b/packages/byd_monitoring.yaml
@@ -555,7 +555,14 @@ automation:
                   notification_id: "byd_bms_warnung"
                   title: "BYD BMS-Warnung (Schattenbetrieb)"
                   message: "{{ alarm_text }}"
-          - alias: "Critical-Push"
+          # Schwere Regeln: eigener Titel (🚨) zur schnellen Triage, aber KEIN
+          # iOS-Critical-Override (Ben-Entscheidung 17.7.): kein Durchdringen von
+          # Stumm/Fokus/Nachtruhe. Begruendung: aus der Ferne/nachts ist ohnehin
+          # nichts zu tun, und bei einer echten Zell-Eskalation kappt das BMS
+          # selbst (~3,65 V) VOR jeder Handlungsmoeglichkeit. Normaler Push,
+          # respektiert Stumm/DND. (Falls je gewuenscht, laesst sich ein
+          # Critical-Override per Regel gezielt wieder ergaenzen.)
+          - alias: "Schwerer Alarm (eigener Titel, normaler Push)"
             conditions:
               - condition: trigger
                 id:
@@ -570,12 +577,6 @@ automation:
                 data:
                   title: "🔋🚨 BYD Akku-Alarm"
                   message: "{{ alarm_text }}"
-                  data:
-                    push:
-                      sound:
-                        name: default
-                        critical: 1
-                        volume: 1
         default:
           - action: notify.notify
             data:

--- a/packages/byd_monitoring.yaml
+++ b/packages/byd_monitoring.yaml
@@ -630,12 +630,18 @@ automation:
           - condition: state
             entity_id: binary_sensor.byd_zelldaten_frisch
             state: "off"
-          # not/state deckt auch unavailable + unknown ab.
-          - condition: not
-            conditions:
-              - condition: state
-                entity_id: sensor.battery_management_unit_connection_health
-                state: "healthy"
+          # BEWUSST NICHT: connection_health != healthy.
+          # Live-Befund 17.7.: nach einem reload_config_entry stand
+          # connection_health auf "unhealthy", waehrend consecutive_failures 0
+          # war und BMU/BMS frische Timestamps lieferten. Der Health-Ping ist
+          # ein eigener Kanal (60 s auf Register 0x0000); beim Reload
+          # konkurrieren alter und neuer Client um das 1-Verbindungs-Limit der
+          # BMU und der Ping faellt aus, waehrend die Polls schon wieder laufen.
+          # Als Watchdog-Bedingung waere das ein reiner Fehlalarm-Pfad OHNE
+          # Erkennungsgewinn: die Frische-Binaries sind die Grundwahrheit
+          # (updated rueckt nur bei ERFOLGREICHEM Poll vor) und decken jeden
+          # Datenausfall bereits ab. connection_health bleibt als eigener,
+          # entprellter verbindung-Alarm (for: 10 min) erhalten.
       # Drossel 6 h. last_triggered wird erst gesetzt, wenn die Bedingungen
       # durch sind - also beim letzten echten Alarm. Nie gelaufen ->
       # as_timestamp(none, 0) = 0 -> Differenz riesig -> meldet (fail-safe).

--- a/packages/byd_monitoring.yaml
+++ b/packages/byd_monitoring.yaml
@@ -121,8 +121,13 @@ template:
       # also immer echt, der Alarm stuetzt sich dann auf 1 echtes Sample plus
       # eingefrorene Bestaetigung. Das irrt Richtung "lieber alarmieren" und
       # ist fuer kritische Regeln die sichere Fehlerrichtung.
+      # NAME BESTIMMT DIE ENTITY_ID (slug), NICHT die unique_id! (Fable-Review
+      # 17.7.) "BYD BMU frisch" -> binary_sensor.byd_bmu_frisch, wie in allen
+      # Alarm-Bedingungen referenziert. Ein Name mit Bindestrich/Extra-Wort
+      # ("BYD BMU-Daten frisch" -> ...byd_bmu_daten_frisch) wuerde die Referenz
+      # ins Leere laufen lassen und ALLE Alarme still lahmlegen.
       - unique_id: byd_bmu_frisch
-        name: "BYD BMU-Daten frisch"
+        name: "BYD BMU frisch"
         icon: mdi:clock-check-outline
         state: >
           {{ (now().timestamp()
@@ -144,10 +149,21 @@ template:
 
       # history_stats-Quelle fuer die KI-Analyse (braucht on/off, keinen
       # Zaehlwert). Der native Sensor zaehlt die aktuell balancierenden Zellen.
+      # Name -> entity_id: "BYD Balancing aktiv nativ" ->
+      # binary_sensor.byd_balancing_aktiv_nativ (wie in opti_ki_analyse
+      # referenziert). Das "nativ" im Namen ist zwingend - ohne wuerde der Slug
+      # byd_balancing_aktiv und die history_stats-Quelle ins Leere laufen; zudem
+      # koennte eine Registry-Leiche des alten MQTT-byd_balancing_aktiv ein
+      # _2-Suffix erzwingen.
+      # Availability zusaetzlich an die Zelldaten-Frische (Codex-Review 17.7.):
+      # ein eingefrorener Balancing-Zaehler > 0 wuerde die history_stats-Uhr
+      # sonst durch einen Datenausfall weiterlaufen lassen.
       - unique_id: byd_balancing_aktiv_nativ
-        name: "BYD Balancing aktiv"
+        name: "BYD Balancing aktiv nativ"
         icon: mdi:scale-balance
-        availability: "{{ has_value('sensor.bms_1_cells_balancing') }}"
+        availability: >
+          {{ has_value('sensor.bms_1_cells_balancing')
+             and is_state('binary_sensor.byd_zelldaten_frisch', 'on') }}
         state: "{{ states('sensor.bms_1_cells_balancing')|int(0) > 0 }}"
 
   - sensor:
@@ -190,16 +206,19 @@ template:
   # atomaren Modbus-Reads obsolet; der kleinere Median-3 bleibt als
   # Einzel-Sample-Robustheit fuer die Steuer-Konsumenten.)
   #
-  # Restrisiko (dokumentiert): die Schreib-Reihenfolge updated vs. delta
-  # innerhalb eines Poll-Zyklus ist nicht garantiert; im schlimmsten Fall geht
-  # ein Sample mit dem Wert des Vorzyklus ein. Der 3er-Median kappt genau
-  # solche Einzelfaelle.
+  # Trigger NUR auf ..._updated, NICHT zusaetzlich auf ..._cells_voltage_delta
+  # (Codex-Review 17.7.): updated aendert sich bei JEDEM Detail-Zyklus (auch bei
+  # numerisch gleichem Delta), reicht also als alleiniger Zyklus-Trigger. Ein
+  # zweiter Trigger auf delta wuerde bei gleichzeitiger Aenderung im selben
+  # Zyklus das Sample DOPPELT anhaengen ([alt, neu, neu]) und den 3er-Median
+  # aushebeln.
+  # Restrisiko (dokumentiert): startet Last zwischen dem letzten BMU-Poll (30 s)
+  # und dem BMS-Sample, kann ein einzelnes Last-Sample durch das Ruhefenster
+  # rutschen. Der 3er-Median kappt genau solche Einzelfaelle.
   # ---------------------------------------------------------------------------
   - triggers:
       - trigger: state
         entity_id: sensor.battery_management_system_1_bms_1_updated
-      - trigger: state
-        entity_id: sensor.battery_management_system_1_bms_1_cells_voltage_delta
     conditions:
       - condition: state
         entity_id: binary_sensor.byd_ruhefenster
@@ -415,13 +434,23 @@ automation:
     conditions:
       - condition: or
         conditions:
-          # Regeln ohne Frische-Bedingung: ruhe_spreizung ist bereits im Sensor
-          # gegated (Ruhefenster + Zelldaten-Frische), verbindung IST die
-          # Ausfallmeldung selbst.
+          # verbindung IST die Ausfallmeldung selbst - keine Frische-Bedingung.
           - condition: trigger
-            id:
-              - ruhe_spreizung
-              - verbindung
+            id: verbindung
+          # ruhe_spreizung: der Ruhe-Sensor gated zwar SEINEN Update (Ruhefenster
+          # + Zelldaten-Frische), haelt aber gelatchte Werte ueber Stunden
+          # (RestoreEntity). Faellt DANACH der BMS-Poll aus, koennte ein stale
+          # >50-mV-Wert die 1-h-Haltezeit per Stagnation erfuellen. Deshalb hier
+          # zusaetzlich die Zelldaten-Frische (Codex-Review 17.7.) - konsistent
+          # mit dem Prinzip: physikalische Alarme werden bei Datenausfall
+          # unterdrueckt, der Watchdog meldet den Ausfall selbst.
+          - condition: and
+            conditions:
+              - condition: trigger
+                id: ruhe_spreizung
+              - condition: state
+                entity_id: binary_sensor.byd_zelldaten_frisch
+                state: "on"
           # Native Fehler-/Warnbits: alles ausser Normal/unknown/unavailable.
           - condition: and
             conditions:

--- a/packages/opti_ki_analyse.yaml
+++ b/packages/opti_ki_analyse.yaml
@@ -112,10 +112,16 @@ sensor:
     end: "{{ now() }}"
 
   # ---- BYD-Gesundheit: Balancing-Dauer heute (optional, s. Spec-Delta) -----
+  # Quelle seit dem Modbus-Cutover (17.7.): binary_sensor.byd_balancing_aktiv_nativ
+  # aus packages/byd_monitoring.yaml (an = sensor.bms_1_cells_balancing > 0).
+  # Der native Sensor ist ein ZAEHLWERT - history_stats braucht einen on/off-
+  # State, deshalb der Umweg ueber den Template-Binary. Bewusst NEUE entity_id:
+  # die alte MQTT-ID wird nicht wiederverwendet (Registry-Leichen koennten
+  # sonst _2-Suffixe erzwingen).
   - platform: history_stats
     name: "Opti KI Balancing Dauer H"
     unique_id: opti_ki_balancing_dauer_h
-    entity_id: binary_sensor.byd_balancing_aktiv
+    entity_id: binary_sensor.byd_balancing_aktiv_nativ
     state: "on"
     type: time
     start: "{{ today_at() }}"
@@ -138,6 +144,10 @@ sensor:
     max_age:
       hours: 24
     sampling_size: 3000
+  # sensor.byd_zellspreizung_ruhe behaelt seine entity_id ueber den Cutover
+  # (unique_id-Carry byd_bmu_zellspreizung_ruhe_mv) - hier ist nichts
+  # umzustellen. Zaesur in der Zeitreihe am 17.7.: Quelle MQTT -> Modbus,
+  # Median-5 -> Median-3 (docs/byd-monitoring-nativ.md).
   - platform: statistics
     name: "Opti KI Ruhe Spreizung Max 24h"
     unique_id: opti_ki_ruhe_spreizung_max_24h

--- a/tests/test_byd_bmu.py
+++ b/tests/test_byd_bmu.py
@@ -1,17 +1,24 @@
-"""Tests fuer die BYD-Monitoring-Templates (byd_bmu.yaml + byd_modul2_fruehwarnung.yaml):
-Zellspreizung-Klemme, Ruhe-Median gegen Einzel-Ausreisser, Temp-Spreizung, Absackung."""
+"""Tests fuer die DEPRECATED MQTT-Templates (legacy/byd_bmu.yaml +
+legacy/byd_modul2_fruehwarnung.yaml): Zellspreizung-Klemme, Ruhe-Median gegen
+Einzel-Ausreisser, Temp-Spreizung, Absackung.
+
+Der aktive Nachfolger ist packages/byd_monitoring.yaml (Modbus nativ), getestet
+in tests/test_byd_monitoring.py. Diese Datei haelt die Legacy-Templates nur
+waehrend der Beobachtungsphase gruen (Rollback-Option) und faellt mit dem
+Abbau-PR zusammen mit legacy/ weg.
+"""
 
 from .ha_harness import (REPO, FakeHass, find_template_entity, load_yaml, render,
                          render_native)
 
 
 def _bmu_entity(kind, unique_id):
-    return find_template_entity(load_yaml(REPO / "packages" / "byd_bmu.yaml"), kind, unique_id)
+    return find_template_entity(load_yaml(REPO / "legacy" / "byd_bmu.yaml"), kind, unique_id)
 
 
 def _fw_entity(kind, unique_id):
     return find_template_entity(
-        load_yaml(REPO / "packages" / "byd_modul2_fruehwarnung.yaml"), kind, unique_id)
+        load_yaml(REPO / "legacy" / "byd_modul2_fruehwarnung.yaml"), kind, unique_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_byd_monitoring.py
+++ b/tests/test_byd_monitoring.py
@@ -149,13 +149,20 @@ def _zelldaten_frisch(updated):
 def test_bmu_frisch_bei_normalem_poll():
     # Poll alle 30 s - typisches Alter live 17,5 s.
     assert _bmu_frisch("2026-07-17 11:44:42.207325") == "True"
-    assert _bmu_frisch("2026-07-17 11:42:01.000000") == "True"
+    # 60 s = 2 verpasste Polls, noch frisch.
+    assert _bmu_frisch("2026-07-17 11:44:00.000000") == "True"
 
 
-def test_bmu_frisch_stale_nach_drei_minuten():
-    # 3 min = 6 verpasste Polls.
+def test_bmu_frisch_grenze_90_sekunden():
+    # Das Fenster MUSS schmaler sein als die kuerzeste Haltezeit, die es
+    # schuetzt (zell_hoch: for 2 min) - sonst ist der Guard wirkungslos:
+    # eingefrorene Daten haetten nach 2 min erst 120 s Alter und wuerden mit
+    # einem 180-s-Fenster noch als "frisch" durchgehen (Codex-Review 17.7.).
+    # Untergrenze: breiter als der 30-s-Poll, sonst Flattern im Normalbetrieb.
+    assert _bmu_frisch("2026-07-17 11:43:31.000000") == "True"   # 89 s
+    assert _bmu_frisch("2026-07-17 11:43:30.000000") == "False"  # 90 s exakt
+    assert _bmu_frisch("2026-07-17 11:43:00.000000") == "False"  # 120 s = zell_hoch-Fall
     assert _bmu_frisch("2026-07-17 11:41:59.000000") == "False"
-    assert _bmu_frisch("2026-07-17 11:30:00.000000") == "False"
 
 
 def test_bmu_frisch_unavailable_und_muell_sind_nicht_frisch():
@@ -168,11 +175,15 @@ def test_bmu_frisch_unavailable_und_muell_sind_nicht_frisch():
     assert _bmu_frisch(None) == "False"
 
 
-def test_zelldaten_frisch_25_minuten_fenster():
-    # Detail-Zyklus ~630 s: 2 verpasste Zyklen + Marge. Live-Stichprobe 162 s.
-    assert _zelldaten_frisch("2026-07-17 11:42:18.000000") == "True"
-    assert _zelldaten_frisch("2026-07-17 11:20:01.000000") == "True"
-    assert _zelldaten_frisch("2026-07-17 11:19:59.000000") == "False"
+def test_zelldaten_frisch_grenze_15_minuten():
+    # Gleiche Logik wie beim BMU-Fenster: 900 s muss schmaler sein als die
+    # 21-min-Haltezeit von zell_bms_grenze_praezise (sonst Guard wirkungslos)
+    # und breiter als der 630-s-Detail-Zyklus (sonst Flattern).
+    assert _zelldaten_frisch("2026-07-17 11:42:18.000000") == "True"   # 162 s, live
+    assert _zelldaten_frisch("2026-07-17 11:34:30.000000") == "True"   # 630 s = 1 Zyklus
+    assert _zelldaten_frisch("2026-07-17 11:30:01.000000") == "True"   # 899 s
+    assert _zelldaten_frisch("2026-07-17 11:30:00.000000") == "False"  # 900 s exakt
+    assert _zelldaten_frisch("2026-07-17 11:24:00.000000") == "False"  # 21 min = praezise-Fall
     assert _zelldaten_frisch("unavailable") == "False"
 
 

--- a/tests/test_byd_monitoring.py
+++ b/tests/test_byd_monitoring.py
@@ -69,8 +69,10 @@ def test_unique_id_carries_vorhanden():
 # Ruhefenster: |bmu_power| < 300 W UND 25 < SoC < 85
 # ---------------------------------------------------------------------------
 
-def _ruhefenster(power=None, soc=None):
-    states = {}
+def _ruhefenster(power=None, soc=None, bmu_frisch="on"):
+    # bmu_frisch defaultet auf "on": die Frische ist eine eigene Bedingung und
+    # wird gezielt in test_ruhefenster_ohne_frische_bmu geprueft.
+    states = {"binary_sensor.byd_bmu_frisch": bmu_frisch}
     if power is not None:
         states["sensor.bmu_power"] = power
     if soc is not None:
@@ -89,6 +91,17 @@ def test_ruhefenster_leistungs_grenzen():
     assert _ruhefenster(power="300", soc="53") == "False"
     assert _ruhefenster(power="-300", soc="53") == "False"
     assert _ruhefenster(power="-2600", soc="53") == "False"
+
+
+def test_ruhefenster_ohne_frische_bmu():
+    # Driver-Haertung: BMU-Poll eingefroren, BMS pollt weiter. power/SoC zeigen
+    # dann stale "Ruhe"-Werte, obwohl der Akku unter Last stehen kann. Ohne
+    # diese Bedingung wuerde der Ruhe-Sensor ein Last-Delta als Ruhewert latchen
+    # - mit Steuerwirkung (Bedarfs-Balancing) und 1-h-Alarm.
+    assert _ruhefenster(power="0.0", soc="53", bmu_frisch="off") == "False"
+    # unknown/unavailable des Binaries zaehlt ebenfalls als nicht frisch.
+    assert _ruhefenster(power="0.0", soc="53", bmu_frisch="unavailable") == "False"
+    assert _ruhefenster(power="0.0", soc="53", bmu_frisch="unknown") == "False"
 
 
 def test_ruhefenster_soc_grenzen():

--- a/tests/test_byd_monitoring.py
+++ b/tests/test_byd_monitoring.py
@@ -1,0 +1,495 @@
+"""Tests fuer packages/byd_monitoring.yaml (BYD-Monitoring nativ ueber Modbus):
+Ruhefenster-Gate, Frische-Binaries, Ruhe-Median-3, Temperatur-Spreizung,
+Zell-Ausreisser, Balancing-Binary und die beiden unique_id-Carries.
+
+GRENZE DIESER HARNESS (bewusst dokumentiert): die Harness rendert ausschliesslich
+Jinja-Templates aus dem YAML. Die eigentliche Trigger-/for:-Semantik von HA ist
+hier NICHT abbildbar - also weder "eingefrorene Werte erfuellen for: per
+Stagnation", noch das Verwerfen von for:-Timern beim Reload, noch der Gate-
+Wechsel nach Schwellen-Ueberschreitung. Genau fuer diese Klasse existieren die
+Frische-Binaries (als Bedingung in der Automation), der Dead-Man-Watchdog und
+der E2E-Livetest - nicht diese Datei.
+"""
+import datetime as dt
+
+import jinja2
+
+from .ha_harness import (REPO, TZ, FakeHass, find_template_entity, load_yaml,
+                         render, render_native)
+
+PACKAGE = REPO / "packages" / "byd_monitoring.yaml"
+
+
+def _entity(kind, unique_id):
+    return find_template_entity(load_yaml(PACKAGE), kind, unique_id)
+
+
+# ---------------------------------------------------------------------------
+# Jinja-Parse-Check ueber die ganze Package-Struktur (Repo-Konvention)
+# ---------------------------------------------------------------------------
+
+def _walk_templates(node, path=""):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            yield from _walk_templates(v, f"{path}.{k}")
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            yield from _walk_templates(v, f"{path}[{i}]")
+    elif isinstance(node, str) and ("{{" in node or "{%" in node):
+        yield path, node
+
+
+def _parse_fails(env, template_str):
+    try:
+        env.parse(template_str)
+        return False
+    except jinja2.TemplateSyntaxError:
+        return True
+
+
+def test_package_jinja_parst():
+    env = jinja2.Environment()
+    fehler = [p for p, t in _walk_templates(load_yaml(PACKAGE)) if _parse_fails(env, t)]
+    assert fehler == []
+
+
+# ---------------------------------------------------------------------------
+# unique_id-Carries: DIE Registry-/Historien-Stabilitaets-Garantie.
+# Bleiben diese IDs gleich, behalten sensor.byd_zellspreizung_ruhe (4x mit
+# Steuerwirkung in opti_derived!) und sensor.byd_temperatur_spreizung ihre
+# entity_id - kein Konsument muss angefasst werden.
+# ---------------------------------------------------------------------------
+
+def test_unique_id_carries_vorhanden():
+    assert _entity("sensor", "byd_bmu_zellspreizung_ruhe_mv")["name"] == "BYD Zellspreizung Ruhe"
+    assert _entity("sensor", "byd_bmu_temp_spreizung_k")["name"] == "BYD Temperatur-Spreizung"
+
+
+# ---------------------------------------------------------------------------
+# Ruhefenster: |bmu_power| < 300 W UND 25 < SoC < 85
+# ---------------------------------------------------------------------------
+
+def _ruhefenster(power=None, soc=None):
+    states = {}
+    if power is not None:
+        states["sensor.bmu_power"] = power
+    if soc is not None:
+        states["sensor.battery_management_unit_state_of_charge"] = soc
+    return render(FakeHass(states=states), _entity("binary_sensor", "byd_ruhefenster")["state"])
+
+
+def test_ruhefenster_normal():
+    assert _ruhefenster(power="0.0", soc="53") == "True"
+
+
+def test_ruhefenster_leistungs_grenzen():
+    # Vorzeichen egal (negativ = Laden), Betrag zaehlt.
+    assert _ruhefenster(power="299", soc="53") == "True"
+    assert _ruhefenster(power="-299", soc="53") == "True"
+    assert _ruhefenster(power="300", soc="53") == "False"
+    assert _ruhefenster(power="-300", soc="53") == "False"
+    assert _ruhefenster(power="-2600", soc="53") == "False"
+
+
+def test_ruhefenster_soc_grenzen():
+    # Knie-Bereiche der LFP-Kennlinie bleiben draussen (exklusive Grenzen).
+    assert _ruhefenster(power="0", soc="26") == "True"
+    assert _ruhefenster(power="0", soc="84") == "True"
+    assert _ruhefenster(power="0", soc="25") == "False"
+    assert _ruhefenster(power="0", soc="85") == "False"
+    assert _ruhefenster(power="0", soc="99") == "False"
+    assert _ruhefenster(power="0", soc="17") == "False"
+
+
+def test_ruhefenster_fehlende_werte_off():
+    # Kein Sample ist besser als ein falsches Sample.
+    assert _ruhefenster(power="0") == "False"
+    assert _ruhefenster(soc="53") == "False"
+    assert _ruhefenster() == "False"
+    assert _ruhefenster(power="unavailable", soc="53") == "False"
+    assert _ruhefenster(power="0", soc="unknown") == "False"
+
+
+# ---------------------------------------------------------------------------
+# Frische-Binaries: now() - updated < 3 min (BMU) bzw. < 25 min (Zelldaten).
+# Die updated-Sensoren liefern NAIVE Lokalzeit-Strings; as_timestamp(x, 0)
+# interpretiert sie als Lokalzeit, Muell/unavailable -> 0 -> Alter riesig.
+# ---------------------------------------------------------------------------
+
+NOW = dt.datetime(2026, 7, 17, 11, 45, 0, tzinfo=TZ)
+
+
+def _frisch(unique_id, entity_id, updated):
+    hass = FakeHass(states={entity_id: updated} if updated is not None else {}, now=NOW)
+    return render(hass, _entity("binary_sensor", unique_id)["state"])
+
+
+def _bmu_frisch(updated):
+    return _frisch("byd_bmu_frisch", "sensor.battery_management_unit_updated", updated)
+
+
+def _zelldaten_frisch(updated):
+    return _frisch("byd_zelldaten_frisch",
+                   "sensor.battery_management_system_1_bms_1_updated", updated)
+
+
+def test_bmu_frisch_bei_normalem_poll():
+    # Poll alle 30 s - typisches Alter live 17,5 s.
+    assert _bmu_frisch("2026-07-17 11:44:42.207325") == "True"
+    assert _bmu_frisch("2026-07-17 11:42:01.000000") == "True"
+
+
+def test_bmu_frisch_stale_nach_drei_minuten():
+    # 3 min = 6 verpasste Polls.
+    assert _bmu_frisch("2026-07-17 11:41:59.000000") == "False"
+    assert _bmu_frisch("2026-07-17 11:30:00.000000") == "False"
+
+
+def test_bmu_frisch_unavailable_und_muell_sind_nicht_frisch():
+    # as_timestamp(x, 0) -> 0 -> Alter riesig -> off. Fail-Safe-Richtung:
+    # lieber "keine Daten" als ein eingefrorener Wert, der Alarme traegt.
+    assert _bmu_frisch("unavailable") == "False"
+    assert _bmu_frisch("unknown") == "False"
+    assert _bmu_frisch("kaputt") == "False"
+    assert _bmu_frisch("") == "False"
+    assert _bmu_frisch(None) == "False"
+
+
+def test_zelldaten_frisch_25_minuten_fenster():
+    # Detail-Zyklus ~630 s: 2 verpasste Zyklen + Marge. Live-Stichprobe 162 s.
+    assert _zelldaten_frisch("2026-07-17 11:42:18.000000") == "True"
+    assert _zelldaten_frisch("2026-07-17 11:20:01.000000") == "True"
+    assert _zelldaten_frisch("2026-07-17 11:19:59.000000") == "False"
+    assert _zelldaten_frisch("unavailable") == "False"
+
+
+# ---------------------------------------------------------------------------
+# Ruhe-Spreizung: Median der letzten 3 Gate-Messungen (this.attributes)
+# ---------------------------------------------------------------------------
+
+DELTA = "sensor.battery_management_system_1_bms_1_cells_voltage_delta"
+
+
+def _ruhe():
+    return _entity("sensor", "byd_bmu_zellspreizung_ruhe_mv")
+
+
+def test_ruhe_median_kappt_einzel_ausreisser():
+    # Historie unauffaellig (2-3 mV), ein Ausreisser von 40 mV kommt rein:
+    # der Median bleibt beim echten Niveau statt den Ausreisser zu latchen.
+    hass = FakeHass(states={DELTA: "40"}, this_attributes={"messreihe": [2.0, 3.0]})
+    assert float(render(hass, _ruhe()["state"])) == 3.0
+
+
+def test_ruhe_median_laesst_echtes_niveau_durch():
+    hass = FakeHass(states={DELTA: "61"}, this_attributes={"messreihe": [55.0, 58.0]})
+    assert float(render(hass, _ruhe()["state"])) == 58.0
+
+
+def test_ruhe_median_erste_messung_ohne_historie():
+    hass = FakeHass(states={DELTA: "4"}, this_attributes={})
+    assert float(render(hass, _ruhe()["state"])) == 4.0
+
+
+def test_ruhe_messreihe_rolliert_auf_drei():
+    hass = FakeHass(states={DELTA: "6"}, this_attributes={"messreihe": [3.0, 4.0, 5.0]})
+    assert render(hass, _ruhe()["attributes"]["messreihe"]) == "[4.0, 5.0, 6.0]"
+
+
+def test_ruhe_attribute_kontext():
+    hass = FakeHass(states={DELTA: "3",
+                            "sensor.battery_management_unit_state_of_charge": "53",
+                            "sensor.bmu_power": "0.0"},
+                    this_attributes={"messreihe": [2.0, 3.0]}, now=NOW)
+    attrs = _ruhe()["attributes"]
+    assert render(hass, attrs["soc"]) == "53"
+    assert render(hass, attrs["leistung_w"]) == "0.0"
+    assert render(hass, attrs["gemessen"]).startswith("2026-07-17T11:45:00")
+
+
+def test_ruhe_median_ueber_mehrere_trigger_zyklen():
+    # Simuliert aufeinanderfolgende Gate-Zyklen: das messreihe-Attribut aus
+    # Zyklus n wird (wie HAs this-Snapshot) zum Input von Zyklus n+1.
+    entity = _ruhe()
+    messreihe = []
+    verlauf = []
+    for roh in ["2", "3", "40", "3", "2", "2"]:
+        hass = FakeHass(states={DELTA: roh}, this_attributes={"messreihe": messreihe})
+        verlauf.append(float(render(hass, entity["state"])))
+        messreihe = render_native(hass, entity["attributes"]["messreihe"])
+        assert isinstance(messreihe, list)
+        assert all(isinstance(v, float) for v in messreihe)
+    # Der 40er-Ausreisser drueckt nie durch; nach 3 weiteren Messungen ist er
+    # aus dem Fenster. Fenster 3 reagiert schneller als das alte Fenster 5 -
+    # bewusst, siehe Plan F2 (Einzel-Sample-Robustheit, nicht Skew-Filter).
+    assert verlauf == [2.0, 2.0, 3.0, 3.0, 3.0, 2.0]
+    assert messreihe == [3.0, 2.0, 2.0]
+
+
+# ---------------------------------------------------------------------------
+# Temperatur-Spreizung: BMU-Temp max - min (ein Poll, 30 s)
+# ---------------------------------------------------------------------------
+
+TMAX = "sensor.battery_management_unit_bmu_cell_temperature_max"
+TMIN = "sensor.battery_management_unit_bmu_cell_temperature_min"
+
+
+def _temp_entity():
+    return _entity("sensor", "byd_bmu_temp_spreizung_k")
+
+
+def test_temp_spreizung_normal():
+    hass = FakeHass(states={TMAX: "33", TMIN: "27"})
+    assert float(render(hass, _temp_entity()["state"])) == 6.0
+    assert render(hass, _temp_entity()["availability"]) == "True"
+
+
+def test_temp_spreizung_live_stichprobe():
+    # Live 17.7.: BMU max 32 / min 29 -> 3 K.
+    hass = FakeHass(states={TMAX: "32", TMIN: "29"})
+    assert float(render(hass, _temp_entity()["state"])) == 3.0
+
+
+def test_temp_spreizung_negativ_geklemmt():
+    hass = FakeHass(states={TMAX: "20", TMIN: "25"})
+    assert float(render(hass, _temp_entity()["state"])) == 0.0
+
+
+def test_temp_spreizung_unavailable_ohne_quelle():
+    assert render(FakeHass(states={TMAX: "33"}), _temp_entity()["availability"]) == "False"
+    assert render(FakeHass(states={TMIN: "27"}), _temp_entity()["availability"]) == "False"
+    assert render(FakeHass(states={TMAX: "33", TMIN: "unavailable"}),
+                  _temp_entity()["availability"]) == "False"
+
+
+# ---------------------------------------------------------------------------
+# Balancing-Binary: history_stats-Quelle der KI-Analyse (braucht on/off)
+# ---------------------------------------------------------------------------
+
+BAL = "sensor.bms_1_cells_balancing"
+
+
+def _balancing():
+    return _entity("binary_sensor", "byd_balancing_aktiv_nativ")
+
+
+def test_balancing_binary_aus_zaehlwert():
+    assert render(FakeHass(states={BAL: "0"}), _balancing()["state"]) == "False"
+    assert render(FakeHass(states={BAL: "1"}), _balancing()["state"]) == "True"
+    assert render(FakeHass(states={BAL: "6"}), _balancing()["state"]) == "True"
+
+
+def test_balancing_binary_availability():
+    assert render(FakeHass(states={BAL: "0"}), _balancing()["availability"]) == "True"
+    assert render(FakeHass(states={}), _balancing()["availability"]) == "False"
+    assert render(FakeHass(states={BAL: "unavailable"}),
+                  _balancing()["availability"]) == "False"
+
+
+# ---------------------------------------------------------------------------
+# Zell-Ausreisser: max |Zelle - Median(160)| aus dem cell_voltages-Attribut
+# ---------------------------------------------------------------------------
+
+AVG = "sensor.bms_1_cells_average_voltage"
+
+
+def _cell_voltages(ausreisser=None):
+    """5 Module x 32 Zellen (echtes Live-Layout), alle 3302 mV.
+    ausreisser: (modul_1basiert, zelle_1basiert, wert_mv)."""
+    daten = [{"m": m, "v": [3302] * 32} for m in range(1, 6)]
+    if ausreisser:
+        m, z, wert = ausreisser
+        daten[m - 1]["v"][z - 1] = wert
+    return daten
+
+
+def _ausreisser():
+    return _entity("sensor", "byd_zell_ausreisser")
+
+
+def _render_ausreisser(feld, daten):
+    hass = FakeHass(states={AVG: "3.302"}, attrs={AVG: {"cell_voltages": daten}})
+    entity = _ausreisser()
+    tpl = entity["state"] if feld == "state" else entity["attributes"][feld]
+    return render(hass, tpl)
+
+
+def test_ausreisser_findet_absackende_zelle():
+    # Modul 3, Zelle 7 sackt auf 3250 mV ab: Median der 160 Zellen = 3302,
+    # groesste Abweichung 52 mV nach unten.
+    daten = _cell_voltages((3, 7, 3250))
+    assert float(_render_ausreisser("state", daten)) == 52.0
+    assert _render_ausreisser("modul", daten) == "3"
+    assert _render_ausreisser("zelle", daten) == "7"
+    assert _render_ausreisser("richtung", daten) == "tief"
+    assert float(_render_ausreisser("median_mv", daten)) == 3302.0
+
+
+def test_ausreisser_findet_hohe_zelle():
+    daten = _cell_voltages((5, 32, 3390))
+    assert float(_render_ausreisser("state", daten)) == 88.0
+    assert _render_ausreisser("modul", daten) == "5"
+    assert _render_ausreisser("zelle", daten) == "32"
+    assert _render_ausreisser("richtung", daten) == "hoch"
+
+
+def test_ausreisser_live_stichprobe_unauffaellig():
+    # Live 17.7.: alle Zellen 3301-3303 -> Ausreisser ~1 mV, kein Befund.
+    daten = _cell_voltages((5, 22, 3303))
+    assert float(_render_ausreisser("state", daten)) == 1.0
+    assert _render_ausreisser("richtung", daten) == "hoch"
+
+
+def test_ausreisser_ohne_abweichung():
+    daten = _cell_voltages()
+    assert float(_render_ausreisser("state", daten)) == 0.0
+    assert _render_ausreisser("richtung", daten) == "keiner"
+
+
+def test_ausreisser_unavailable_ohne_attribut():
+    hass = FakeHass(states={AVG: "3.302"})
+    assert render(hass, _ausreisser()["availability"]) == "False"
+    hass_ok = FakeHass(states={AVG: "3.302"},
+                       attrs={AVG: {"cell_voltages": _cell_voltages()}})
+    assert render(hass_ok, _ausreisser()["availability"]) == "True"
+
+
+# ---------------------------------------------------------------------------
+# Alarm-Automation: Variablen-Block
+# ---------------------------------------------------------------------------
+
+TEMP_AVG = "sensor.bms_1_cells_average_temperature"
+
+
+def _alarm_variables():
+    cfg = load_yaml(PACKAGE)
+    auto = next(a for a in cfg["automation"] if a["id"] == "byd_akku_alarme_nativ")
+    return next(a for a in auto["actions"] if "variables" in a)["variables"]
+
+
+def test_modul_hinweis_wird_vor_alarm_text_definiert():
+    # HA rendert variables: SEQUENZIELL und reicht nur die bereits gerenderten
+    # Variablen weiter. Steht modul_hinweis hinter alarm_text, rendert es dort
+    # still zu einem Leerstring - kein Fehler, nur ein kaputter Alarmtext.
+    # Diese Reihenfolge ist deshalb bindend, nicht kosmetisch.
+    keys = list(_alarm_variables())
+    assert keys.index("modul_hinweis") < keys.index("alarm_text")
+
+
+def _alarm_automation():
+    cfg = load_yaml(PACKAGE)
+    return next(a for a in cfg["automation"] if a["id"] == "byd_akku_alarme_nativ")
+
+
+def _trigger_ids():
+    return [t["id"] for t in _alarm_automation()["triggers"]]
+
+
+def _condition_trigger_ids():
+    """Alle in den conditions referenzierten Trigger-IDs (flach)."""
+    gefunden = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            if node.get("condition") == "trigger":
+                ids = node["id"]
+                gefunden.extend([ids] if isinstance(ids, str) else ids)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+
+    walk(_alarm_automation()["conditions"])
+    return gefunden
+
+
+def test_jede_regel_hat_einen_alarmtext():
+    # alarm_text nutzt .get(trigger.id, 'BYD-Alarm: ' ~ trigger.id) - eine
+    # vertippte oder vergessene ID faellt also nicht auf, sondern pusht still
+    # einen generischen Text. Deshalb hier hart gegenpruefen.
+    text = _alarm_variables()["alarm_text"]
+    fehlend = [tid for tid in _trigger_ids() if f"'{tid}':" not in text]
+    assert fehlend == []
+
+
+def test_jede_regel_ist_in_den_conditions_abgedeckt():
+    # Jede Trigger-ID muss in genau einem condition-Zweig auftauchen: fehlt
+    # eine, laesst der or-Block sie durchfallen und die Regel feuert NIE
+    # (fail-silent) - der gefaehrlichste Fehler in dieser Automation.
+    abgedeckt = _condition_trigger_ids()
+    fehlend = [tid for tid in _trigger_ids() if tid not in abgedeckt]
+    assert fehlend == []
+    # Keine Karteileiche: nichts in den conditions, was es als Trigger nicht gibt.
+    assert [tid for tid in abgedeckt if tid not in _trigger_ids()] == []
+
+
+def test_frische_bedingung_fuer_jeden_physikalischen_alarm():
+    # Grundprinzip 2 des Plans: eingefrorene Werte erfuellen for: per
+    # Stagnation. Jede physikalische BMU-Regel MUSS deshalb byd_bmu_frisch
+    # als Bedingung haben, die BMS-Praezisionsregel byd_zelldaten_frisch.
+    bmu_regeln = {"zell_hoch", "zell_kritisch", "zell_bms_grenze", "zell_niedrig",
+                  "temp_hoch", "temp_kritisch", "temp_delta"}
+    for zweig in _alarm_automation()["conditions"][0]["conditions"]:
+        ids = set(_condition_trigger_ids_von(zweig))
+        entities = _condition_entities_von(zweig)
+        if ids & bmu_regeln:
+            assert "binary_sensor.byd_bmu_frisch" in entities, ids
+        if "zell_bms_grenze_praezise" in ids:
+            assert "binary_sensor.byd_zelldaten_frisch" in entities, ids
+
+
+def _condition_trigger_ids_von(zweig):
+    gefunden = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            if node.get("condition") == "trigger":
+                ids = node["id"]
+                gefunden.extend([ids] if isinstance(ids, str) else ids)
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+
+    walk(zweig)
+    return gefunden
+
+
+def _condition_entities_von(zweig):
+    gefunden = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            if "entity_id" in node and isinstance(node["entity_id"], str):
+                gefunden.append(node["entity_id"])
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+
+    walk(zweig)
+    return gefunden
+
+
+def _cell_temps(waermstes_modul=None, tmax=None):
+    """5 Module x 12 Fuehler (echtes Live-Layout), alle 31 C."""
+    daten = [{"m": m, "t": [31] * 12} for m in range(1, 6)]
+    if waermstes_modul:
+        daten[waermstes_modul - 1]["t"][5] = tmax
+    return daten
+
+
+def test_modul_hinweis_findet_waermstes_modul():
+    hass = FakeHass(states={TEMP_AVG: "31.3"},
+                    attrs={TEMP_AVG: {"cell_temps": _cell_temps(4, 47)}})
+    assert render(hass, _alarm_variables()["modul_hinweis"]) == "Modul 4 mit 47 C"
+
+
+def test_modul_hinweis_ohne_attribut():
+    # Zelldaten weg (Detail-Poll haengt) -> der Temp-Alarm feuert trotzdem,
+    # nur ohne Modul-Identifikation.
+    hass = FakeHass(states={TEMP_AVG: "31.3"})
+    assert render(hass, _alarm_variables()["modul_hinweis"]) == "unbekannt"

--- a/tests/test_byd_monitoring.py
+++ b/tests/test_byd_monitoring.py
@@ -24,6 +24,38 @@ def _entity(kind, unique_id):
     return find_template_entity(load_yaml(PACKAGE), kind, unique_id)
 
 
+def _slug(name):
+    # HA leitet die entity_id aus dem NAMEN ab (slugify), nicht aus der
+    # unique_id: lowercase, nicht-alphanumerische Laeufe -> "_", getrimmt.
+    import re
+    return re.sub(r"_+", "_", re.sub(r"[^a-z0-9]+", "_", name.lower())).strip("_")
+
+
+# unique_id -> (domain, erwartete entity_id-Objektkennung). Die ID ist die, die
+# von den Alarmen / Consumern referenziert wird. Faengt die Fehlerklasse
+# "Name slugt nicht zur referenzierten entity_id" (Fable-Review 17.7.), die alle
+# Alarme still lahmlegen wuerde und von der Template-Render-Harness NICHT
+# gesehen wird. Fuer die Carry-Sensoren stellt der Test sicher, dass auch eine
+# Frischinstallation OHNE Registry-Carry die richtige entity_id bekommt.
+NAMING = [
+    ("binary_sensor", "byd_ruhefenster", "byd_ruhefenster"),
+    ("binary_sensor", "byd_bmu_frisch", "byd_bmu_frisch"),
+    ("binary_sensor", "byd_zelldaten_frisch", "byd_zelldaten_frisch"),
+    ("binary_sensor", "byd_balancing_aktiv_nativ", "byd_balancing_aktiv_nativ"),
+    ("sensor", "byd_zell_ausreisser", "byd_zell_ausreisser"),
+    ("sensor", "byd_bmu_temp_spreizung_k", "byd_temperatur_spreizung"),
+    ("sensor", "byd_bmu_zellspreizung_ruhe_mv", "byd_zellspreizung_ruhe"),
+]
+
+
+def test_name_slugt_zur_referenzierten_entity_id():
+    for domain, unique_id, erwartet in NAMING:
+        name = _entity(domain, unique_id)["name"]
+        assert _slug(name) == erwartet, (
+            f"{domain}/{unique_id}: name '{name}' -> {domain}.{_slug(name)}, "
+            f"aber referenziert wird {domain}.{erwartet}")
+
+
 # ---------------------------------------------------------------------------
 # Jinja-Parse-Check ueber die ganze Package-Struktur (Repo-Konvention)
 # ---------------------------------------------------------------------------
@@ -303,10 +335,19 @@ def test_balancing_binary_aus_zaehlwert():
     assert render(FakeHass(states={BAL: "6"}), _balancing()["state"]) == "True"
 
 
+FRESH = "binary_sensor.byd_zelldaten_frisch"
+
+
 def test_balancing_binary_availability():
-    assert render(FakeHass(states={BAL: "0"}), _balancing()["availability"]) == "True"
-    assert render(FakeHass(states={}), _balancing()["availability"]) == "False"
-    assert render(FakeHass(states={BAL: "unavailable"}),
+    # Verfuegbar nur bei vorhandenem Zaehler UND frischen Zelldaten - sonst
+    # liefe die history_stats-Uhr durch einen Datenausfall weiter.
+    assert render(FakeHass(states={BAL: "0", FRESH: "on"}),
+                  _balancing()["availability"]) == "True"
+    assert render(FakeHass(states={BAL: "0", FRESH: "off"}),
+                  _balancing()["availability"]) == "False"
+    assert render(FakeHass(states={BAL: "0"}), _balancing()["availability"]) == "False"
+    assert render(FakeHass(states={FRESH: "on"}), _balancing()["availability"]) == "False"
+    assert render(FakeHass(states={BAL: "unavailable", FRESH: "on"}),
                   _balancing()["availability"]) == "False"
 
 

--- a/tests/test_ki_analyse.py
+++ b/tests/test_ki_analyse.py
@@ -84,10 +84,13 @@ STATES_VOLL = {
     "input_number.opti_halte_spread_ct": "5",
     "input_number.minsoc": "10",
     "input_number.maxsoc": "95",
+    # byd_zellspreizung_ruhe/byd_temperatur_spreizung behalten ihre entity_id
+    # ueber den Modbus-Cutover (unique_id-Carry); der SoH kommt seit 17.7. vom
+    # nativen sensor.bms_1_state_of_health statt vom MQTT-sensor.byd_soh.
     "sensor.byd_zellspreizung_ruhe": "2",
     "sensor.opti_ki_ruhe_spreizung_max_24h": "4",
     "sensor.byd_temperatur_spreizung": "3",
-    "sensor.byd_soh": "96",
+    "sensor.bms_1_state_of_health": "96",
     "sensor.opti_ki_balancing_dauer_h": "1.2",
 }
 
@@ -104,9 +107,13 @@ def test_datenpaket_rendert_valides_json():
 
 
 def test_datenpaket_markiert_fehlende_quellen():
+    # "sensor.bms_1_" muss mit raus, sonst bleibt der SoH nach dem Cutover als
+    # einzige BYD-Quelle stehen und der Fall "BYD komplett weg" waere nicht mehr
+    # getestet.
     ohne_optionales = {k: v for k, v in STATES_VOLL.items()
                        if not k.startswith(("sensor.opti_price_spread", "sensor.opti_grid_import",
-                                            "sensor.opti_pv_yield", "sensor.byd_"))}
+                                            "sensor.opti_pv_yield", "sensor.byd_",
+                                            "sensor.bms_1_"))}
     hass = FakeHass(states=ohne_optionales,
                     attrs={"sensor.opti_strategie_vorschau": {"grund": "Default (Nacht/keine Aktion)"}})
     ergebnis = json.loads(render(hass, _datenpaket_template()))


### PR DESCRIPTION
## Worum es geht

Nach dem Wechsel der BYD-Datenquelle (bydlogc-MQTT-Bridge -> native HACS-Integration `TimWeyand/byd_battery_box`, Modbus) hingen die alten Akku-Gesundheits-Alarme an toten `sensor.byd_*`. Es gab damit **keine aktiven Akku-Alarme mehr**. Dieser PR baut die Alarm- und Monitoring-Schicht nativ neu.

## Was drin ist

- **`packages/byd_monitoring.yaml`** (neu): Template-Layer + 13 Alarmregeln (`byd_akku_alarme_nativ`) + Dead-Man-Watchdog (`byd_daten_watchdog`).
- **`tests/test_byd_monitoring.py`** (neu): 34 Tests, inkl. Slug-Test (name -> entity_id) und Guard-Tests gegen fail-silent-Fallen.
- **`docs/byd-monitoring-nativ.md`** (neu): gepinnter Entity-Vertrag (Version/Commit/Snapshot), Kadenz/Aufloesung, Cutover/Rollback, bekannte Integrations-Maengel, Phase-2-Skizze.
- **`legacy/`**: alte Packages (`byd_bmu.yaml`, `byd_modul2_fruehwarnung.yaml`) verschoben (`git mv`, Historie erhalten) + Deprecation-Header.
- **Consumer-Migration**: `opti_ki_analyse` auf `binary_sensor.byd_balancing_aktiv_nativ` und `sensor.bms_1_state_of_health`; `docs/installation.md` + README auf das neue Package umgestellt.

## Kern-Designentscheidung

Die Integration setzt Entities bei Modbus-Abbruch **nie** auf `unavailable` - die Werte **frieren ein** und erfuellen `for:`-Haltezeiten per Stagnation. Schutz:

- **Frische-Binaries** `byd_bmu_frisch` (< 90 s) / `byd_zelldaten_frisch` (< 900 s) als Bedingung in jedem physikalischen Alarm. Die Fenster sind bewusst schmaler als die kuerzeste geschuetzte `for:`-Zeit (sonst ist der Guard wirkungslos).
- **Zeitbasierter Dead-Man-Watchdog** - faengt auch den Boot-Setup-Fehlschlag der Integration ohne State-Uebergang, den ein edge-Trigger nie sehen wuerde.

Zwei Kadenzen: BMU-Poll 30 s (zeitkritische Alarme, 10-mV-Aufloesung), BMS-Detail ~630 s (praeziser mV-Backstop + Spreizung/Diagnose). Schwellen liegen bewusst vor den BMS-Schutzgrenzen (2,75/3,65 V), SoC-Gating gegen Ladeschluss-Fehlalarme.

## Review

Architektur (Plan) + Implementierung wurden von zwei unabhaengigen Modellen reviewt (Cross-Family). Materielle Findings eingearbeitet, u. a.:

- **Blocker**: entity_id wird aus dem `name:` slugifiziert, nicht aus der `unique_id` - ein falscher Name haette alle Alarme still lahmgelegt (die Render-Test-Harness sieht das nicht -> neuer Slug-Test).
- Frische-Fenster schmaler als die geschuetzten Haltezeiten; `ruhe_spreizung` + Zelldaten-Frische; Median-3 gegen Doppel-Append gehaertet; `connection_health` als Fehlalarm-Quelle aus dem Watchdog entfernt.

## Tests

`.venv/bin/python -m pytest -q` -> **255 passed**.

## Deploy-Status

Bereits live deployed und verifiziert (atomarer Cutover, Backup, Push-Kanal real getestet). Rollback-Pfade dokumentiert. Der Merge dieses PR bringt Repo und Live-Stand deckungsgleich.

## Bewusst nicht in diesem PR

- Modul-2-Fruehwarnung (Trend-Monitoring) -> Phase 2, Helfer-Snapshot gesichert.
- Endgueltiger Abbau der `legacy/`-Dateien + toten MQTT-Registry-Reste -> nach ein paar Beobachtungstagen.
