### PR TITLE
feat(byd): Modul-2-Frühwarnung nativ (Bestätigungszähler + Mess-Anker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Der Minimalpfad. Voller Ablauf mit beiden Einspiel-Varianten, allen Erststart-We
 | `packages/sma_statistik.yaml` | Gleitende Mittelwert-Sensoren für Verbrauch & Batterielast |
 | `packages/opti_ki_analyse.yaml` | **optional** - täglicher KI-Tagesreport (rein lesend) |
 | `packages/byd_monitoring.yaml` | **optional** - BYD-Zell-Monitoring + Akku-Alarme über die native Modbus-Integration (→ [docs/byd-monitoring-nativ.md](docs/byd-monitoring-nativ.md)) |
-| `legacy/` | Abgelöste Packages (BYD via bydlogc→MQTT, Modul-2-Frühwarnung) - **nicht mehr einbauen**, siehe Deprecation-Header in den Dateien |
+| `packages/byd_modul2_fruehwarnung.yaml` | **optional** - BYD Modul-2-Frühwarnung (Degradations-Trend des schwächsten Moduls, rein beobachtend, kein Alarm); setzt `byd_monitoring.yaml` voraus (→ [docs/byd-modul2-fruehwarnung.md](docs/byd-modul2-fruehwarnung.md)) |
+| `legacy/` | Abgelöste Packages (BYD via bydlogc→MQTT, alte Modul-2-Frühwarnung) - **nicht mehr einbauen**, siehe Deprecation-Header in den Dateien |
 | `packages/opti_ev_sperre.yaml` | **optional** - EV-Schnelllade-Entladesperre (Hausakku entlädt nicht ins Auto, wenn evcc im Modus now/minpv lädt); braucht HACS `evcc_intg` + Ladepunkt-Block im Mapping → [docs/strategie-logik.md](docs/strategie-logik.md) (Option 13) |
 | `automations/opti_strategie.yaml` | Strategie-Automation (editierbar, kein Blueprint) |
 

--- a/docs/byd-modul2-fruehwarnung.md
+++ b/docs/byd-modul2-fruehwarnung.md
@@ -46,7 +46,8 @@ Der Messzyklus läuft als Zustandsmaschine (`input_select.byd_knie_zyklus_status
 2. **armed → latched (Knie-Latch):** Wenn der Bestätigungszähler `sensor.byd_knie_bestaetigungen` **≥ 2 konsekutive qualifizierende BMS-Zyklen** erreicht (Zellmin von Modul 2 unter der eingefrorenen Referenz, im Entladeband, bei frischen Daten), und die Spannung seit dem Anker klar über der Schwelle war (Überschwelle-Guard, ref + 30 mV).
    Der Latch-Sensor snapshottet in diesem Moment die **Mess-Anker-Werte** (Nettoenergie und Absackung am ersten Unterschreitungs-Sample, siehe unten) plus Begleitwerte (SoC, Zellmin, schwächste Zelle, Cycle-ID) als Attribute.
 3. **armed → invalid:** Bei Messqualitäts-Problemen wird der Zyklus verworfen statt falsch gemessen: Datenlücke (eines der beiden Frische-Binaries ≥ 2 min aus) oder HA-Neustart, jeweils **nahe am Knie** (Zellmin ≤ ref + 10 mV, fail-safe: unbekannt zählt als nah → verwerfen), oder ein unplausibler Nettoenergie-Sprung (> 3 kWh zwischen zwei Updates, außerhalb der Anker-Sekunden).
-   Der Grund landet in `input_text.byd_knie_invalid_grund`.
+   Beim HA-Neustart wartet der Pfad **bis zu 15 min auf frische Zelldaten**, bevor der Nähe-Check greift - direkt nach dem Boot ist Zellmin noch `unavailable`, und `float(0)` würde sonst **jeden** Routine-Restart im armed-Zustand als knie-nah invalidieren und gesunde Plateau-Zyklen verwerfen; erst nach dem Timeout (Integration wirklich tot) greift `float(0)` korrekt als „verwerfen".
+   Mit `invalid` werden `armed` und der Überschwelle-Guard zurückgesetzt (kein Zustandswiderspruch), der Grund landet in `input_text.byd_knie_invalid_grund`.
 
 Das Attribut `sauberer_zyklus` markiert Zyklen ohne nennenswerte Zwischenladung (< 0,5 kWh geladen seit Voll); nur diese sind untereinander streng vergleichbar.
 
@@ -58,16 +59,16 @@ Ein `for:` von z. B. ≥ 21 min würde (a) Latch-Ausbeute an Haushaltslast-Flatt
 Stattdessen zählt `sensor.byd_knie_bestaetigungen` konsekutive qualifizierende BMS-Detail-Zyklen.
 Er ist trigger-basiert (auf den Attribut-Träger **und** auf die Cycle-ID als Reset-Signal) und **zustands- statt flankensicher** - alle Entscheidungen fallen im Template gegen die eigenen Vorwerte (`this.attributes`):
 
-- **Reset über die Cycle-ID:** ist die gespeicherte Cycle-ID ≠ der aktuellen, startet der Zähler neu. Das fängt auch ein Re-Arm `armed → armed` ab, weil der Voll-Anker **immer** eine neue Cycle-ID vergibt.
+- **Reset über die Cycle-ID:** ist die gespeicherte Cycle-ID ≠ der aktuellen, wird der Zähler **bedingungslos auf 0** gesetzt - das reine Reset-Event ist kein qualifizierendes Sample. Erst der nächste `cells_average_voltage`-Trigger im laufenden Zyklus kann Stand 1 erzeugen (sonst könnte das erste echte Folge-Sample bereits Stand 2 und damit einen verfrühten Latch auslösen). Das fängt auch ein Re-Arm `armed → armed` ab, weil der Voll-Anker **immer** eine neue Cycle-ID vergibt.
 - **Dedupe (300 s):** liegt der Abstand zum letzten gezählten Sample unter 300 s, ist es ein Doppel-Event desselben BMS-Samples und wird nicht gezählt.
-- **Lücken-Guard (1500 s):** liegt der Abstand über 1500 s, ist die Kontinuität gebrochen (Datenlücke zwischen den Samples) und der Zähler startet bei 1 neu.
+- **Lücken-Guard / Streak-Start (1500 s):** liegt der Abstand über 1500 s (auch: kein laufender Streak, `letzter_zyklus` = 0 nach Reset), ist es das erste Sample eines Streaks und der Zähler startet bei 1.
 - Ein nicht-qualifizierendes Sample nullt den Zähler.
 
-**Mess-Anker:** Beim Übergang auf Zählerstand 1 snapshottet der Zähler den aktuellen `sensor.byd_nettoenergie_seit_voll` als `netto_bei_erstem_sample` und die aktuelle Absackung als `absackung_bei_erstem_sample`.
-Der Latch übernimmt **diese** Werte, nicht die zum Latch-Zeitpunkt: gemessen wird am ersten Unterschreitungs-Sample (Lag zum echten Knie ≤ 1 Zyklus, ~0-0,26 kWh bandbegrenzt), die zweite Bestätigung validiert nur noch.
-Damit verschwindet der Wartezeit-Offset aus der Messung.
+**Mess-Anker:** Beim frischen Übergang auf Zählerstand 1 snapshottet der Zähler den aktuellen `sensor.byd_nettoenergie_seit_voll` als `netto_bei_erstem_sample` sowie - **aus demselben `cell_voltages`-Attribut, das die Qualifikation gerechnet hat** - `absackung_bei_erstem_sample`, `zelle_bei_erstem_sample` und `schwaechstes_modul_bei_erstem_sample`.
+Der Latch übernimmt **diese** geankerten Werte, nicht die zum Latch-Zeitpunkt und nicht den (gegateten, ggf. veralteten) Momentanwert des Absackungs-Sensors - so passen Absackungswert und Zell-Nummer garantiert zusammen.
+Gemessen wird am ersten Unterschreitungs-Sample (Lag zum echten Knie ≤ 1 Zyklus, ~0-0,26 kWh bandbegrenzt), die zweite Bestätigung validiert nur noch; der Wartezeit-Offset verschwindet aus der Messung.
 
-Der Latch selbst hängt an einem **state-Trigger** auf den Zähler mit der Bedingung Wert ≥ 2 (kein `numeric_state`, das nur die steigende Flanke sähe): scheitert der erste Latch-Versuch (Bedingung, Crash, Neustart mit restauriertem Zähler), feuert der nächste Zyklus (2 → 3) erneut.
+Der Latch selbst hängt an einem **state-Trigger** auf den Zähler mit der Bedingung Wert ≥ 2 **und** einem numerischen Mess-Anker (kein `numeric_state`, das nur die steigende Flanke sähe): scheitert der erste Latch-Versuch (Bedingung, ungültiger Anker, Crash, Neustart mit restauriertem Zähler), feuert der nächste Zyklus (2 → 3) erneut.
 
 ## Interpretation
 

--- a/docs/byd-modul2-fruehwarnung.md
+++ b/docs/byd-modul2-fruehwarnung.md
@@ -1,46 +1,73 @@
 # BYD Modul-2-Frühwarnung: Degradations-Monitoring für das schwächste Modul
 
-> ⛔ **Überholt seit 17.7.2026 - Neubau als Phase 2 eingeplant.**
-> Dieses Package hängt komplett an den MQTT-Sensoren des abgelösten bydlogc-Wegs und ist seit dem bydlogc-Stopp am 17.7.2026 funktionslos.
-> Es liegt nur noch unter [`legacy/byd_modul2_fruehwarnung.yaml`](../legacy/byd_modul2_fruehwarnung.yaml).
-> Der Neubau auf die nativen Zelldaten ist skizziert in [byd-monitoring-nativ.md](byd-monitoring-nativ.md) (Abschnitt „Phase 2").
-> Fachlich (Metrik-Definitionen, Zustandsmaschine, Interpretations-Hinweise) gilt diese Doku als Vorlage weiter.
+Dieses optionale Package ([`packages/byd_modul2_fruehwarnung.yaml`](../packages/byd_modul2_fruehwarnung.yaml)) beobachtet das schwächste Modul eines BYD-HVS-Turms auf schleichende Degradation.
+Es baut auf dem nativen BYD-Monitoring ([`packages/byd_monitoring.yaml`](../packages/byd_monitoring.yaml), Doku: [byd-monitoring-nativ.md](byd-monitoring-nativ.md)) auf und ist rein beobachtend, ohne jede Steuerwirkung und **ohne Alarm/Push**.
+Datenquelle sind die nativen Modbus-Zelldaten der Integration `byd_battery_box` (Attribut `cell_voltages`, native Energie-Lebenszähler), nicht mehr die abgelösten MQTT-Sensoren.
 
-Dieses optionale Package ([`legacy/byd_modul2_fruehwarnung.yaml`](../legacy/byd_modul2_fruehwarnung.yaml)) beobachtet das schwächste Modul eines BYD-HVS-Turms auf schleichende Degradation.
-Es baut auf dem BMU-Monitoring ([`legacy/byd_bmu.yaml`](../legacy/byd_bmu.yaml), Doku: [byd-bmu-monitoring.md](byd-bmu-monitoring.md)) auf und ist rein beobachtend, ohne jede Steuerwirkung.
 Nach der Erstinstallation einmalig `input_number.byd_knie_referenzspannung` auf 3,20 V stellen; die Helfer tragen bewusst kein `initial:`, weil HA das bei jedem Neustart anwenden und Referenz wie Zyklus-Status überschreiben würde.
+
+> **Zäsur 17.7.2026 gegenüber der alten (MQTT-)Frühwarnung:**
+> Beide Metriken wechseln Quelle **und** Definition, die Zeitreihen sind nicht durchgängig zu lesen.
+> Metrik A misst jetzt gegen den Median **aller 160 Zellen** statt gegen den Peer-Median der vier Nachbarmodule (der war zur schwächsten Zelle der Nachbarn hin systematisch nach unten verzerrt).
+> Metrik B wird über einen Bestätigungszähler mit Mess-Anker statt über eine `for:`-Haltezeit erkannt.
+> Der alte Latch-Pfad war ohnehin **nie** end-to-end durchlaufen (kein einziger echter Messwert), die Absackungs-Reihe erst zwei Tage alt - deshalb bekommen alle Entities neue `unique_id`s (Suffix `_nativ`) und werden über einen Orphan-Purge frisch registriert, statt eine fachlich gebrochene Reihe scheinbar fortzuführen.
 
 ## Ausgangslage
 
 In jedem Serien-Turm stellt genau eine Zelle das Minimum, das ist noch kein Befund.
 Interessant sind Größe und Trend der Abweichung: eine stabil leicht schwächere Zelle ist normale Fertigungsstreuung, eine über Monate wachsende Abweichung ist ein alterndes Modul und ein Fall für die Garantie.
-In diesem Setup ist Modul 2 (Zelle 23) das schwächste Glied, deshalb sind die Templates und Trigger auf Modul 2 verdrahtet.
+In diesem Setup ist Modul 2 (bislang Zelle 23) das schwächste Glied, deshalb sind die Templates und Trigger auf Modul 2 verdrahtet.
 Für andere Türme die Modul-Nummer in den Templates und Automationen anpassen.
 
-## Metrik A: relative Zell-Absackung (laufend)
+## Metrik A: relative Zell-Absackung (in standardisierten Betriebspunkten)
 
-`sensor.byd_modul_2_absackung` misst in mV, wie weit die schwächste Zelle von Modul 2 unter dem Peer-Median der vier Nachbarmodule liegt.
-Der Median (Mittel der beiden mittleren von vier Peer-Werten) ist robust gegen einen einzelnen abweichenden Nachbarn.
-Der Wert ist zustandsabhängig und muss im gleichen Betriebspunkt verglichen werden: im LFP-Plateau in Ruhe liegt er nahe 0 mV, unter Entladelast (Innenwiderstands-Anteil) und am unteren Kennlinien-Knie (Kapazitäts-Anteil) steigt er.
-Attribute liefern Kontext für jede Messung: SoC, Leistung, absolute Modul-2-Spannung, schwächste Zell-ID und welches Modul aktuell das Minimum stellt.
+`sensor.byd_modul_2_zell_absackung` misst in mV, wie weit die schwächste Zelle von Modul 2 unter dem **Median aller 160 Zellen** liegt.
+Der Median über den ganzen Turm ist der robuste zentrale Referenzpunkt (anders als der alte Peer-Median der Nachbar-**Minima**, der die schwächste Zelle gegen die jeweils schwächsten Zellen der Nachbarn verglich).
+
+Der Wert ist zustandsabhängig und wird deshalb **nicht mehr laufend**, sondern nur in einem standardisierten Betriebspunkt gesampelt - die Interpretations-Vorgabe „nur im gleichen Betriebspunkt vergleichen" erzwingt jetzt der Sensor selbst:
+Der Sensor ist trigger-basiert (Trigger direkt auf den Attribut-Träger `sensor.bms_1_cells_average_voltage`, damit das gelesene Attribut aus dem auslösenden Zyklus stammt) und übernimmt ein Sample nur, wenn die Zelldaten frisch sind, das Entladeband seit ≥ 3 min an ist und der BMU-SoC zwischen 25 und 85 % liegt.
+
+Attribute liefern Kontext für jede Messung: `zelle` (Zell-Nummer 1-32 des Minimums **innerhalb** von Modul 2 - beantwortet dauerhaft „ist es noch Zelle 23?"), `schwaechstes_modul` (Modul 1-5 der global schwächsten Zelle - macht eine Drift zu einem anderen Modul sichtbar), `median_mv`, `soc`, `leistung_w`.
+
+> **Restrisiko (dokumentiert, bewusst ohne Glättung):** SoC und Leistung für Gate und Attribute stammen vom letzten BMU-Poll (bis ~60 s vor dem Zell-Read).
+> Ein Lastwechsel genau in diesem Fenster kann ein einzelnes Sample falsch etikettieren; über die Kontext-Attribute ist es filterbar.
+> Es gibt bewusst keine Median-Glättung auf der Trend-Serie - Ausreißer sollen sichtbar bleiben.
 
 ## Metrik B: Nettoenergie bis zum Knie (pro Vollzyklus)
 
-`sensor.byd_modul_2_netto_bis_knie` beantwortet die eigentliche Kapazitätsfrage in kWh statt in mV:
+`sensor.byd_modul_2_nettoenergie_bis_knie` beantwortet die eigentliche Kapazitätsfrage in kWh statt in mV:
 wie viel Nettoenergie (entladen minus geladen) lässt sich nach einer Vollladung entnehmen, bis die schwächste Zelle ihr unteres Knie erreicht?
 Sinkt dieser Wert über Monate, verliert das Modul messbar Kapazität.
 
 Der Messzyklus läuft als Zustandsmaschine (`input_select.byd_knie_zyklus_status`):
 
-1. **idle → armed (Voll-Anker):** Nach Ladeschluss (Zellmax war >= 3,55 V für 2 min, dann 5 min keine nennenswerte Ladung, SoC > 94 %, Daten frisch) werden die Utility-Meter (`byd_geladen_seit_voll`/`byd_entladen_seit_voll`) genullt, die Knie-Referenzspannung eingefroren (`byd_knie_ref_frozen`, Default 3,20 V) und der Zyklus scharf geschaltet.
+1. **idle → armed (Voll-Anker):** Nach Ladeschluss (Zellmax war ≥ 3,55 V für 2 min, dann 5 min keine nennenswerte Ladung, SoC > 94 %, beide Frische-Binaries an, Zähler-Basiswerte gültig) werden die utility_meter (`byd_geladen_seit_voll`/`byd_entladen_seit_voll`, Quellen `bms_1_charge/discharge_total_energy`) genullt, die Knie-Referenzspannung eingefroren (`byd_knie_ref_frozen`, Default 3,20 V), eine **neue Cycle-ID** vergeben (sie setzt den Bestätigungszähler zurück) und der Zyklus scharf geschaltet.
    Eine Re-Arm-Sperre (mindestens 0,5 kWh netto entnommen seit dem letzten Anker) verhindert Mehrfach-Resets im Ladeschluss-Flattern.
-2. **armed → latched (Knie-Latch):** Wenn Modul-2-min die eingefrorene Referenz erstmals 3 min lang unterschreitet, im standardisierten Entladeband (500 bis 1500 W über die Haltezeit), bei frischen Daten und nachdem die Spannung seit dem Anker klar über der Schwelle war (Überschwelle-Guard, ref + 30 mV).
-   Der Latch-Sensor snapshottet in diesem Moment Nettoenergie und Begleitwerte (Absackung, SoC, Temperatur, Zell-IDs, Cycle-ID) als Attribute.
-   Das Entladeband standardisiert den Betriebspunkt, damit die kWh-Werte über Zyklen vergleichbar sind; die 3-min-Haltezeit ersetzt eine explizite mV-Hysterese.
-3. **armed → invalid:** Bei Messqualitäts-Problemen wird der Zyklus verworfen statt falsch gemessen: Datenlücke oder HA-Neustart nahe am Knie (Modul-2-min <= ref + 10 mV) oder ein unplausibler Nettoenergie-Sprung (> 3 kWh zwischen zwei Updates, außerhalb der Anker-Sekunden).
+2. **armed → latched (Knie-Latch):** Wenn der Bestätigungszähler `sensor.byd_knie_bestaetigungen` **≥ 2 konsekutive qualifizierende BMS-Zyklen** erreicht (Zellmin von Modul 2 unter der eingefrorenen Referenz, im Entladeband, bei frischen Daten), und die Spannung seit dem Anker klar über der Schwelle war (Überschwelle-Guard, ref + 30 mV).
+   Der Latch-Sensor snapshottet in diesem Moment die **Mess-Anker-Werte** (Nettoenergie und Absackung am ersten Unterschreitungs-Sample, siehe unten) plus Begleitwerte (SoC, Zellmin, schwächste Zelle, Cycle-ID) als Attribute.
+3. **armed → invalid:** Bei Messqualitäts-Problemen wird der Zyklus verworfen statt falsch gemessen: Datenlücke (eines der beiden Frische-Binaries ≥ 2 min aus) oder HA-Neustart, jeweils **nahe am Knie** (Zellmin ≤ ref + 10 mV, fail-safe: unbekannt zählt als nah → verwerfen), oder ein unplausibler Nettoenergie-Sprung (> 3 kWh zwischen zwei Updates, außerhalb der Anker-Sekunden).
    Der Grund landet in `input_text.byd_knie_invalid_grund`.
 
 Das Attribut `sauberer_zyklus` markiert Zyklen ohne nennenswerte Zwischenladung (< 0,5 kWh geladen seit Voll); nur diese sind untereinander streng vergleichbar.
+
+### Bestätigungszähler statt `for:` - Zähler-Mechanik und Mess-Anker
+
+Die Knie-Erkennung läuft bewusst **nicht** über eine `for:`-Haltezeit.
+Ein `for:` von z. B. ≥ 21 min würde (a) Latch-Ausbeute an Haushaltslast-Flattern verlieren, (b) sich per Stagnation auch auf eingefrorenen Werten erfüllen und (c) einen mit der Wartezeit wachsenden kWh-Offset in die Messung tragen.
+
+Stattdessen zählt `sensor.byd_knie_bestaetigungen` konsekutive qualifizierende BMS-Detail-Zyklen.
+Er ist trigger-basiert (auf den Attribut-Träger **und** auf die Cycle-ID als Reset-Signal) und **zustands- statt flankensicher** - alle Entscheidungen fallen im Template gegen die eigenen Vorwerte (`this.attributes`):
+
+- **Reset über die Cycle-ID:** ist die gespeicherte Cycle-ID ≠ der aktuellen, startet der Zähler neu. Das fängt auch ein Re-Arm `armed → armed` ab, weil der Voll-Anker **immer** eine neue Cycle-ID vergibt.
+- **Dedupe (300 s):** liegt der Abstand zum letzten gezählten Sample unter 300 s, ist es ein Doppel-Event desselben BMS-Samples und wird nicht gezählt.
+- **Lücken-Guard (1500 s):** liegt der Abstand über 1500 s, ist die Kontinuität gebrochen (Datenlücke zwischen den Samples) und der Zähler startet bei 1 neu.
+- Ein nicht-qualifizierendes Sample nullt den Zähler.
+
+**Mess-Anker:** Beim Übergang auf Zählerstand 1 snapshottet der Zähler den aktuellen `sensor.byd_nettoenergie_seit_voll` als `netto_bei_erstem_sample` und die aktuelle Absackung als `absackung_bei_erstem_sample`.
+Der Latch übernimmt **diese** Werte, nicht die zum Latch-Zeitpunkt: gemessen wird am ersten Unterschreitungs-Sample (Lag zum echten Knie ≤ 1 Zyklus, ~0-0,26 kWh bandbegrenzt), die zweite Bestätigung validiert nur noch.
+Damit verschwindet der Wartezeit-Offset aus der Messung.
+
+Der Latch selbst hängt an einem **state-Trigger** auf den Zähler mit der Bedingung Wert ≥ 2 (kein `numeric_state`, das nur die steigende Flanke sähe): scheitert der erste Latch-Versuch (Bedingung, Crash, Neustart mit restauriertem Zähler), feuert der nächste Zyklus (2 → 3) erneut.
 
 ## Interpretation
 
@@ -49,13 +76,21 @@ Stabiler Offset bei Metrik A plus stabile kWh bei Metrik B bedeutet Fertigungsst
 Wachsende Absackung im gleichen Betriebspunkt oder sinkende Nettoenergie-bis-Knie über Monate bedeutet beschleunigte Alterung, dann die Messreihe sichern und den Garantiefall mit Daten belegen (BYD Battery-Box Premium: 10 Jahre mit Kapazitätszusage).
 Ein Modul-Ausbau (Turm läuft offiziell auch mit 4 Modulen) ist erst sinnvoll, wenn das Modul effektiv mehr als seine eigene Kapazität kostet oder aktiv stört, und damit klar hinter Beobachten und Garantiefall die dritte Option.
 
+## Warum kein Alarm
+
+Das alte Package hatte keinen `notify`, und das bleibt richtig: Trend-Metriken ohne Baseline können keinen sinnvollen Schwellwert haben (Bens Fehlalarm-Vorgabe).
+Erst nach Wochen Baseline lohnt eine Drift-Regel - dann als eigener PR.
+Im Package steht dafür nur ein TODO-Vermerk.
+
 ## Design-Historie
 
-Das ursprüngliche, Codex-adversarial gehärtete Design liegt unter [byd-modul2-fruehwarnung-design.md](byd-modul2-fruehwarnung-design.md).
-Abweichungen zum dortigen Stand: das Package liegt separat (nicht in `byd_bmu.yaml` gebündelt, Live-Parität) und die Helfer tragen kein `initial:` mehr (Neustart-Reset-Bug, Codex-Review 16.7.).
+Das ursprüngliche, Codex-adversarial gehärtete MQTT-Design liegt unter [byd-modul2-fruehwarnung-design.md](byd-modul2-fruehwarnung-design.md); die alte Implementierung unter [`legacy/byd_modul2_fruehwarnung.yaml`](../legacy/byd_modul2_fruehwarnung.yaml).
+Der native Neubau (Phase 2) ist in [byd-monitoring-nativ.md](byd-monitoring-nativ.md#phase-2-modul-frühwarnung-neu-bauen-umgesetzt) eingeordnet.
+Wesentliche Abweichungen zum MQTT-Stand: Median(160) statt Peer-Median, Bestätigungszähler mit Mess-Anker statt `for:`-Haltezeit, native Modbus-Quellen und die beiden Frische-Binaries aus dem Monitoring-Package.
 
 ## Status und offene Punkte
 
-- Live seit 15.07.2026, die Absackungs-Metrik liefert seitdem Daten.
-- Der komplette Latch-Pfad (Voll-Anker bis Knie-Latch) ist noch nicht end-to-end durchlaufen; er braucht eine Vollladung mit anschließender Entladung bis unter die Referenzspannung im Entladeband.
+- Package, Tests und Doku sind gebaut; der Live-Deploy (Orphan-Purge, Re-Seed, Dashboard-Karten-Umzug) steht noch aus (Checkliste im Package-Header).
+- Der komplette Latch-Pfad (Voll-Anker bis Knie-Latch) ist auch nativ noch nicht end-to-end durchlaufen; er braucht eine Vollladung mit anschließender Entladung bis unter die Referenzspannung im Entladeband. Der erste E2E-Durchlauf verifiziert diesen im Alt-Design nie erreichten Pfad erstmals.
+- Der Invalid-Pfad wird aktiv getestet (Integration nahe am Knie einmal reloaden → `datenluecke`-Invalid muss greifen), nicht nur passiv beobachtet.
 - Erst nach den ersten sauberen Zyklen lohnt eine Bewertung der Referenzspannung (3,20 V) und des Entladebands.

--- a/docs/byd-monitoring-nativ.md
+++ b/docs/byd-monitoring-nativ.md
@@ -178,6 +178,12 @@ Spalte „Frische" = zusätzliche Bedingung auf das jeweilige Frische-Binary.
 
 Jeder Alarm stößt wie bisher `script.ki_alarm_kontext` an (`continue_on_error`, existiert nur live).
 
+### Push-Kanäle: kein iOS-Critical-Override (bewusster Trade-off, 17.7.)
+
+Die Spalte "Critical" in der Tabelle meint nur den **Titel `🔋🚨`** zur schnellen Triage - alle Alarme senden einen **normalen Push** (`notify.mobile_app_iphone_15_ben`), der Stumm/Fokus/Nachtruhe respektiert. Der frühere iOS-Critical-Override (`sound.critical: 1`, durchdringt DND) wurde auf Nutzerwunsch entfernt: aus der Ferne bzw. nachts ist bei einer Zell-Eskalation ohnehin nichts zu tun, und das BMS kappt selbst bei ~3,65 V vor jeder Handlungsmöglichkeit.
+
+**Bewusster Rest-Trade-off:** Der eine Fall, in dem `zell_bms_grenze` wirklich zählt (BMS kappt NICHT trotz > 3,65 V), tritt bevorzugt nachts am Ladeschluss auf - ohne Critical-Ton kann er in DND untergehen. Falls je gewünscht, lässt sich ein Override per Regel gezielt für genau `zell_bms_grenze`/`bms_fehler`/`bmu_fehler` wieder ergänzen.
+
 ### SoC-Gating der Zellspannungs-Alarme
 
 Am Ladeschluss (SoC ≥ 90 %, LFP-Knie, Balancing aktiv) laufen Max-Zellspannung und Spreizung kurzzeitig hoch - beobachtet: **3,659 V Peak bei 0 W Ladeleistung**.
@@ -224,7 +230,10 @@ Zeitbasiert statt edge-basiert, weil er genau die zwei Fälle abdecken muss, die
 - **Modul-Identifikation im Temperatur-Alarm** ist best-effort aus `cell_temps` und damit bis zu 10,5 min alt (im Alarmtext gekennzeichnet).
   Bewusster Trade-off für 30-s-Alarm-Latenz statt 10,5 min.
 - **BMU- vs. BMS-SoC** können ~1 % divergieren; für die 90-%- und 25-85-%-Gates egal.
-- Die Integration ist ein **0.1.x-Fork mit 3 Stars**. Mittelfristig sinnvoll: `ConfigEntryNotReady`-Issue beim Fork melden (Setup-Retry).
+- Die Integration ist ein **0.1.x-Fork mit 3 Stars** - das realste Ausfallszenario ist der Setup-Fehlschlag nach HA-Neustart ohne Retry (gemeldet als Fork-Issue #14, `ConfigEntryNotReady`). Genau dafür ist der Dead-Man-Watchdog da.
+- **HACS-Update-Disziplin (wichtig):** Der cells/temps-Fix (Fork-Issue #16 / PR #17) ist derzeit nur **lokal** in `/config/custom_components/byd_battery_box/bydboxclient.py` gepatcht (Backup `.bak-cellswap-20260717`). Ein HACS-Update auf `byd_battery_box` **überschreibt den Patch** und stellt die Vertauschung wieder her, bis PR #17 gemergt ist. HACS updatet nicht ungefragt (manuell) - also bis zum Merge **kein Update auf diese Integration**, und nach jedem doch erfolgten Update prüfen: `sensor.<...>_cells_per_module` muss **32** sein. (Der Bug betrifft nur die zwei Zähler-Sensoren, nicht die `cell_voltages`-Arrays - die Frühwarnung ist gegen die Vertauschung isoliert, plus Plausibilitäts-Floor `m2min > 2,5 V`.)
+- **Live-vor-Merge-Stand:** Alarm-Package (`feat/byd-alarme-nativ` / PR #51) und Frühwarnung (`feat/byd-modul2-nativ`) laufen live, bevor sie auf `main` gemergt sind - plus der Lokalpatch. Drei gleichzeitige Live-vs-Repo-Abweichungen; Fenster klein halten (PR #51 bald mergen). **Schneller Rückfall:** der bydlogc-Container (Docker-VM 192.168.10.6) ist nur gestoppt, nicht entfernt - `docker start bydlogger` reaktiviert die alte MQTT-Datenquelle; HA-Backups `20c04425`/`5075f782`/`668ffd3c` decken die drei Cutover-Stufen ab.
+- **BMU spricht unauthentifiziertes Modbus**, und die komplette Alarmkette hängt jetzt an diesem Port. Die VLAN-Isolation der BMU (IoT-VLAN, nur Reader-Host -> BMU:8080 + BMU -> 443/1883) sollte nicht beliebig weit nach hinten geschoben werden.
 
 ## Bewusste Auslassungen
 

--- a/docs/byd-monitoring-nativ.md
+++ b/docs/byd-monitoring-nativ.md
@@ -107,8 +107,8 @@ Dann weiß man ohnehin nichts Neues - und `verbindung`/Watchdog melden den Ausfa
 | Entity | unique_id | Quelle | Zweck |
 |---|---|---|---|
 | `binary_sensor.byd_ruhefenster` | `byd_ruhefenster` | \|`bmu_power`\| < 300 W UND 25 < SoC < 85 | Gate für die Ruhe-Sensoren |
-| `binary_sensor.byd_bmu_frisch` | `byd_bmu_frisch` | Alter von `..._updated` < 3 min (= 6 verpasste Polls) | Frische-Bedingung BMU-Alarme, Watchdog |
-| `binary_sensor.byd_zelldaten_frisch` | `byd_zelldaten_frisch` | Alter von `..._bms_1_updated` < 25 min (2 verpasste Zyklen + Marge) | Frische-Bedingung BMS-Regeln, Ruhe-Sensoren, Watchdog |
+| `binary_sensor.byd_bmu_frisch` | `byd_bmu_frisch` | Alter von `..._updated` < 90 s (= 3 verpasste Polls) | Frische-Bedingung BMU-Alarme, Watchdog |
+| `binary_sensor.byd_zelldaten_frisch` | `byd_zelldaten_frisch` | Alter von `..._bms_1_updated` < 15 min (900 s; schmaler als die 21-min-Haltezeit der Präzisionsregel, breiter als der 630-s-Zyklus) | Frische-Bedingung BMS-Regeln, Ruhe-Sensoren, Watchdog |
 | `binary_sensor.byd_balancing_aktiv_nativ` | `byd_balancing_aktiv_nativ` | `bms_1_cells_balancing` > 0 | history_stats-Quelle der KI-Analyse |
 | `sensor.byd_zellspreizung_ruhe` | `byd_bmu_zellspreizung_ruhe_mv` (**Carry**) | Median-3 des nativen `cells_voltage_delta`, im Ruhefenster | **Bedarfs-Balancing (Steuerwirkung!)**, KI-Analyse, Alarm |
 | `sensor.byd_temperatur_spreizung` | `byd_bmu_temp_spreizung_k` (**Carry**) | BMU-Temp max - min (ein Poll) | KI-Analyse, `temp_delta`-Alarm |
@@ -219,7 +219,7 @@ Zeitbasiert statt edge-basiert, weil er genau die zwei Fälle abdecken muss, die
 - **`numeric_state`-Nachfeuer-Schwäche:** Ist die Schwelle bereits überschritten und wird erst danach das Gate wahr (oder lädt HA neu, wodurch `for:`-Timer verworfen werden), feuert der Trigger nicht nach.
   War im alten Design identisch, bleibt ein akzeptiertes Restrisiko.
   Option für später: den Watchdog um Schwellen-Checks erweitern.
-- **Watchdog-Latenz:** Detail-Staleness wird schlimmstenfalls erst nach ~30-55 min gemeldet (25-min-Fenster + 30-min-Raster).
+- **Watchdog-Latenz:** Detail-Staleness wird schlimmstenfalls erst nach ~30-45 min gemeldet (15-min-Fenster + 30-min-Raster).
   Für reine Zelldaten akzeptabel, weil alle zeitkritischen Alarme auf der BMU-Ebene mit 3-min-Frische laufen.
 - **Modul-Identifikation im Temperatur-Alarm** ist best-effort aus `cell_temps` und damit bis zu 10,5 min alt (im Alarmtext gekennzeichnet).
   Bewusster Trade-off für 30-s-Alarm-Latenz statt 10,5 min.
@@ -268,17 +268,17 @@ Grund: alte und neue Definition teilen sich zwei unique_ids - gleichzeitig aktiv
 
 **Danach (Abbau-PR nach mehreren Beobachtungstagen):** `legacy/`, `tests/test_byd_bmu.py` und die Doku-Reste löschen, live die `.bak`-Dateien und die MQTT-Registry-Leichen (UI) entfernen.
 
-## Phase 2: Modul-Frühwarnung neu bauen
+## Phase 2: Modul-Frühwarnung neu bauen (umgesetzt)
 
-Die Modul-2-Frühwarnung ([byd-modul2-fruehwarnung.md](byd-modul2-fruehwarnung.md)) ist bewusst **nicht** Teil dieses Umbaus: die Alarm-Lücke war akut, die Frühwarnung ist Trend-Monitoring.
-Ehrlich benannt: sie ist seit dem bydlogc-Stopp am 17.7. ohnehin funktionslos, der Cutover macht das nur formell.
-Damit kein schleichender Feature-Verlust entsteht, ist der Neubau fest für die nächsten 1-2 Wochen eingeplant (vor der nächsten Referenzdaten-Kampagne).
+Die Modul-2-Frühwarnung war bewusst **nicht** Teil des Alarm-Umbaus (die Alarm-Lücke war akut, die Frühwarnung ist Trend-Monitoring) und ist seit dem bydlogc-Stopp am 17.7. ohnehin funktionslos gewesen.
+Der native Neubau ist inzwischen umgesetzt: Package [`packages/byd_modul2_fruehwarnung.yaml`](../packages/byd_modul2_fruehwarnung.yaml), Doku [byd-modul2-fruehwarnung.md](byd-modul2-fruehwarnung.md), Tests [`tests/test_byd_modul2_fruehwarnung.py`](../tests/test_byd_modul2_fruehwarnung.py).
 
-Skizze:
+Kernpunkte der Umsetzung (Details in der Frühwarnungs-Doku):
 
-- **Metrik A präziser:** schwächste Zelle von Modul 2 gegen den Median aller 160 Zellen (aus `cell_voltages`), im Entladeband - identifiziert zusätzlich, ob es noch Zelle 23 ist.
-- **Metrik B (Netto-kWh bis Knie):** Zustandsmaschine portierbar; `utility_meter` auf `sensor.bms_1_charge_total_energy`/`_discharge_total_energy`, Leistung `sensor.bmu_power` (Vorzeichen identisch).
-  Das Modul-Minimum kommt per Template aus dem Attribut (10,5-min-Kadenz), der Knie-Latch braucht deshalb eine Zelldaten-Frische-Bedingung **und** eine Haltezeit ≥ 21 min (2 bestätigende Zyklen - `for:` allein zählt keine Samples).
+- **Metrik A präziser:** schwächste Zelle von Modul 2 gegen den Median aller 160 Zellen (aus `cell_voltages`), nur in standardisierten Betriebspunkten gesampelt (Entladeband ≥ 3 min, SoC 25-85, Zelldaten frisch) - identifiziert zusätzlich, ob es noch Zelle 23 ist.
+- **Metrik B (Netto-kWh bis Knie):** Zustandsmaschine portiert; `utility_meter` auf `sensor.bms_1_charge_total_energy`/`_discharge_total_energy`, Leistung `sensor.bmu_power` (Vorzeichen identisch).
+  Die Knie-Erkennung läuft statt über `for:` (das sich per Stagnation auch auf eingefrorenen Werten erfüllt) über einen **Bestätigungszähler** (2 konsekutive qualifizierende BMS-Zyklen) mit **Mess-Anker** am ersten Unterschreitungs-Sample, damit der Wartezeit-Offset aus der Messung fällt.
+- Das Package hat bewusst **keinen Alarm/Push** (Trend-Metriken ohne Baseline haben keinen sinnvollen Schwellwert) und teilt sich Helfer-/Meter-IDs mit `legacy/byd_modul2_fruehwarnung.yaml` - beide nie parallel betreiben, Orphan-Purge vor dem Deploy (Liste im Package-Header).
 
 ## Tests
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,6 +78,7 @@ kopieren und alle `DEIN_*`-Platzhalter durch echte Entitäts-IDs ersetzen.
 | `sma_statistik.yaml` | gleitende Mittelwerte (Verbrauch, Batterielast) |
 | `opti_ki_analyse.yaml` | **optional** - täglicher KI-Tagesreport per `ai_task.generate_data`, rein lesend; Details siehe [docs/canonical-layer.md](canonical-layer.md#ki-analyse-schicht-optional-phase-1) |
 | `byd_monitoring.yaml` | **optional** - BYD-Zell-Monitoring + Akku-Alarme (Spreizung, Temperaturen, Balancing, native Fehlerbits, Daten-Watchdog); braucht die HACS-Integration [`byd_battery_box`](https://github.com/TimWeyand/byd_battery_box) und eine Route/SNAT-Regel zur Box → **[docs/byd-monitoring-nativ.md](byd-monitoring-nativ.md)** |
+| `byd_modul2_fruehwarnung.yaml` | **optional** - BYD Modul-2-Frühwarnung (Degradations-Trend des schwächsten Moduls, rein beobachtend, kein Alarm); setzt `byd_monitoring.yaml` voraus → **[docs/byd-modul2-fruehwarnung.md](byd-modul2-fruehwarnung.md)** |
 | `opti_ev_sperre.yaml` | **optional** - EV-Schnelllade-Entladesperre (evcc im Modus now/minpv); braucht HACS `evcc_intg` + Ladepunkt-Block im Mapping → [docs/strategie-logik.md](strategie-logik.md) (Option 13) |
 
 **4. Home Assistant neu starten** → Helfer, Templates, Statistik & Modbus sind da.

--- a/packages/byd_modul2_fruehwarnung.yaml
+++ b/packages/byd_modul2_fruehwarnung.yaml
@@ -233,8 +233,16 @@ template:
         unit_of_measurement: "mV"
         state_class: measurement
         icon: mdi:arrow-down-bold-box
+        # Availability wie beim zellmin-Sensor: Attribut da UND ein m:2-Eintrag
+        # vorhanden - sonst laeuft min() auf einer leeren Liste in einen
+        # Template-Error.
         availability: >
-          {{ state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') is not none }}
+          {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+          {% set ns = namespace(hat=false) %}
+          {% for modul in daten or [] %}
+            {% if modul['m'] == 2 and (modul['v'] | length) > 0 %}{% set ns.hat = true %}{% endif %}
+          {% endfor %}
+          {{ ns.hat }}
         state: >
           {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
           {% set alle = namespace(v=[]) %}
@@ -281,14 +289,17 @@ template:
   # eingefrorenen Referenz. Trigger auf den Attribut-Traeger (jeder Detail-
   # Zyklus) UND auf die cycle_id (Reset-Signal des Voll-Ankers). Zustandssicher
   # ueber this.attributes:
-  #   - cycle_id_gesehen: gespeicherte != aktuelle -> Zaehler startet neu (faengt
-  #     auch Re-Arm armed->armed ab, der Voll-Anker vergibt IMMER eine neue
-  #     cycle_id).
-  #   - letzter_zyklus (Timestamp des letzten GEZAEHLTEN Samples):
+  #   - cycle_id_gesehen: gespeicherte != aktuelle -> Zaehler BEDINGUNGSLOS auf 0
+  #     (das reine Reset-Event ist KEIN qualifizierendes Sample; faengt auch
+  #     Re-Arm armed->armed ab, der Voll-Anker vergibt IMMER eine neue cycle_id).
+  #     Erst ein cells_average_voltage-Trigger im laufenden Zyklus kann Stand 1
+  #     erzeugen - sonst koennte das erste echte Sample schon Stand 2 latchen.
+  #   - letzter_zyklus (Timestamp des letzten GEZAEHLTEN Samples, 0 = kein Streak):
   #       Abstand < 300 s  -> Doppel-Event, nicht zaehlen (Dedupe)
-  #       Abstand > 1500 s -> Kontinuitaet gebrochen (Datenluecke), Neustart bei 1
-  #   - erstes Sample (Uebergang auf 1) snapshottet netto_bei_erstem_sample und
-  #     absackung_bei_erstem_sample; Stand 2 ueberschreibt sie NICHT.
+  #       Abstand > 1500 s -> Streak-Start (erstes Sample nach Reset/Luecke) -> 1
+  #   - erstes Sample (frischer Uebergang auf 1) snapshottet die Mess-Anker
+  #     netto/absackung/zelle/schwaechstes_modul; Stand 2 ueberschreibt sie NICHT.
+  #     Absackung/Zell-Nr/Modul aus DEMSELBEN Attribut wie die Qualifikation.
   # min(m:2) direkt aus dem Attribut (nicht ueber den zellmin-Sensor -
   # Render-Race).
   # ---------------------------------------------------------------------------
@@ -309,14 +320,15 @@ template:
           {% set qual = is_state('input_select.byd_knie_zyklus_status', 'armed')
              and is_state('binary_sensor.byd_zelldaten_frisch', 'on')
              and is_state('binary_sensor.byd_entladeband', 'on')
+             and has_value('sensor.byd_nettoenergie_seit_voll')
              and m2min is not none
              and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
           {% set cur_cycle = states('input_text.byd_knie_cycle_id') %}
-          {% set seen = this.attributes.get('cycle_id_gesehen') %}
+          {% set neuer_zyklus = cur_cycle != this.attributes.get('cycle_id_gesehen') %}
           {% set prev = this.state | int(0) %}
           {% set abstand = now().timestamp() - (this.attributes.get('letzter_zyklus') | float(0)) %}
-          {% if not qual %}0
-          {% elif cur_cycle != seen %}1
+          {% if neuer_zyklus %}0
+          {% elif not qual %}0
           {% elif abstand < 300 %}{{ prev }}
           {% elif abstand > 1500 %}1
           {% else %}{{ prev + 1 }}{% endif %}
@@ -325,6 +337,8 @@ template:
           # damit der Reset-Vergleich im Folge-Zyklus korrekt greift.
           cycle_id_gesehen: "{{ states('input_text.byd_knie_cycle_id') }}"
           # Timestamp des letzten gezaehlten Samples (0 = kein laufender Streak).
+          # cycle_id-Wechsel setzt bedingungslos 0 (Reset-Event ist KEIN Sample);
+          # nur ein cells_average_voltage-Trigger im laufenden Zyklus zaehlt.
           letzter_zyklus: >
             {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
             {% set mns = namespace(m2=none) %}
@@ -333,20 +347,23 @@ template:
             {% set qual = is_state('input_select.byd_knie_zyklus_status', 'armed')
                and is_state('binary_sensor.byd_zelldaten_frisch', 'on')
                and is_state('binary_sensor.byd_entladeband', 'on')
+               and has_value('sensor.byd_nettoenergie_seit_voll')
                and m2min is not none
                and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
-            {% set cur_cycle = states('input_text.byd_knie_cycle_id') %}
-            {% set seen = this.attributes.get('cycle_id_gesehen') %}
+            {% set neuer_zyklus = states('input_text.byd_knie_cycle_id') != this.attributes.get('cycle_id_gesehen') %}
             {% set letzter = this.attributes.get('letzter_zyklus') | float(0) %}
             {% set jetzt = now().timestamp() %}
             {% set abstand = jetzt - letzter %}
-            {% if not qual %}0
-            {% elif cur_cycle != seen %}{{ jetzt }}
+            {% if neuer_zyklus %}0
+            {% elif not qual %}0
             {% elif abstand < 300 %}{{ letzter }}
             {% else %}{{ jetzt }}{% endif %}
-          # Mess-Anker: nur beim Uebergang auf Stand 1 (frisches erstes Sample)
-          # gesetzt, sonst carry. erstes_sample = qual UND (neue cycle_id ODER
-          # Luecken-Neustart).
+          # Mess-Anker: nur beim frischen Uebergang auf Stand 1 gesetzt (qual,
+          # SELBER Zyklus, Streak-Start via Luecken-/Boot-Abstand), sonst carry.
+          # Der cycle_id-Wechsel selbst ankert NICHT (er nullt nur).
+          # Absackung/Zell-Nr/Modul werden aus DEMSELBEN cell_voltages-Attribut
+          # gerechnet wie die Qualifikation - der Latch darf nicht den gegateten,
+          # ggf. veralteten Sensor lesen (Wert und Zell-Nr muessen zusammenpassen).
           netto_bei_erstem_sample: >
             {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
             {% set mns = namespace(m2=none) %}
@@ -355,12 +372,12 @@ template:
             {% set qual = is_state('input_select.byd_knie_zyklus_status', 'armed')
                and is_state('binary_sensor.byd_zelldaten_frisch', 'on')
                and is_state('binary_sensor.byd_entladeband', 'on')
+               and has_value('sensor.byd_nettoenergie_seit_voll')
                and m2min is not none
                and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
-            {% set cur_cycle = states('input_text.byd_knie_cycle_id') %}
-            {% set seen = this.attributes.get('cycle_id_gesehen') %}
+            {% set neuer_zyklus = states('input_text.byd_knie_cycle_id') != this.attributes.get('cycle_id_gesehen') %}
             {% set abstand = now().timestamp() - (this.attributes.get('letzter_zyklus') | float(0)) %}
-            {% set erstes = qual and (cur_cycle != seen or abstand > 1500) %}
+            {% set erstes = qual and not neuer_zyklus and abstand > 1500 %}
             {{ states('sensor.byd_nettoenergie_seit_voll') if erstes
                else this.attributes.get('netto_bei_erstem_sample') }}
           absackung_bei_erstem_sample: >
@@ -371,14 +388,61 @@ template:
             {% set qual = is_state('input_select.byd_knie_zyklus_status', 'armed')
                and is_state('binary_sensor.byd_zelldaten_frisch', 'on')
                and is_state('binary_sensor.byd_entladeband', 'on')
+               and has_value('sensor.byd_nettoenergie_seit_voll')
                and m2min is not none
                and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
-            {% set cur_cycle = states('input_text.byd_knie_cycle_id') %}
-            {% set seen = this.attributes.get('cycle_id_gesehen') %}
+            {% set neuer_zyklus = states('input_text.byd_knie_cycle_id') != this.attributes.get('cycle_id_gesehen') %}
             {% set abstand = now().timestamp() - (this.attributes.get('letzter_zyklus') | float(0)) %}
-            {% set erstes = qual and (cur_cycle != seen or abstand > 1500) %}
-            {{ states('sensor.byd_modul_2_zell_absackung') if erstes
-               else this.attributes.get('absackung_bei_erstem_sample') }}
+            {% set erstes = qual and not neuer_zyklus and abstand > 1500 %}
+            {% if erstes %}
+              {% set alle = namespace(v=[]) %}
+              {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+              {{ ((alle.v | median) - (mns.m2 | min)) | round(1) }}
+            {% else %}{{ this.attributes.get('absackung_bei_erstem_sample') }}{% endif %}
+          zelle_bei_erstem_sample: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set mns = namespace(m2=none) %}
+            {% for modul in daten or [] %}{% if modul['m'] == 2 %}{% set mns.m2 = modul['v'] %}{% endif %}{% endfor %}
+            {% set m2min = ((mns.m2 | min) / 1000) if mns.m2 else none %}
+            {% set qual = is_state('input_select.byd_knie_zyklus_status', 'armed')
+               and is_state('binary_sensor.byd_zelldaten_frisch', 'on')
+               and is_state('binary_sensor.byd_entladeband', 'on')
+               and has_value('sensor.byd_nettoenergie_seit_voll')
+               and m2min is not none
+               and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
+            {% set neuer_zyklus = states('input_text.byd_knie_cycle_id') != this.attributes.get('cycle_id_gesehen') %}
+            {% set abstand = now().timestamp() - (this.attributes.get('letzter_zyklus') | float(0)) %}
+            {% set erstes = qual and not neuer_zyklus and abstand > 1500 %}
+            {% if erstes %}
+              {% set zns = namespace(minv=99999, zelle=0) %}
+              {% for wert in mns.m2 %}
+                {% if wert < zns.minv %}{% set zns.minv = wert %}{% set zns.zelle = loop.index %}{% endif %}
+              {% endfor %}
+              {{ zns.zelle }}
+            {% else %}{{ this.attributes.get('zelle_bei_erstem_sample') }}{% endif %}
+          schwaechstes_modul_bei_erstem_sample: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set mns = namespace(m2=none) %}
+            {% for modul in daten or [] %}{% if modul['m'] == 2 %}{% set mns.m2 = modul['v'] %}{% endif %}{% endfor %}
+            {% set m2min = ((mns.m2 | min) / 1000) if mns.m2 else none %}
+            {% set qual = is_state('input_select.byd_knie_zyklus_status', 'armed')
+               and is_state('binary_sensor.byd_zelldaten_frisch', 'on')
+               and is_state('binary_sensor.byd_entladeband', 'on')
+               and has_value('sensor.byd_nettoenergie_seit_voll')
+               and m2min is not none
+               and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
+            {% set neuer_zyklus = states('input_text.byd_knie_cycle_id') != this.attributes.get('cycle_id_gesehen') %}
+            {% set abstand = now().timestamp() - (this.attributes.get('letzter_zyklus') | float(0)) %}
+            {% set erstes = qual and not neuer_zyklus and abstand > 1500 %}
+            {% if erstes %}
+              {% set gns = namespace(minv=99999, modul=0) %}
+              {% for modul in daten %}
+                {% for wert in modul['v'] %}
+                  {% if wert < gns.minv %}{% set gns.minv = wert %}{% set gns.modul = modul['m'] %}{% endif %}
+                {% endfor %}
+              {% endfor %}
+              {{ gns.modul }}
+            {% else %}{{ this.attributes.get('schwaechstes_modul_bei_erstem_sample') }}{% endif %}
 
   # ---------------------------------------------------------------------------
   # Metrik B - Latch-Snapshot: snapshottet beim Uebergang nach "latched" die
@@ -405,8 +469,10 @@ template:
           soc: "{{ states('sensor.battery_management_unit_state_of_charge') }}"
           leistung_w: "{{ states('sensor.bmu_power') }}"
           modul2_volt: "{{ states('sensor.byd_modul_2_zellmin') }}"
-          modul2_schwaechste_zelle: "{{ state_attr('sensor.byd_modul_2_zell_absackung', 'zelle') }}"
-          schwaechstes_modul: "{{ state_attr('sensor.byd_modul_2_zell_absackung', 'schwaechstes_modul') }}"
+          # Zell-Nr und Modul aus DEM Zaehler-Anker (gleicher Zyklus wie die
+          # geankerte Absackung), NICHT vom gegateten Momentan-Sensor.
+          modul2_schwaechste_zelle: "{{ state_attr('sensor.byd_knie_bestaetigungen', 'zelle_bei_erstem_sample') }}"
+          schwaechstes_modul: "{{ state_attr('sensor.byd_knie_bestaetigungen', 'schwaechstes_modul_bei_erstem_sample') }}"
           ref_verwendet_v: "{{ states('input_number.byd_knie_ref_frozen') }}"
           cycle_id: "{{ states('input_text.byd_knie_cycle_id') }}"
           sauberer_zyklus: "{{ states('sensor.byd_geladen_seit_voll')|float(0) < 0.5 }}"
@@ -469,6 +535,14 @@ automation:
           {{ is_state('input_select.byd_knie_zyklus_status','idle')
              or states('sensor.byd_nettoenergie_seit_voll')|float(0) >= 0.5 }}
     actions:
+      # ZUERST den Anker-Zeitstempel setzen: der 120-s-Naehe-Guard der
+      # Invalid-Automation (zaehlersprung) blockt sonst nicht das ganze
+      # Reset-Fenster - der Meter-Reset unten erzeugt einen Netto-Sprung, der
+      # ohne aktualisierten voll_anker_zeit als unplausibel gewertet wuerde
+      # (Re-Arm-Race).
+      - action: input_datetime.set_datetime
+        target: { entity_id: input_datetime.byd_voll_anker_zeit }
+        data: { datetime: "{{ now().isoformat() }}" }
       - action: utility_meter.reset
         target:
           entity_id:
@@ -483,9 +557,6 @@ automation:
       - action: input_text.set_value
         target: { entity_id: input_text.byd_knie_cycle_id }
         data: { value: "{{ now().isoformat() }}" }   # neue cycle_id resettet den Bestaetigungszaehler
-      - action: input_datetime.set_datetime
-        target: { entity_id: input_datetime.byd_voll_anker_zeit }
-        data: { datetime: "{{ now().isoformat() }}" }
       - action: input_select.select_option
         target: { entity_id: input_select.byd_knie_zyklus_status }
         data: { option: "armed" }
@@ -531,14 +602,21 @@ automation:
       - condition: state
         entity_id: input_boolean.byd_knie_ueberschwelle_gesehen
         state: "on"
+      # Zaehler >= 2 UND der Mess-Anker ist numerisch (nicht unavailable/None) -
+      # sonst latcht die Maschine mit ungueltigem Snapshot und die Retry-Faehigkeit
+      # (2 -> 3) griffe nicht, weil der Zaehler schon >= 2 stuende.
       - condition: template
-        value_template: "{{ states('sensor.byd_knie_bestaetigungen')|int(0) >= 2 }}"
+        value_template: >
+          {{ states('sensor.byd_knie_bestaetigungen')|int(0) >= 2
+             and (state_attr('sensor.byd_knie_bestaetigungen', 'netto_bei_erstem_sample')|float(none)) is not none }}
     actions:
       - action: input_select.select_option
         target: { entity_id: input_select.byd_knie_zyklus_status }
         data: { option: "latched" }        # der Latch-Sensor snapshottet hierauf
       - action: input_boolean.turn_off
         target: { entity_id: input_boolean.byd_knie_armed }
+      - action: input_boolean.turn_off   # Guard zuruecksetzen (naechster Anker setzt ihn neu)
+        target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
 
   - id: byd_knie_invalid
     alias: "BYD | Knie-Zyklus ungueltig markieren"
@@ -568,31 +646,65 @@ automation:
       - condition: state
         entity_id: input_select.byd_knie_zyklus_status
         state: "armed"
-      - condition: or
-        conditions:
-          - condition: and
-            conditions:
+    actions:
+      - choose:
+          # Datenluecke ODER Neustart nahe Knie.
+          - conditions:
               - condition: trigger
                 id: ["datenluecke", "neustart"]
+            sequence:
+              # Beim Neustart erst auf frische Zelldaten warten (bis 15 min):
+              # zellmin ist nach dem Boot noch unavailable (erste BMS-Detail-
+              # Runde bis 630 s spaeter), float(0) wuerde sonst JEDEN Routine-
+              # Restart im armed-Zustand als "nah am Knie" invalidieren und
+              # gesunde Plateau-Zyklen verwerfen. Nach Timeout (Integration
+              # wirklich tot, Fork-Setup-Fehlschlag) greift float(0) korrekt =
+              # verwerfen. Datenluecke wartet NICHT (sie IST das Ausfall-Signal).
+              - if:
+                  - condition: trigger
+                    id: neustart
+                then:
+                  - wait_template: "{{ has_value('sensor.byd_modul_2_zellmin') }}"
+                    timeout: "00:15:00"
+                    continue_on_timeout: true
+              # Nach dem evtl. langen Warten muss der Zyklus noch armed sein.
+              - condition: state
+                entity_id: input_select.byd_knie_zyklus_status
+                state: "armed"
               # Naehe-Check fail-safe (Codex-P2): float(0) statt float(9) -
-              # unbekannt/unavailable (z. B. Boot-Setup-Fehlschlag) zaehlt als
-              # NAH am Knie -> invalid (unbekannt heisst verwerfen, nicht durchwinken).
+              # unbekannt/unavailable zaehlt als NAH am Knie -> invalid.
               - condition: template
                 value_template: >
                   {{ states('sensor.byd_modul_2_zellmin')|float(0)
                      <= states('input_number.byd_knie_ref_frozen')|float(3.20) + 0.01 }}
-          - condition: template
-            value_template: >
-              {{ trigger.id == 'zaehlersprung'
-                 and trigger.from_state is not none and trigger.to_state is not none
-                 and trigger.from_state.state not in ['unknown','unavailable']
-                 and trigger.to_state.state not in ['unknown','unavailable']
-                 and (trigger.to_state.state|float - trigger.from_state.state|float) > 3
-                 and (now().timestamp() - state_attr('input_datetime.byd_voll_anker_zeit','timestamp')|float(0)) > 120 }}
-    actions:
-      - action: input_select.select_option
-        target: { entity_id: input_select.byd_knie_zyklus_status }
-        data: { option: "invalid" }
-      - action: input_text.set_value
-        target: { entity_id: input_text.byd_knie_invalid_grund }
-        data: { value: "{{ trigger.id }} @ {{ now().strftime('%Y-%m-%d %H:%M') }}" }
+              - action: input_select.select_option
+                target: { entity_id: input_select.byd_knie_zyklus_status }
+                data: { option: "invalid" }
+              - action: input_boolean.turn_off   # armed aus (sonst Zustandswiderspruch)
+                target: { entity_id: input_boolean.byd_knie_armed }
+              - action: input_boolean.turn_off   # Guard zuruecksetzen
+                target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
+              - action: input_text.set_value
+                target: { entity_id: input_text.byd_knie_invalid_grund }
+                data: { value: "{{ trigger.id }} @ {{ now().strftime('%Y-%m-%d %H:%M') }}" }
+          # Unplausibler Netto-Sprung (> 3 kWh, ausserhalb der Anker-Sekunden).
+          - conditions:
+              - condition: template
+                value_template: >
+                  {{ trigger.id == 'zaehlersprung'
+                     and trigger.from_state is not none and trigger.to_state is not none
+                     and trigger.from_state.state not in ['unknown','unavailable']
+                     and trigger.to_state.state not in ['unknown','unavailable']
+                     and (trigger.to_state.state|float - trigger.from_state.state|float) > 3
+                     and (now().timestamp() - state_attr('input_datetime.byd_voll_anker_zeit','timestamp')|float(0)) > 120 }}
+            sequence:
+              - action: input_select.select_option
+                target: { entity_id: input_select.byd_knie_zyklus_status }
+                data: { option: "invalid" }
+              - action: input_boolean.turn_off   # armed aus (sonst Zustandswiderspruch)
+                target: { entity_id: input_boolean.byd_knie_armed }
+              - action: input_boolean.turn_off   # Guard zuruecksetzen
+                target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
+              - action: input_text.set_value
+                target: { entity_id: input_text.byd_knie_invalid_grund }
+                data: { value: "{{ trigger.id }} @ {{ now().strftime('%Y-%m-%d %H:%M') }}" }

--- a/packages/byd_modul2_fruehwarnung.yaml
+++ b/packages/byd_modul2_fruehwarnung.yaml
@@ -74,6 +74,14 @@
 # 3-kWh-Sprung setzt eine >39-min-Datenluecke voraus - und die zu verwerfen ist
 # genau richtig konservativ.
 #
+# PLAUSIBILITAETS-FLOOR (Meta-Review 17.7., Fable+Codex): die qual-Bedingung
+# verlangt zusaetzlich m2min > 2,5 V. Ein implausibel niedriger Wert (Garbage,
+# Sensor-Stoerung, oder eine kuenftige Integrations-Regression, die die
+# Attribute verschoebe) zaehlt so NICHT als "unter Knie" - echtes Tiefstvolt
+# ist Sache des Alarm-Layers, nicht der Fruehwarnung. Belt-and-suspenders:
+# macht Garbage inert statt latch-faehig; der Watchdog prueft nur Frische,
+# nicht Plausibilitaet.
+#
 # HELFER OHNE initial: HA wendet initial bei JEDEM Neustart an (nicht nur beim
 # ersten Setup) und wuerde Referenz und Zyklus-Status ueberschreiben; ohne
 # initial restored HA den letzten Wert. Deploy-Re-Seed (der Zyklus vom 16.7.
@@ -322,7 +330,7 @@ template:
              and is_state('binary_sensor.byd_entladeband', 'on')
              and has_value('sensor.byd_nettoenergie_seit_voll')
              and m2min is not none
-             and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
+             and m2min > 2.5 and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
           {% set cur_cycle = states('input_text.byd_knie_cycle_id') %}
           {% set neuer_zyklus = cur_cycle != this.attributes.get('cycle_id_gesehen') %}
           {% set prev = this.state | int(0) %}
@@ -349,7 +357,7 @@ template:
                and is_state('binary_sensor.byd_entladeband', 'on')
                and has_value('sensor.byd_nettoenergie_seit_voll')
                and m2min is not none
-               and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
+               and m2min > 2.5 and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
             {% set neuer_zyklus = states('input_text.byd_knie_cycle_id') != this.attributes.get('cycle_id_gesehen') %}
             {% set letzter = this.attributes.get('letzter_zyklus') | float(0) %}
             {% set jetzt = now().timestamp() %}
@@ -374,7 +382,7 @@ template:
                and is_state('binary_sensor.byd_entladeband', 'on')
                and has_value('sensor.byd_nettoenergie_seit_voll')
                and m2min is not none
-               and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
+               and m2min > 2.5 and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
             {% set neuer_zyklus = states('input_text.byd_knie_cycle_id') != this.attributes.get('cycle_id_gesehen') %}
             {% set abstand = now().timestamp() - (this.attributes.get('letzter_zyklus') | float(0)) %}
             {% set erstes = qual and not neuer_zyklus and abstand > 1500 %}
@@ -390,7 +398,7 @@ template:
                and is_state('binary_sensor.byd_entladeband', 'on')
                and has_value('sensor.byd_nettoenergie_seit_voll')
                and m2min is not none
-               and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
+               and m2min > 2.5 and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
             {% set neuer_zyklus = states('input_text.byd_knie_cycle_id') != this.attributes.get('cycle_id_gesehen') %}
             {% set abstand = now().timestamp() - (this.attributes.get('letzter_zyklus') | float(0)) %}
             {% set erstes = qual and not neuer_zyklus and abstand > 1500 %}
@@ -409,7 +417,7 @@ template:
                and is_state('binary_sensor.byd_entladeband', 'on')
                and has_value('sensor.byd_nettoenergie_seit_voll')
                and m2min is not none
-               and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
+               and m2min > 2.5 and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
             {% set neuer_zyklus = states('input_text.byd_knie_cycle_id') != this.attributes.get('cycle_id_gesehen') %}
             {% set abstand = now().timestamp() - (this.attributes.get('letzter_zyklus') | float(0)) %}
             {% set erstes = qual and not neuer_zyklus and abstand > 1500 %}
@@ -430,7 +438,7 @@ template:
                and is_state('binary_sensor.byd_entladeband', 'on')
                and has_value('sensor.byd_nettoenergie_seit_voll')
                and m2min is not none
-               and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
+               and m2min > 2.5 and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
             {% set neuer_zyklus = states('input_text.byd_knie_cycle_id') != this.attributes.get('cycle_id_gesehen') %}
             {% set abstand = now().timestamp() - (this.attributes.get('letzter_zyklus') | float(0)) %}
             {% set erstes = qual and not neuer_zyklus and abstand > 1500 %}

--- a/packages/byd_modul2_fruehwarnung.yaml
+++ b/packages/byd_modul2_fruehwarnung.yaml
@@ -1,0 +1,598 @@
+# =============================================================================
+# BYD Modul-2 Fruehwarnung (nativ ueber Modbus) - OPTIONAL, rein beobachtend
+# -----------------------------------------------------------------------------
+# Beobachtet das schwaechste Modul des Turms (hier Modul 2) auf schleichende
+# Degradation - KEINE Steuerwirkung, KEIN Alarm/Push (bewusst, s. unten).
+# Portiert legacy/byd_modul2_fruehwarnung.yaml auf die native Integration
+# byd_battery_box (Modbus). Design/Doku: docs/byd-modul2-fruehwarnung.md.
+#
+# ABHAENGIGKEIT: setzt packages/byd_monitoring.yaml voraus. Referenziert von
+# dort DIREKT (nichts dupliziert):
+#   binary_sensor.byd_bmu_frisch, binary_sensor.byd_zelldaten_frisch,
+#   sensor.battery_management_unit_state_of_charge, sensor.bmu_power,
+#   sensor.bmu_cell_voltage_max, sensor.bms_1_cells_average_voltage
+#   (Attribut cell_voltages), sensor.bms_1_charge/discharge_total_energy.
+#
+# +++ NIE PARALLEL zu legacy/byd_modul2_fruehwarnung.yaml betreiben +++
+# Beide teilen sich Helfer-IDs (byd_knie_*) und utility_meter-IDs
+# (byd_geladen_seit_voll / byd_entladen_seit_voll). Gleichzeitig aktiv erzeugt
+# HA _2-Suffixe und vermischt zwei inkompatible Zustandsmaschinen.
+#
+# ---------------------------------------------------------------------------
+# ORPHAN-PURGE VOR DEM DEPLOY (E5): die Template-Entities bekommen NEUE
+# unique_ids (Suffix _nativ), damit der Slug-Test die Live-IDs beweist. Die
+# entity_ids bleiben kanonisch nur, wenn die verwaisten Registry-Eintraege der
+# Legacy-Fruehwarnung VOR dem Restart per UI geloescht werden - sonst haengt
+# HA _2-Suffixe an. Zu loeschende Orphans (config-los seit dem Cutover):
+#   sensor.byd_modul_2_absackung           (Metrik A alt, ersetzt durch
+#                                            sensor.byd_modul_2_zell_absackung)
+#   sensor.byd_modul_2_netto_bis_knie      (bzw. dessen tatsaechliche ID)
+#   sensor.byd_nettoenergie_seit_voll
+#   binary_sensor.byd_entladeband
+#   binary_sensor.byd_daten_frisch         (wird NICHT nachgebaut)
+#   utility_meter.byd_geladen_seit_voll / _entladen_seit_voll
+# Danach registrieren sich die neuen Entities frisch unter ihren Namens-Slugs.
+# Die Absackungs-Dashboard-Karte einmal auf den neuen Namen umziehen.
+#
+# ---------------------------------------------------------------------------
+# ZWEI METRIKEN (Design: docs/byd-modul2-fruehwarnung.md)
+# ---------------------------------------------------------------------------
+#   A) sensor.byd_modul_2_zell_absackung - Absackung der schwaechsten Zelle von
+#      Modul 2 gegen den Median ALLER 160 Zellen, in mV. Nur in standardisierten
+#      Betriebspunkten gesampelt (Entladeband >= 3 min, SoC 25-85, Zelldaten
+#      frisch) - die Interpretations-Vorgabe erzwingt jetzt der Sensor selbst.
+#   B) sensor.byd_modul_2_nettoenergie_bis_knie - Nettoenergie in kWh von der
+#      letzten Vollladung bis zum LFP-Knie der schwaechsten Zelle. DIE
+#      Langzeit-Metrik fuer Kapazitaets-Degradation.
+#
+# KEIN ALARM/PUSH: das Alt-Design hatte keinen, und Trend-Metriken ohne
+# Baseline koennen keinen sinnvollen Schwellwert haben. Erst nach Wochen
+# Baseline lohnt eine Drift-Regel - dann als eigener PR.
+# TODO(nach Baseline): Drift-Regel auf sensor.byd_modul_2_nettoenergie_bis_knie.
+#
+# ---------------------------------------------------------------------------
+# ZUSTANDSMASCHINE (input_select.byd_knie_zyklus_status)
+# ---------------------------------------------------------------------------
+#   idle -> armed (Voll-Anker nach Ladeschluss) -> latched (Knie bestaetigt,
+#   Snapshot) bzw. invalid (Messqualitaet unzureichend).
+#
+# KNIE-ERKENNUNG PER BESTAETIGUNGSZAEHLER statt for: (Codex-P1). Ein for: >= 21
+# min wuerde (a) Latch-Ausbeute an Haushaltslast-Flattern verlieren, (b) sich
+# per Stagnation auch auf eingefrorenen Werten erfuellen, (c) einen mit der
+# Wartezeit wachsenden kWh-Offset erzeugen. Der Zaehler
+# sensor.byd_knie_bestaetigungen zaehlt konsekutive qualifizierende BMS-Zyklen
+# und ist ZUSTANDS- statt flankensicher (cycle_id-basierter Reset, 300-s-Dedupe
+# gegen Doppel-Events, 1500-s-Luecken-Guard). MESS-ANKER: beim Uebergang auf
+# Stand 1 snapshottet der Zaehler netto_bei_erstem_sample und
+# absackung_bei_erstem_sample - der Latch uebernimmt DIESE Werte, gemessen am
+# ersten Unterschreitungs-Sample (Lag <= 1 Zyklus, 0-0,26 kWh). Der Latch
+# feuert ueber einen state-Trigger auf den Zaehler mit >= 2-Bedingung, ist also
+# nach einem Fehlschlag/Neustart retry-faehig (2 -> 3 feuert erneut).
+#
+# ZAEHLERSPRUNG-INVALID > 3 kWh: bleibt. Der WR macht max. ~4,6 kW, also sind
+# 3 kWh in einem ~10,5-min-BMS-Zyklus physikalisch unmoeglich. Ein legitimer
+# 3-kWh-Sprung setzt eine >39-min-Datenluecke voraus - und die zu verwerfen ist
+# genau richtig konservativ.
+#
+# HELFER OHNE initial: HA wendet initial bei JEDEM Neustart an (nicht nur beim
+# ersten Setup) und wuerde Referenz und Zyklus-Status ueberschreiben; ohne
+# initial restored HA den letzten Wert. Deploy-Re-Seed (der Zyklus vom 16.7.
+# ist durch den Quellenwechsel gebrochen, NICHT wiederherstellen):
+#   status=idle, armed=off, ueberschwelle=off, top_erreicht=off,
+#   referenzspannung=3,20, ref_frozen=3,20.
+# =============================================================================
+
+input_number:
+  byd_knie_referenzspannung:
+    name: "BYD Knie-Referenzspannung"
+    min: 3.05
+    max: 3.35
+    step: 0.005
+    unit_of_measurement: "V"
+    mode: box
+    icon: mdi:sine-wave
+  byd_knie_ref_frozen:
+    name: "BYD Knie-Referenz (eingefroren)"
+    min: 3.05
+    max: 3.35
+    step: 0.001
+    unit_of_measurement: "V"
+    mode: box
+    icon: mdi:snowflake
+
+input_boolean:
+  byd_knie_armed:
+    name: "BYD Knie scharf"
+    icon: mdi:target
+  byd_knie_ueberschwelle_gesehen:
+    name: "BYD Knie Ueberschwelle gesehen"
+    icon: mdi:arrow-up-bold
+  byd_top_erreicht:
+    name: "BYD Ladeschluss erreicht"
+    icon: mdi:arrow-collapse-up
+
+input_select:
+  byd_knie_zyklus_status:
+    name: "BYD Knie Zyklus-Status"
+    # Erste Option = Startwert bei Erstinstallation; danach restore.
+    options: ["idle", "armed", "latched", "invalid"]
+    icon: mdi:state-machine
+
+input_text:
+  byd_knie_cycle_id:
+    name: "BYD Knie Cycle-ID"
+    max: 40
+  byd_knie_invalid_grund:
+    name: "BYD Knie Invalid-Grund"
+    max: 120
+
+input_datetime:
+  byd_voll_anker_zeit:
+    name: "BYD Voll-Anker Zeit"
+    has_date: true
+    has_time: true
+
+utility_meter:
+  # Quellen: native BMS-Lebenszaehler (kWh, total_increasing). Der Zyklus-Reset
+  # passiert im Voll-Anker per utility_meter.reset, deshalb kein periodischer.
+  byd_geladen_seit_voll:
+    source: sensor.bms_1_charge_total_energy
+    name: "BYD geladen seit Voll"
+    periodically_resetting: false
+  byd_entladen_seit_voll:
+    source: sensor.bms_1_discharge_total_energy
+    name: "BYD entladen seit Voll"
+    periodically_resetting: false
+
+template:
+  # ---------------------------------------------------------------------------
+  # Zustandslose Ableitungen (laufend reevaluiert)
+  # ---------------------------------------------------------------------------
+  - binary_sensor:
+      # Standardisierter Betriebspunkt: 500-1500 W ENTLADUNG (bmu_power positiv =
+      # Entladen, negativ = Laden). Braucht frische BMU-Daten - eingefrorene
+      # 800 W duerfen kein Band halten (Codex-P2).
+      - unique_id: byd_entladeband_nativ
+        name: "BYD Entladeband"
+        icon: mdi:speedometer-slow
+        state: >
+          {% set p = states('sensor.bmu_power')|float(0) %}
+          {{ is_state('binary_sensor.byd_bmu_frisch', 'on')
+             and has_value('sensor.bmu_power') and 500 <= p <= 1500 }}
+
+  - sensor:
+      # Schwaechste Zelle von Modul 2 (V, 3 Dezimalen) direkt aus dem
+      # cell_voltages-Attribut. Fuer Anzeige, Ueberschwelle-Trigger und die
+      # Naehe-Checks der Invalid-Automation. Availability am Attribut UND am
+      # Vorhandensein des m:2-Eintrags.
+      - unique_id: byd_modul2_zellmin_nativ
+        name: "BYD Modul-2 Zellmin"
+        unit_of_measurement: "V"
+        device_class: voltage
+        state_class: measurement
+        icon: mdi:battery-low
+        availability: >
+          {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+          {% set ns = namespace(hat=false) %}
+          {% for modul in daten or [] %}
+            {% if modul['m'] == 2 and (modul['v'] | length) > 0 %}{% set ns.hat = true %}{% endif %}
+          {% endfor %}
+          {{ ns.hat }}
+        state: >
+          {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+          {% set ns = namespace(m2=none) %}
+          {% for modul in daten or [] %}
+            {% if modul['m'] == 2 %}{% set ns.m2 = modul['v'] %}{% endif %}
+          {% endfor %}
+          {{ ((ns.m2 | min) / 1000) | round(3) }}
+
+      # Nettoenergie seit dem letzten Voll-Anker (entladen - geladen, kWh).
+      # measurement statt total_increasing (darf bei PV-Zwischenladung sinken).
+      - unique_id: byd_netto_energie_seit_voll_nativ
+        name: "BYD Nettoenergie seit Voll"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: measurement
+        icon: mdi:battery-minus-outline
+        availability: >
+          {{ has_value('sensor.byd_entladen_seit_voll') and has_value('sensor.byd_geladen_seit_voll') }}
+        state: >
+          {{ (states('sensor.byd_entladen_seit_voll')|float
+              - states('sensor.byd_geladen_seit_voll')|float) | round(3) }}
+
+  # ---------------------------------------------------------------------------
+  # Metrik A: Zell-Absackung Modul 2 gegen Median(160), nur in standardisierten
+  # Betriebspunkten. Trigger direkt auf den Attribut-Traeger
+  # (cells_average_voltage) - ein einfacher state-Trigger feuert auch auf
+  # Attribut-Updates, damit stammt das gelesene Attribut aus DEM ausloesenden
+  # Zyklus (kein Reihenfolge-Race zu einem fremden Timestamp-Sensor).
+  # Gate: Zelldaten frisch, Entladeband seit >= 3 min, BMU-SoC 25-85.
+  # Restrisiko (dokumentiert, bewusst ohne Glaettung): SoC/Leistung stammen vom
+  # letzten BMU-Poll (bis ~60 s vor dem Zell-Read), ein Lastwechsel in diesem
+  # Fenster kann ein Sample falsch etikettieren - ueber die Kontext-Attribute
+  # filterbar.
+  # ---------------------------------------------------------------------------
+  - triggers:
+      - trigger: state
+        entity_id: sensor.bms_1_cells_average_voltage
+    conditions:
+      - condition: state
+        entity_id: binary_sensor.byd_zelldaten_frisch
+        state: "on"
+      - condition: state
+        entity_id: binary_sensor.byd_entladeband
+        state: "on"
+        for: "00:03:00"
+      - condition: numeric_state
+        entity_id: sensor.battery_management_unit_state_of_charge
+        above: 25
+        below: 85
+    sensor:
+      - unique_id: byd_modul2_zell_absackung_nativ
+        name: "BYD Modul-2 Zell-Absackung"
+        unit_of_measurement: "mV"
+        state_class: measurement
+        icon: mdi:arrow-down-bold-box
+        availability: >
+          {{ state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') is not none }}
+        state: >
+          {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+          {% set alle = namespace(v=[]) %}
+          {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+          {% set med = alle.v | median %}
+          {% set m2 = namespace(v=[]) %}
+          {% for modul in daten %}{% if modul['m'] == 2 %}{% set m2.v = modul['v'] | list %}{% endif %}{% endfor %}
+          {{ (med - (m2.v | min)) | round(1) }}
+        attributes:
+          # Zell-Nummer 1..32 des Minimums INNERHALB von Modul 2.
+          zelle: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set ns = namespace(minv=99999, zelle=0) %}
+            {% for modul in daten %}
+              {% if modul['m'] == 2 %}
+                {% for wert in modul['v'] %}
+                  {% if wert < ns.minv %}{% set ns.minv = wert %}{% set ns.zelle = loop.index %}{% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.zelle }}
+          # Modul (1..5) der global schwaechsten Zelle - macht eine Drift zu
+          # einem anderen Modul sichtbar.
+          schwaechstes_modul: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set ns = namespace(minv=99999, modul=0) %}
+            {% for modul in daten %}
+              {% for wert in modul['v'] %}
+                {% if wert < ns.minv %}{% set ns.minv = wert %}{% set ns.modul = modul['m'] %}{% endif %}
+              {% endfor %}
+            {% endfor %}
+            {{ ns.modul }}
+          median_mv: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set alle = namespace(v=[]) %}
+            {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+            {{ alle.v | median }}
+          soc: "{{ states('sensor.battery_management_unit_state_of_charge') }}"
+          leistung_w: "{{ states('sensor.bmu_power') }}"
+          gemessen: "{{ now().isoformat() }}"
+
+  # ---------------------------------------------------------------------------
+  # Bestaetigungszaehler: konsekutive qualifizierende BMS-Zyklen unter der
+  # eingefrorenen Referenz. Trigger auf den Attribut-Traeger (jeder Detail-
+  # Zyklus) UND auf die cycle_id (Reset-Signal des Voll-Ankers). Zustandssicher
+  # ueber this.attributes:
+  #   - cycle_id_gesehen: gespeicherte != aktuelle -> Zaehler startet neu (faengt
+  #     auch Re-Arm armed->armed ab, der Voll-Anker vergibt IMMER eine neue
+  #     cycle_id).
+  #   - letzter_zyklus (Timestamp des letzten GEZAEHLTEN Samples):
+  #       Abstand < 300 s  -> Doppel-Event, nicht zaehlen (Dedupe)
+  #       Abstand > 1500 s -> Kontinuitaet gebrochen (Datenluecke), Neustart bei 1
+  #   - erstes Sample (Uebergang auf 1) snapshottet netto_bei_erstem_sample und
+  #     absackung_bei_erstem_sample; Stand 2 ueberschreibt sie NICHT.
+  # min(m:2) direkt aus dem Attribut (nicht ueber den zellmin-Sensor -
+  # Render-Race).
+  # ---------------------------------------------------------------------------
+  - triggers:
+      - trigger: state
+        entity_id: sensor.bms_1_cells_average_voltage
+      - trigger: state
+        entity_id: input_text.byd_knie_cycle_id
+    sensor:
+      - unique_id: byd_knie_bestaetigungen_nativ
+        name: "BYD Knie Bestaetigungen"
+        icon: mdi:counter
+        state: >
+          {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+          {% set mns = namespace(m2=none) %}
+          {% for modul in daten or [] %}{% if modul['m'] == 2 %}{% set mns.m2 = modul['v'] %}{% endif %}{% endfor %}
+          {% set m2min = ((mns.m2 | min) / 1000) if mns.m2 else none %}
+          {% set qual = is_state('input_select.byd_knie_zyklus_status', 'armed')
+             and is_state('binary_sensor.byd_zelldaten_frisch', 'on')
+             and is_state('binary_sensor.byd_entladeband', 'on')
+             and m2min is not none
+             and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
+          {% set cur_cycle = states('input_text.byd_knie_cycle_id') %}
+          {% set seen = this.attributes.get('cycle_id_gesehen') %}
+          {% set prev = this.state | int(0) %}
+          {% set abstand = now().timestamp() - (this.attributes.get('letzter_zyklus') | float(0)) %}
+          {% if not qual %}0
+          {% elif cur_cycle != seen %}1
+          {% elif abstand < 300 %}{{ prev }}
+          {% elif abstand > 1500 %}1
+          {% else %}{{ prev + 1 }}{% endif %}
+        attributes:
+          # Immer die aktuell gesehene cycle_id merken (auch nicht-qualifizierend),
+          # damit der Reset-Vergleich im Folge-Zyklus korrekt greift.
+          cycle_id_gesehen: "{{ states('input_text.byd_knie_cycle_id') }}"
+          # Timestamp des letzten gezaehlten Samples (0 = kein laufender Streak).
+          letzter_zyklus: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set mns = namespace(m2=none) %}
+            {% for modul in daten or [] %}{% if modul['m'] == 2 %}{% set mns.m2 = modul['v'] %}{% endif %}{% endfor %}
+            {% set m2min = ((mns.m2 | min) / 1000) if mns.m2 else none %}
+            {% set qual = is_state('input_select.byd_knie_zyklus_status', 'armed')
+               and is_state('binary_sensor.byd_zelldaten_frisch', 'on')
+               and is_state('binary_sensor.byd_entladeband', 'on')
+               and m2min is not none
+               and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
+            {% set cur_cycle = states('input_text.byd_knie_cycle_id') %}
+            {% set seen = this.attributes.get('cycle_id_gesehen') %}
+            {% set letzter = this.attributes.get('letzter_zyklus') | float(0) %}
+            {% set jetzt = now().timestamp() %}
+            {% set abstand = jetzt - letzter %}
+            {% if not qual %}0
+            {% elif cur_cycle != seen %}{{ jetzt }}
+            {% elif abstand < 300 %}{{ letzter }}
+            {% else %}{{ jetzt }}{% endif %}
+          # Mess-Anker: nur beim Uebergang auf Stand 1 (frisches erstes Sample)
+          # gesetzt, sonst carry. erstes_sample = qual UND (neue cycle_id ODER
+          # Luecken-Neustart).
+          netto_bei_erstem_sample: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set mns = namespace(m2=none) %}
+            {% for modul in daten or [] %}{% if modul['m'] == 2 %}{% set mns.m2 = modul['v'] %}{% endif %}{% endfor %}
+            {% set m2min = ((mns.m2 | min) / 1000) if mns.m2 else none %}
+            {% set qual = is_state('input_select.byd_knie_zyklus_status', 'armed')
+               and is_state('binary_sensor.byd_zelldaten_frisch', 'on')
+               and is_state('binary_sensor.byd_entladeband', 'on')
+               and m2min is not none
+               and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
+            {% set cur_cycle = states('input_text.byd_knie_cycle_id') %}
+            {% set seen = this.attributes.get('cycle_id_gesehen') %}
+            {% set abstand = now().timestamp() - (this.attributes.get('letzter_zyklus') | float(0)) %}
+            {% set erstes = qual and (cur_cycle != seen or abstand > 1500) %}
+            {{ states('sensor.byd_nettoenergie_seit_voll') if erstes
+               else this.attributes.get('netto_bei_erstem_sample') }}
+          absackung_bei_erstem_sample: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set mns = namespace(m2=none) %}
+            {% for modul in daten or [] %}{% if modul['m'] == 2 %}{% set mns.m2 = modul['v'] %}{% endif %}{% endfor %}
+            {% set m2min = ((mns.m2 | min) / 1000) if mns.m2 else none %}
+            {% set qual = is_state('input_select.byd_knie_zyklus_status', 'armed')
+               and is_state('binary_sensor.byd_zelldaten_frisch', 'on')
+               and is_state('binary_sensor.byd_entladeband', 'on')
+               and m2min is not none
+               and m2min < states('input_number.byd_knie_ref_frozen')|float(3.20) %}
+            {% set cur_cycle = states('input_text.byd_knie_cycle_id') %}
+            {% set seen = this.attributes.get('cycle_id_gesehen') %}
+            {% set abstand = now().timestamp() - (this.attributes.get('letzter_zyklus') | float(0)) %}
+            {% set erstes = qual and (cur_cycle != seen or abstand > 1500) %}
+            {{ states('sensor.byd_modul_2_zell_absackung') if erstes
+               else this.attributes.get('absackung_bei_erstem_sample') }}
+
+  # ---------------------------------------------------------------------------
+  # Metrik B - Latch-Snapshot: snapshottet beim Uebergang nach "latched" die
+  # MESS-ANKER-Werte (netto/absackung am ersten Unterschreitungs-Sample, nicht
+  # den Momentanwert) plus Kontext.
+  # ---------------------------------------------------------------------------
+  - triggers:
+      - trigger: state
+        entity_id: input_select.byd_knie_zyklus_status
+        to: "latched"
+    sensor:
+      - unique_id: byd_modul2_netto_bis_knie_nativ
+        name: "BYD Modul-2 Nettoenergie bis Knie"
+        unit_of_measurement: "kWh"
+        device_class: energy
+        state_class: measurement
+        icon: mdi:battery-alert-variant-outline
+        state: "{{ state_attr('sensor.byd_knie_bestaetigungen', 'netto_bei_erstem_sample') }}"
+        attributes:
+          netto_kwh: "{{ state_attr('sensor.byd_knie_bestaetigungen', 'netto_bei_erstem_sample') }}"
+          a_absackung_mv: "{{ state_attr('sensor.byd_knie_bestaetigungen', 'absackung_bei_erstem_sample') }}"
+          geladen_inkrement_kwh: "{{ states('sensor.byd_geladen_seit_voll') }}"
+          entladen_inkrement_kwh: "{{ states('sensor.byd_entladen_seit_voll') }}"
+          soc: "{{ states('sensor.battery_management_unit_state_of_charge') }}"
+          leistung_w: "{{ states('sensor.bmu_power') }}"
+          modul2_volt: "{{ states('sensor.byd_modul_2_zellmin') }}"
+          modul2_schwaechste_zelle: "{{ state_attr('sensor.byd_modul_2_zell_absackung', 'zelle') }}"
+          schwaechstes_modul: "{{ state_attr('sensor.byd_modul_2_zell_absackung', 'schwaechstes_modul') }}"
+          ref_verwendet_v: "{{ states('input_number.byd_knie_ref_frozen') }}"
+          cycle_id: "{{ states('input_text.byd_knie_cycle_id') }}"
+          sauberer_zyklus: "{{ states('sensor.byd_geladen_seit_voll')|float(0) < 0.5 }}"
+          gemessen: "{{ now().isoformat() }}"
+
+automation:
+  - id: byd_top_erreicht_merker
+    alias: "BYD | Ladeschluss-Merker setzen"
+    description: "Merkt sich, dass im laufenden Ladevorgang die Ladeschluss-Zellspannung erreicht wurde (Voll-Anker-Evidenz). bmu_cell_voltage_max ist 10-mV-granular, feuert also effektiv ab 3,56 V - fuer Ladeschluss-Evidenz egal."
+    mode: single
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.bmu_cell_voltage_max
+        above: 3.55
+        for: "00:02:00"
+    conditions:
+      # Eingefrorene 3,56 V duerfen keine Ladeschluss-Evidenz vortaeuschen.
+      - condition: state
+        entity_id: binary_sensor.byd_bmu_frisch
+        state: "on"
+    actions:
+      - action: input_boolean.turn_on
+        target: { entity_id: input_boolean.byd_top_erreicht }
+
+  - id: byd_voll_anker
+    alias: "BYD | Voll-Anker (Ladeabschluss)"
+    description: >-
+      Ladeabschluss-Event: Zellmax war >=3,55 V (Merker), danach Ladeende
+      (bmu_power > -300 W = nicht mehr nennenswert Laden) fuer 5 min. Setzt den
+      Knie-Zyklus neu auf. Re-Arm-Sperre: nur wenn idle ODER seit letztem Anker
+      >=0,5 kWh netto entnommen (verhindert Mehrfach-Reset im Ladeschluss-Flattern).
+    mode: single
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.bmu_power
+        above: -300
+        for: "00:05:00"
+    conditions:
+      - condition: state
+        entity_id: input_boolean.byd_top_erreicht
+        state: "on"
+      - condition: numeric_state
+        entity_id: sensor.battery_management_unit_state_of_charge
+        above: 94
+      # Beide Frische-Binaries UND die Gueltigkeit der Zyklus-Basiswerte
+      # (Codex-P2): das alte byd_daten_frisch enthielt die Meter, nicht verlieren.
+      - condition: state
+        entity_id: binary_sensor.byd_bmu_frisch
+        state: "on"
+      - condition: state
+        entity_id: binary_sensor.byd_zelldaten_frisch
+        state: "on"
+      - condition: template
+        value_template: >
+          {{ has_value('sensor.byd_geladen_seit_voll')
+             and has_value('sensor.byd_entladen_seit_voll')
+             and has_value('sensor.byd_nettoenergie_seit_voll') }}
+      - condition: template
+        value_template: >
+          {{ is_state('input_select.byd_knie_zyklus_status','idle')
+             or states('sensor.byd_nettoenergie_seit_voll')|float(0) >= 0.5 }}
+    actions:
+      - action: utility_meter.reset
+        target:
+          entity_id:
+            - sensor.byd_geladen_seit_voll
+            - sensor.byd_entladen_seit_voll
+      - action: input_number.set_value
+        target: { entity_id: input_number.byd_knie_ref_frozen }
+        data:
+          value: "{{ states('input_number.byd_knie_referenzspannung')|float(3.20) }}"
+      - action: input_boolean.turn_on   # am Anker ist Modul 2 verifiziert hoch -> Flag direkt setzen (Guard-Automation ist redundanter Backup)
+        target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
+      - action: input_text.set_value
+        target: { entity_id: input_text.byd_knie_cycle_id }
+        data: { value: "{{ now().isoformat() }}" }   # neue cycle_id resettet den Bestaetigungszaehler
+      - action: input_datetime.set_datetime
+        target: { entity_id: input_datetime.byd_voll_anker_zeit }
+        data: { datetime: "{{ now().isoformat() }}" }
+      - action: input_select.select_option
+        target: { entity_id: input_select.byd_knie_zyklus_status }
+        data: { option: "armed" }
+      - action: input_boolean.turn_on
+        target: { entity_id: input_boolean.byd_knie_armed }
+      - action: input_boolean.turn_off
+        target: { entity_id: input_boolean.byd_top_erreicht }
+
+  - id: byd_knie_ueberschwelle_gesehen
+    alias: "BYD | Knie Ueberschwelle gesehen"
+    description: "Setzt das Guard-Flag, sobald Modul-2-min seit dem Anker klar (>= ref+30 mV) oberhalb der Schwelle war."
+    mode: single
+    triggers:
+      - trigger: template
+        value_template: >
+          {{ states('sensor.byd_modul_2_zellmin')|float(0)
+             > states('input_number.byd_knie_ref_frozen')|float(3.20) + 0.03 }}
+    conditions:
+      - condition: state
+        entity_id: input_boolean.byd_knie_armed
+        state: "on"
+    actions:
+      - action: input_boolean.turn_on
+        target: { entity_id: input_boolean.byd_knie_ueberschwelle_gesehen }
+
+  - id: byd_knie_latch
+    alias: "BYD | Knie-Latch (Nettoenergie festhalten)"
+    description: >-
+      Latcht, wenn der Bestaetigungszaehler >= 2 konsekutive qualifizierende
+      BMS-Zyklen unter der eingefrorenen Referenz erreicht (Knie bestaetigt).
+      State-Trigger auf den Zaehler mit >= 2-Bedingung (kein numeric_state, das
+      nur die Flanke sieht) - scheitert der erste Latch-Versuch (Bedingung,
+      Crash, Neustart mit restauriertem Zaehler), feuert der naechste Zyklus
+      (2 -> 3) erneut. Der Latch-Sensor snapshottet die Mess-Anker-Werte.
+    mode: single
+    triggers:
+      - trigger: state
+        entity_id: sensor.byd_knie_bestaetigungen
+    conditions:
+      - condition: state
+        entity_id: input_select.byd_knie_zyklus_status
+        state: "armed"
+      - condition: state
+        entity_id: input_boolean.byd_knie_ueberschwelle_gesehen
+        state: "on"
+      - condition: template
+        value_template: "{{ states('sensor.byd_knie_bestaetigungen')|int(0) >= 2 }}"
+    actions:
+      - action: input_select.select_option
+        target: { entity_id: input_select.byd_knie_zyklus_status }
+        data: { option: "latched" }        # der Latch-Sensor snapshottet hierauf
+      - action: input_boolean.turn_off
+        target: { entity_id: input_boolean.byd_knie_armed }
+
+  - id: byd_knie_invalid
+    alias: "BYD | Knie-Zyklus ungueltig markieren"
+    description: >-
+      Markiert den laufenden armed-Zyklus als invalid bei Mess-Qualitaetsproblemen:
+      Datenluecke nahe Knie, Neustart nahe Knie, unplausibler Netto-Sprung.
+    mode: queued
+    max: 5
+    triggers:
+      - trigger: state
+        id: datenluecke
+        entity_id: binary_sensor.byd_bmu_frisch
+        to: "off"
+        for: "00:02:00"
+      - trigger: state
+        id: datenluecke
+        entity_id: binary_sensor.byd_zelldaten_frisch
+        to: "off"
+        for: "00:02:00"
+      - trigger: homeassistant
+        id: neustart
+        event: start
+      - trigger: state
+        id: zaehlersprung
+        entity_id: sensor.byd_nettoenergie_seit_voll
+    conditions:
+      - condition: state
+        entity_id: input_select.byd_knie_zyklus_status
+        state: "armed"
+      - condition: or
+        conditions:
+          - condition: and
+            conditions:
+              - condition: trigger
+                id: ["datenluecke", "neustart"]
+              # Naehe-Check fail-safe (Codex-P2): float(0) statt float(9) -
+              # unbekannt/unavailable (z. B. Boot-Setup-Fehlschlag) zaehlt als
+              # NAH am Knie -> invalid (unbekannt heisst verwerfen, nicht durchwinken).
+              - condition: template
+                value_template: >
+                  {{ states('sensor.byd_modul_2_zellmin')|float(0)
+                     <= states('input_number.byd_knie_ref_frozen')|float(3.20) + 0.01 }}
+          - condition: template
+            value_template: >
+              {{ trigger.id == 'zaehlersprung'
+                 and trigger.from_state is not none and trigger.to_state is not none
+                 and trigger.from_state.state not in ['unknown','unavailable']
+                 and trigger.to_state.state not in ['unknown','unavailable']
+                 and (trigger.to_state.state|float - trigger.from_state.state|float) > 3
+                 and (now().timestamp() - state_attr('input_datetime.byd_voll_anker_zeit','timestamp')|float(0)) > 120 }}
+    actions:
+      - action: input_select.select_option
+        target: { entity_id: input_select.byd_knie_zyklus_status }
+        data: { option: "invalid" }
+      - action: input_text.set_value
+        target: { entity_id: input_text.byd_knie_invalid_grund }
+        data: { value: "{{ trigger.id }} @ {{ now().strftime('%Y-%m-%d %H:%M') }}" }

--- a/tests/test_byd_modul2_fruehwarnung.py
+++ b/tests/test_byd_modul2_fruehwarnung.py
@@ -297,6 +297,15 @@ def test_zaehler_qual_ohne_netto_zaehlt_nicht():
     assert _count(prev="1", seen="C1", cycle="C1", abstand=630, netto="unavailable") == "0"
 
 
+def test_zaehler_plausibilitaets_floor():
+    # Meta-Review-Haertung: ein implausibel niedriges m2min (Garbage/Stoerung,
+    # z.B. ~31 mV) darf NICHT als "unter Knie" qualifizieren - echtes Tiefstvolt
+    # ist Sache des Alarm-Layers. Floor m2min > 2,5 V macht Garbage inert.
+    assert _count(prev="1", seen="C1", cycle="C1", abstand=630, m2min_mv=31) == "0"
+    # Regressionsschutz: plausibler Wert knapp ueber dem Floor zaehlt weiter.
+    assert _count(prev="1", seen="C1", cycle="C1", abstand=630, m2min_mv=2600) == "2"
+
+
 def test_zaehler_band_bruch_nullt():
     assert _count(prev="1", seen="C1", cycle="C1", abstand=630, band="off") == "0"
 

--- a/tests/test_byd_modul2_fruehwarnung.py
+++ b/tests/test_byd_modul2_fruehwarnung.py
@@ -1,0 +1,515 @@
+"""Tests fuer packages/byd_modul2_fruehwarnung.yaml (BYD Modul-2 Fruehwarnung
+nativ ueber Modbus): Zellmin, Zell-Absackung (Metrik A), Entladeband,
+Bestaetigungszaehler mit Mess-Anker, Netto-Sensor, Latch-Snapshot (Metrik B)
+und die Struktur-Garantien der 5 Automationen.
+
+GRENZE DIESER HARNESS (bewusst, wie test_byd_monitoring.py): die Harness rendert
+ausschliesslich Jinja-Templates aus dem YAML. Die eigentliche Trigger-/for:-/
+Restore-/Listener-Reihenfolge-Semantik von HA, die utility_meter-Baselines und
+das Registry-Verhalten sind hier NICHT abbildbar - dafuer existieren die
+Struktur-Asserts (unten) und der E2E-Livetest.
+"""
+import datetime as dt
+import re
+
+import jinja2
+
+from .ha_harness import (REPO, TZ, FakeHass, find_template_entity, load_yaml,
+                         render)
+
+PACKAGE = REPO / "packages" / "byd_modul2_fruehwarnung.yaml"
+AVG = "sensor.bms_1_cells_average_voltage"
+
+
+def _entity(kind, unique_id):
+    return find_template_entity(load_yaml(PACKAGE), kind, unique_id)
+
+
+def _auto(auto_id):
+    return next(a for a in load_yaml(PACKAGE)["automation"] if a["id"] == auto_id)
+
+
+def _slug(name):
+    return re.sub(r"_+", "_", re.sub(r"[^a-z0-9]+", "_", name.lower())).strip("_")
+
+
+# ---------------------------------------------------------------------------
+# 1) Jinja-Parse-Walk ueber das ganze Package (Repo-Konvention)
+# ---------------------------------------------------------------------------
+
+def _walk_templates(node, path=""):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            yield from _walk_templates(v, f"{path}.{k}")
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            yield from _walk_templates(v, f"{path}[{i}]")
+    elif isinstance(node, str) and ("{{" in node or "{%" in node):
+        yield path, node
+
+
+def _parse_fails(env, template_str):
+    try:
+        env.parse(template_str)
+        return False
+    except jinja2.TemplateSyntaxError:
+        return True
+
+
+def test_package_jinja_parst():
+    env = jinja2.Environment()
+    fehler = [p for p, t in _walk_templates(load_yaml(PACKAGE)) if _parse_fails(env, t)]
+    assert fehler == []
+
+
+# ---------------------------------------------------------------------------
+# 2) Slug-Test: unique_id (_nativ) -> erwartete kanonische entity_id fuer ALLE
+# Template-Entities. Nach dem Orphan-Purge beweist das die Live-IDs, an denen
+# die Dashboard-Karten und die Automationen haengen.
+# ---------------------------------------------------------------------------
+
+NAMING = [
+    ("binary_sensor", "byd_entladeband_nativ", "byd_entladeband"),
+    ("sensor", "byd_modul2_zellmin_nativ", "byd_modul_2_zellmin"),
+    ("sensor", "byd_netto_energie_seit_voll_nativ", "byd_nettoenergie_seit_voll"),
+    ("sensor", "byd_modul2_zell_absackung_nativ", "byd_modul_2_zell_absackung"),
+    ("sensor", "byd_knie_bestaetigungen_nativ", "byd_knie_bestaetigungen"),
+    ("sensor", "byd_modul2_netto_bis_knie_nativ", "byd_modul_2_nettoenergie_bis_knie"),
+]
+
+
+def test_name_slugt_zur_kanonischen_entity_id():
+    for domain, unique_id, erwartet in NAMING:
+        name = _entity(domain, unique_id)["name"]
+        assert _slug(name) == erwartet, (
+            f"{domain}/{unique_id}: name '{name}' -> {domain}.{_slug(name)}, "
+            f"aber referenziert wird {domain}.{erwartet}")
+
+
+# ---------------------------------------------------------------------------
+# 3) Zellmin: min(cell_voltages m:2)/1000, 3 Dezimalen, Availability
+# ---------------------------------------------------------------------------
+
+def _cv(m2_min_mv=3250, m2_min_zelle=23, extra=None):
+    """5 Module x 32 Zellen, Grundniveau 3300 mV. Modul 2 hat sein Minimum
+    an Zelle m2_min_zelle. extra=(modul, zelle, mv) setzt einen weiteren Wert."""
+    daten = [{"m": m, "v": [3300] * 32} for m in range(1, 6)]
+    daten[1]["v"][m2_min_zelle - 1] = m2_min_mv
+    if extra:
+        m, z, mv = extra
+        daten[m - 1]["v"][z - 1] = mv
+    return daten
+
+
+def _cv_ohne_m2():
+    return [{"m": m, "v": [3300] * 32} for m in (1, 3, 4, 5)]
+
+
+def _zellmin():
+    return _entity("sensor", "byd_modul2_zellmin_nativ")
+
+
+def _render_zellmin(feld, daten):
+    hass = FakeHass(states={AVG: "3.300"}, attrs={AVG: {"cell_voltages": daten}})
+    ent = _zellmin()
+    return render(hass, ent["state"] if feld == "state" else ent[feld])
+
+
+def test_zellmin_extrahiert_modul2_minimum():
+    assert float(_render_zellmin("state", _cv(m2_min_mv=3190))) == 3.19
+
+
+def test_zellmin_rundet_auf_drei_dezimalen():
+    assert _render_zellmin("state", _cv(m2_min_mv=3187)) == "3.187"
+
+
+def test_zellmin_availability():
+    assert _render_zellmin("availability", _cv()) == "True"
+    # Ohne Attribut ueberhaupt.
+    hass = FakeHass(states={AVG: "3.300"})
+    assert render(hass, _zellmin()["availability"]) == "False"
+    # Attribut da, aber kein m:2-Eintrag.
+    hass2 = FakeHass(states={AVG: "3.300"}, attrs={AVG: {"cell_voltages": _cv_ohne_m2()}})
+    assert render(hass2, _zellmin()["availability"]) == "False"
+
+
+# ---------------------------------------------------------------------------
+# 4) Zell-Absackung (Metrik A): Median(160) - min(m:2) in mV
+# ---------------------------------------------------------------------------
+
+def _absackung():
+    return _entity("sensor", "byd_modul2_zell_absackung_nativ")
+
+
+def _render_absackung(feld, daten):
+    hass = FakeHass(states={AVG: "3.300",
+                            "sensor.battery_management_unit_state_of_charge": "60",
+                            "sensor.bmu_power": "800"},
+                    attrs={AVG: {"cell_voltages": daten}})
+    ent = _absackung()
+    tpl = ent["state"] if feld == "state" else ent["attributes"][feld]
+    return render(hass, tpl)
+
+
+def test_absackung_state_und_zell_id():
+    daten = _cv(m2_min_mv=3250, m2_min_zelle=23)
+    assert float(_render_absackung("state", daten)) == 50.0
+    assert _render_absackung("zelle", daten) == "23"
+    assert _render_absackung("schwaechstes_modul", daten) == "2"
+    assert float(_render_absackung("median_mv", daten)) == 3300.0
+
+
+def test_absackung_schwaechstes_modul_wechselt():
+    # Modul 4 stellt mit 3200 mV das globale Minimum, Modul 2 bleibt bei 3250:
+    # die Absackung misst weiter Modul 2, schwaechstes_modul zeigt aber Modul 4.
+    daten = _cv(m2_min_mv=3250, m2_min_zelle=23, extra=(4, 10, 3200))
+    assert float(_render_absackung("state", daten)) == 50.0
+    assert _render_absackung("schwaechstes_modul", daten) == "4"
+    assert _render_absackung("zelle", daten) == "23"
+
+
+def test_absackung_kontext_attribute():
+    daten = _cv(m2_min_mv=3250)
+    assert _render_absackung("soc", daten) == "60"
+    assert _render_absackung("leistung_w", daten) == "800"
+
+
+def test_absackung_availability_ohne_attribut():
+    hass = FakeHass(states={AVG: "3.300"})
+    assert render(hass, _absackung()["availability"]) == "False"
+
+
+# ---------------------------------------------------------------------------
+# 5) Entladeband: 500 <= bmu_power <= 1500 UND bmu_frisch
+# ---------------------------------------------------------------------------
+
+def _entladeband(power=None, bmu_frisch="on"):
+    states = {"binary_sensor.byd_bmu_frisch": bmu_frisch}
+    if power is not None:
+        states["sensor.bmu_power"] = power
+    return render(FakeHass(states=states), _entity("binary_sensor", "byd_entladeband_nativ")["state"])
+
+
+def test_entladeband_grenzen():
+    assert _entladeband(power="500") == "True"
+    assert _entladeband(power="1500") == "True"
+    assert _entladeband(power="800") == "True"
+    assert _entladeband(power="499") == "False"
+    assert _entladeband(power="1501") == "False"
+
+
+def test_entladeband_laden_nie_im_band():
+    # Negativ = Laden - darf nie im Entladeband liegen.
+    assert _entladeband(power="-800") == "False"
+    assert _entladeband(power="-1500") == "False"
+
+
+def test_entladeband_ohne_frische_bmu():
+    # Eingefrorene 800 W duerfen kein Band halten.
+    assert _entladeband(power="800", bmu_frisch="off") == "False"
+    assert _entladeband(power="800", bmu_frisch="unavailable") == "False"
+
+
+def test_entladeband_fehlende_werte_off():
+    assert _entladeband() == "False"
+    assert _entladeband(power="unavailable") == "False"
+
+
+# ---------------------------------------------------------------------------
+# 6) Bestaetigungszaehler: konsekutive qualifizierende Zyklen + Mess-Anker
+# ---------------------------------------------------------------------------
+
+NOW = dt.datetime(2026, 7, 17, 21, 0, 0, tzinfo=TZ)
+
+
+def _counter():
+    return _entity("sensor", "byd_knie_bestaetigungen_nativ")
+
+
+def _counter_hass(*, m2min_mv=3190, status="armed", frisch="on", band="on",
+                  ref="3.20", cycle="C1", netto="5.0", absackung="30.0",
+                  prev="0", seen="C1", abstand=None,
+                  netto_anker=None, absackung_anker=None, now=NOW):
+    this_attrs = {}
+    if seen is not None:
+        this_attrs["cycle_id_gesehen"] = seen
+    if abstand is not None:
+        this_attrs["letzter_zyklus"] = now.timestamp() - abstand
+    if netto_anker is not None:
+        this_attrs["netto_bei_erstem_sample"] = netto_anker
+    if absackung_anker is not None:
+        this_attrs["absackung_bei_erstem_sample"] = absackung_anker
+    states = {
+        "input_select.byd_knie_zyklus_status": status,
+        "binary_sensor.byd_zelldaten_frisch": frisch,
+        "binary_sensor.byd_entladeband": band,
+        "input_number.byd_knie_ref_frozen": ref,
+        "input_text.byd_knie_cycle_id": cycle,
+        "sensor.byd_nettoenergie_seit_voll": netto,
+        "sensor.byd_modul_2_zell_absackung": absackung,
+    }
+    return FakeHass(states=states, attrs={AVG: {"cell_voltages": _cv(m2_min_mv=m2min_mv)}},
+                    this_attributes=this_attrs, this_state=prev, now=now)
+
+
+def _count(**kw):
+    return render(_counter_hass(**kw), _counter()["state"])
+
+
+def _count_attr(feld, **kw):
+    return render(_counter_hass(**kw), _counter()["attributes"][feld])
+
+
+def test_zaehler_erstes_qualifizierendes_sample():
+    # Neue cycle_id (seen != cycle) und qualifizierend -> Start bei 1.
+    assert _count(prev="0", seen="C0", cycle="C1") == "1"
+
+
+def test_zaehler_zweites_qualifizierendes_sample():
+    # Gleiche cycle_id, Abstand im gueltigen Fenster -> Inkrement auf 2.
+    assert _count(prev="1", seen="C1", cycle="C1", abstand=630) == "2"
+
+
+def test_zaehler_band_bruch_nullt():
+    assert _count(prev="1", seen="C1", cycle="C1", abstand=630, band="off") == "0"
+
+
+def test_zaehler_frisch_off_nullt():
+    assert _count(prev="1", seen="C1", cycle="C1", abstand=630, frisch="off") == "0"
+
+
+def test_zaehler_ueber_referenz_nullt():
+    # m2min 3250 mV = 3,25 V >= ref 3,20 V -> nicht qualifizierend.
+    assert _count(prev="1", seen="C1", cycle="C1", abstand=630, m2min_mv=3250) == "0"
+
+
+def test_zaehler_neue_cycle_id_startet_neu():
+    # Re-Arm / neuer Voll-Anker: cycle_id wechselt -> Neustart bei 1.
+    assert _count(prev="2", seen="C1", cycle="C2", abstand=630) == "1"
+
+
+def test_zaehler_doppel_event_dedupe():
+    # Zwei Events desselben Samples (< 300 s Abstand) -> kein Inkrement.
+    assert _count(prev="1", seen="C1", cycle="C1", abstand=100) == "1"
+
+
+def test_zaehler_luecke_startet_neu_bei_eins():
+    # > 1500 s Abstand = Kontinuitaet gebrochen -> Neustart bei 1.
+    assert _count(prev="1", seen="C1", cycle="C1", abstand=2000) == "1"
+
+
+def test_zaehler_cycle_id_gesehen_immer_aktuell():
+    # Auch nicht-qualifizierend wird die aktuelle cycle_id gemerkt.
+    assert _count_attr("cycle_id_gesehen", cycle="C7", band="off") == "C7"
+
+
+def test_mess_anker_wird_bei_stand_eins_gesetzt():
+    # Erstes Sample (neue cycle_id, qualifizierend): netto/absackung geankert.
+    assert _count_attr("netto_bei_erstem_sample",
+                       prev="0", seen="C0", cycle="C1", netto="5.0") == "5.0"
+    assert _count_attr("absackung_bei_erstem_sample",
+                       prev="0", seen="C0", cycle="C1", absackung="30.0") == "30.0"
+
+
+def test_mess_anker_wird_bei_stand_zwei_nicht_ueberschrieben():
+    # Inkrement auf 2: der momentane netto/absackung-Wert (9.9/44.0) darf den
+    # am ersten Sample geankerten (5.0/30.0) NICHT ueberschreiben.
+    assert _count_attr("netto_bei_erstem_sample",
+                       prev="1", seen="C1", cycle="C1", abstand=630,
+                       netto="9.9", netto_anker="5.0") == "5.0"
+    assert _count_attr("absackung_bei_erstem_sample",
+                       prev="1", seen="C1", cycle="C1", abstand=630,
+                       absackung="44.0", absackung_anker="30.0") == "30.0"
+
+
+# ---------------------------------------------------------------------------
+# 7) Netto-Sensor: entladen - geladen, Availability
+# ---------------------------------------------------------------------------
+
+GEL = "sensor.byd_geladen_seit_voll"
+ENT = "sensor.byd_entladen_seit_voll"
+
+
+def _netto():
+    return _entity("sensor", "byd_netto_energie_seit_voll_nativ")
+
+
+def test_netto_differenz():
+    hass = FakeHass(states={ENT: "6.2", GEL: "0.3"})
+    assert float(render(hass, _netto()["state"])) == 5.9
+
+
+def test_netto_availability():
+    assert render(FakeHass(states={ENT: "6.2", GEL: "0.3"}), _netto()["availability"]) == "True"
+    assert render(FakeHass(states={ENT: "6.2"}), _netto()["availability"]) == "False"
+    assert render(FakeHass(states={GEL: "0.3"}), _netto()["availability"]) == "False"
+    assert render(FakeHass(states={ENT: "unavailable", GEL: "0.3"}),
+                  _netto()["availability"]) == "False"
+
+
+# ---------------------------------------------------------------------------
+# 8) Latch-Snapshot (Metrik B): Mess-Anker-Werte, nicht der Momentanwert
+# ---------------------------------------------------------------------------
+
+COUNTER = "sensor.byd_knie_bestaetigungen"
+
+
+def _latch():
+    return _entity("sensor", "byd_modul2_netto_bis_knie_nativ")
+
+
+def _latch_hass():
+    return FakeHass(states={
+        "sensor.byd_nettoenergie_seit_voll": "9.9",     # Momentanwert (NICHT geankert)
+        "sensor.byd_modul_2_zell_absackung": "44.0",    # Momentanwert (NICHT geankert)
+        "sensor.byd_geladen_seit_voll": "0.2",
+        "sensor.byd_entladen_seit_voll": "6.1",
+        "sensor.battery_management_unit_state_of_charge": "22",
+        "sensor.bmu_power": "700",
+        "sensor.byd_modul_2_zellmin": "3.19",
+        "input_number.byd_knie_ref_frozen": "3.20",
+        "input_text.byd_knie_cycle_id": "C1",
+    }, attrs={COUNTER: {"netto_bei_erstem_sample": "5.8",
+                        "absackung_bei_erstem_sample": "38.0"}}, now=NOW)
+
+
+def test_latch_state_aus_mess_anker():
+    # State kommt aus dem Zaehler-Anker (5.8), NICHT aus dem Momentanwert (9.9).
+    assert render(_latch_hass(), _latch()["state"]) == "5.8"
+
+
+def test_latch_attribute_aus_mess_anker():
+    hass = _latch_hass()
+    attrs = _latch()["attributes"]
+    assert render(hass, attrs["netto_kwh"]) == "5.8"
+    assert render(hass, attrs["a_absackung_mv"]) == "38.0"
+    # Kontext kommt weiter aus den Momentanwerten.
+    assert render(hass, attrs["entladen_inkrement_kwh"]) == "6.1"
+    assert render(hass, attrs["sauberer_zyklus"]) == "True"   # geladen 0.2 < 0.5
+    assert render(hass, attrs["cycle_id"]) == "C1"
+
+
+# ---------------------------------------------------------------------------
+# 9) Struktur-Asserts: die Trigger-/for:-Semantik ist nicht testbar, ihre
+# STRUKTUR aber schon - genau die Punkte, an denen der Plan (E2) haengt.
+# ---------------------------------------------------------------------------
+
+def _entities_in(node):
+    gefunden = []
+
+    def walk(n):
+        if isinstance(n, dict):
+            e = n.get("entity_id")
+            if isinstance(e, str):
+                gefunden.append(e)
+            elif isinstance(e, list):
+                gefunden.extend(x for x in e if isinstance(x, str))
+            for v in n.values():
+                walk(v)
+        elif isinstance(n, list):
+            for v in n:
+                walk(v)
+
+    walk(node)
+    return gefunden
+
+
+def _templates_in(node):
+    gefunden = []
+
+    def walk(n):
+        if isinstance(n, dict):
+            t = n.get("value_template")
+            if isinstance(t, str):
+                gefunden.append(t)
+            for v in n.values():
+                walk(v)
+        elif isinstance(n, list):
+            for v in n:
+                walk(v)
+
+    walk(node)
+    return gefunden
+
+
+def test_voll_anker_prueft_beide_frische_binaries_und_meter_has_value():
+    va = _auto("byd_voll_anker")
+    entities = _entities_in(va["conditions"])
+    assert "binary_sensor.byd_bmu_frisch" in entities
+    assert "binary_sensor.byd_zelldaten_frisch" in entities
+    joined = " ".join(_templates_in(va["conditions"]))
+    for meter in ("sensor.byd_geladen_seit_voll", "sensor.byd_entladen_seit_voll",
+                  "sensor.byd_nettoenergie_seit_voll"):
+        assert f"has_value('{meter}')" in joined, meter
+
+
+def test_latch_ist_state_trigger_auf_zaehler_mit_ge_zwei():
+    latch = _auto("byd_knie_latch")
+    trigger = latch["triggers"]
+    assert any(t.get("trigger") == "state"
+               and t.get("entity_id") == COUNTER for t in trigger)
+    # KEIN numeric_state-Trigger (der saehe nur die Flanke, nicht den Retry).
+    assert all(t.get("trigger") != "numeric_state" for t in trigger)
+    cond_texts = " ".join(_templates_in(latch["conditions"]))
+    assert ">= 2" in cond_texts
+
+
+def test_invalid_naehe_check_ist_fail_safe_float_null():
+    inv = _auto("byd_knie_invalid")
+    texts = " ".join(_templates_in(inv["conditions"]))
+    # float(0) statt float(9): unbekannt zaehlt als nah am Knie -> verwerfen.
+    assert "sensor.byd_modul_2_zellmin')|float(0)" in texts
+    assert "float(9)" not in texts
+
+
+def test_invalid_datenluecke_deckt_beide_frische_binaries_ab():
+    inv = _auto("byd_knie_invalid")
+    luecke = [t.get("entity_id") for t in inv["triggers"] if t.get("id") == "datenluecke"]
+    assert "binary_sensor.byd_bmu_frisch" in luecke
+    assert "binary_sensor.byd_zelldaten_frisch" in luecke
+
+
+# Selbst-Verdrahtung: jede byd_-prefixte Entity, die das Package referenziert,
+# muss hier definiert sein ODER aus dem gepinnten byd_monitoring-Vertrag stammen.
+# Faengt Tippfehler wie byd_modul2_zellmin statt byd_modul_2_zellmin.
+DEFINIERT = {
+    # Template-Slugs
+    "sensor.byd_modul_2_zellmin", "sensor.byd_nettoenergie_seit_voll",
+    "sensor.byd_modul_2_zell_absackung", "sensor.byd_knie_bestaetigungen",
+    "sensor.byd_modul_2_nettoenergie_bis_knie", "binary_sensor.byd_entladeband",
+    # utility_meter (entity_id = Konfig-Key)
+    "sensor.byd_geladen_seit_voll", "sensor.byd_entladen_seit_voll",
+    # Helfer
+    "input_number.byd_knie_referenzspannung", "input_number.byd_knie_ref_frozen",
+    "input_boolean.byd_knie_armed", "input_boolean.byd_knie_ueberschwelle_gesehen",
+    "input_boolean.byd_top_erreicht", "input_select.byd_knie_zyklus_status",
+    "input_text.byd_knie_cycle_id", "input_text.byd_knie_invalid_grund",
+    "input_datetime.byd_voll_anker_zeit",
+}
+# Aus packages/byd_monitoring.yaml (gepinnter Vertrag).
+VERTRAG = {"binary_sensor.byd_bmu_frisch", "binary_sensor.byd_zelldaten_frisch"}
+REF_RE = re.compile(
+    r"(?:sensor|binary_sensor|input_number|input_boolean|input_select|"
+    r"input_text|input_datetime)\.byd_[a-z0-9_]+")
+
+
+def _alle_strings(node):
+    if isinstance(node, dict):
+        for v in node.values():
+            yield from _alle_strings(v)
+    elif isinstance(node, list):
+        for v in node:
+            yield from _alle_strings(v)
+    elif isinstance(node, str):
+        yield node
+
+
+def test_alle_byd_referenzen_sind_definiert_oder_im_vertrag():
+    # Ueber die GEPARSTE Struktur laufen, nicht ueber den Rohtext - so bleiben
+    # die im Header dokumentierten Orphan-Purge-IDs (Kommentare) aussen vor.
+    erlaubt = DEFINIERT | VERTRAG
+    refs = set()
+    for s in _alle_strings(load_yaml(PACKAGE)):
+        refs.update(REF_RE.findall(s))
+    unbekannt = sorted(r for r in refs if r not in erlaubt)
+    assert unbekannt == [], f"undefinierte byd-Referenzen: {unbekannt}"

--- a/tests/test_byd_modul2_fruehwarnung.py
+++ b/tests/test_byd_modul2_fruehwarnung.py
@@ -174,9 +174,14 @@ def test_absackung_kontext_attribute():
     assert _render_absackung("leistung_w", daten) == "800"
 
 
-def test_absackung_availability_ohne_attribut():
-    hass = FakeHass(states={AVG: "3.300"})
-    assert render(hass, _absackung()["availability"]) == "False"
+def test_absackung_availability_ohne_attribut_oder_ohne_m2():
+    # Finding 6: ohne Attribut UND ohne m:2-Eintrag unavailable (sonst laeuft
+    # min() im State auf einer leeren Liste in einen Template-Error).
+    assert render(FakeHass(states={AVG: "3.300"}), _absackung()["availability"]) == "False"
+    hass_m2 = FakeHass(states={AVG: "3.300"}, attrs={AVG: {"cell_voltages": _cv_ohne_m2()}})
+    assert render(hass_m2, _absackung()["availability"]) == "False"
+    hass_ok = FakeHass(states={AVG: "3.300"}, attrs={AVG: {"cell_voltages": _cv()}})
+    assert render(hass_ok, _absackung()["availability"]) == "True"
 
 
 # ---------------------------------------------------------------------------
@@ -261,13 +266,35 @@ def _count_attr(feld, **kw):
 
 
 def test_zaehler_erstes_qualifizierendes_sample():
-    # Neue cycle_id (seen != cycle) und qualifizierend -> Start bei 1.
-    assert _count(prev="0", seen="C0", cycle="C1") == "1"
+    # Selber Zyklus (seen == cycle), noch kein Streak (letzter fehlt -> Abstand
+    # riesig), qualifizierend -> Streak-Start bei 1.
+    assert _count(prev="0", seen="C1", cycle="C1", abstand=None) == "1"
 
 
 def test_zaehler_zweites_qualifizierendes_sample():
     # Gleiche cycle_id, Abstand im gueltigen Fenster -> Inkrement auf 2.
     assert _count(prev="1", seen="C1", cycle="C1", abstand=630) == "2"
+
+
+def test_zaehler_cycle_id_wechsel_nullt_bedingungslos():
+    # Finding 3: der cycle_id-Wechsel ist das Reset-Event, KEIN Sample. Auch
+    # qualifizierend darf er nicht auf 1 zaehlen (sonst latcht das erste echte
+    # Folge-Sample bereits bei Stand 2).
+    assert _count(prev="2", seen="C1", cycle="C2", abstand=630) == "0"
+    # ... und selbst mit riesigem Abstand bleibt es beim Reset auf 0.
+    assert _count(prev="0", seen="C1", cycle="C2", abstand=None) == "0"
+
+
+def test_zaehler_reset_dann_erstes_echtes_sample_ist_eins():
+    # Nach dem Reset (seen wurde auf C2 gesetzt, letzter=0) erzeugt das erste
+    # echte cells_average_voltage-Sample im selben Zyklus Stand 1 - nicht mehr.
+    assert _count(prev="0", seen="C2", cycle="C2", abstand=None) == "1"
+
+
+def test_zaehler_qual_ohne_netto_zaehlt_nicht():
+    # Finding 2: ist der Netto-Sensor unavailable, ist das Sample nicht
+    # qualifizierend (kein gueltiger Mess-Anker moeglich) -> 0.
+    assert _count(prev="1", seen="C1", cycle="C1", abstand=630, netto="unavailable") == "0"
 
 
 def test_zaehler_band_bruch_nullt():
@@ -281,11 +308,6 @@ def test_zaehler_frisch_off_nullt():
 def test_zaehler_ueber_referenz_nullt():
     # m2min 3250 mV = 3,25 V >= ref 3,20 V -> nicht qualifizierend.
     assert _count(prev="1", seen="C1", cycle="C1", abstand=630, m2min_mv=3250) == "0"
-
-
-def test_zaehler_neue_cycle_id_startet_neu():
-    # Re-Arm / neuer Voll-Anker: cycle_id wechselt -> Neustart bei 1.
-    assert _count(prev="2", seen="C1", cycle="C2", abstand=630) == "1"
 
 
 def test_zaehler_doppel_event_dedupe():
@@ -304,22 +326,35 @@ def test_zaehler_cycle_id_gesehen_immer_aktuell():
 
 
 def test_mess_anker_wird_bei_stand_eins_gesetzt():
-    # Erstes Sample (neue cycle_id, qualifizierend): netto/absackung geankert.
-    assert _count_attr("netto_bei_erstem_sample",
-                       prev="0", seen="C0", cycle="C1", netto="5.0") == "5.0"
-    assert _count_attr("absackung_bei_erstem_sample",
-                       prev="0", seen="C0", cycle="C1", absackung="30.0") == "30.0"
+    # Frischer Uebergang auf 1 (selber Zyklus, letzter=0): netto aus dem
+    # Momentanwert, Absackung/Zell-Nr/Modul aus DEMSELBEN cell_voltages-Attribut.
+    kw = dict(prev="0", seen="C1", cycle="C1", abstand=None, netto="5.0", m2min_mv=3190)
+    assert _count_attr("netto_bei_erstem_sample", **kw) == "5.0"
+    # Median(160)=3300, min(m:2)=3190 -> 110 mV; Zelle 23 (Default-Fixture); Modul 2.
+    assert float(_count_attr("absackung_bei_erstem_sample", **kw)) == 110.0
+    assert _count_attr("zelle_bei_erstem_sample", **kw) == "23"
+    assert _count_attr("schwaechstes_modul_bei_erstem_sample", **kw) == "2"
+
+
+def test_mess_anker_absackung_aus_attribut_nicht_aus_gegatetem_sensor():
+    # Finding 1: der Anker rechnet die Absackung aus dem eigenen Attribut, nicht
+    # aus states('sensor.byd_modul_2_zell_absackung'). Der (bewusst abweichende)
+    # Momentanwert des gegateten Sensors darf keine Rolle spielen.
+    # m2min 3195 mV = 3,195 V < ref 3,20 -> qualifiziert; Absackung = 3300-3195.
+    assert float(_count_attr("absackung_bei_erstem_sample",
+                             prev="0", seen="C1", cycle="C1", abstand=None,
+                             m2min_mv=3195, absackung="999")) == 105.0
 
 
 def test_mess_anker_wird_bei_stand_zwei_nicht_ueberschrieben():
-    # Inkrement auf 2: der momentane netto/absackung-Wert (9.9/44.0) darf den
-    # am ersten Sample geankerten (5.0/30.0) NICHT ueberschreiben.
+    # Inkrement auf 2: die Momentanwerte duerfen die am ersten Sample geankerten
+    # Werte NICHT ueberschreiben.
     assert _count_attr("netto_bei_erstem_sample",
                        prev="1", seen="C1", cycle="C1", abstand=630,
                        netto="9.9", netto_anker="5.0") == "5.0"
     assert _count_attr("absackung_bei_erstem_sample",
                        prev="1", seen="C1", cycle="C1", abstand=630,
-                       absackung="44.0", absackung_anker="30.0") == "30.0"
+                       m2min_mv=3100, absackung_anker="30.0") == "30.0"
 
 
 # ---------------------------------------------------------------------------
@@ -370,7 +405,9 @@ def _latch_hass():
         "input_number.byd_knie_ref_frozen": "3.20",
         "input_text.byd_knie_cycle_id": "C1",
     }, attrs={COUNTER: {"netto_bei_erstem_sample": "5.8",
-                        "absackung_bei_erstem_sample": "38.0"}}, now=NOW)
+                        "absackung_bei_erstem_sample": "38.0",
+                        "zelle_bei_erstem_sample": "23",
+                        "schwaechstes_modul_bei_erstem_sample": "2"}}, now=NOW)
 
 
 def test_latch_state_aus_mess_anker():
@@ -383,6 +420,10 @@ def test_latch_attribute_aus_mess_anker():
     attrs = _latch()["attributes"]
     assert render(hass, attrs["netto_kwh"]) == "5.8"
     assert render(hass, attrs["a_absackung_mv"]) == "38.0"
+    # Zell-Nr und Modul kommen ebenfalls aus dem Anker (gleicher Zyklus wie die
+    # Absackung), nicht vom gegateten Momentan-Sensor.
+    assert render(hass, attrs["modul2_schwaechste_zelle"]) == "23"
+    assert render(hass, attrs["schwaechstes_modul"]) == "2"
     # Kontext kommt weiter aus den Momentanwerten.
     assert render(hass, attrs["entladen_inkrement_kwh"]) == "6.1"
     assert render(hass, attrs["sauberer_zyklus"]) == "True"   # geladen 0.2 < 0.5
@@ -443,7 +484,25 @@ def test_voll_anker_prueft_beide_frische_binaries_und_meter_has_value():
         assert f"has_value('{meter}')" in joined, meter
 
 
-def test_latch_ist_state_trigger_auf_zaehler_mit_ge_zwei():
+def _turn_off_targets(node):
+    """entity_ids aller input_boolean.turn_off-Aktionen unter node."""
+    gefunden = []
+
+    def walk(n):
+        if isinstance(n, dict):
+            if n.get("action") == "input_boolean.turn_off":
+                gefunden.extend(_entities_in(n.get("target", {})))
+            for v in n.values():
+                walk(v)
+        elif isinstance(n, list):
+            for v in n:
+                walk(v)
+
+    walk(node)
+    return gefunden
+
+
+def test_latch_ist_state_trigger_auf_zaehler_mit_ge_zwei_und_anker_guard():
     latch = _auto("byd_knie_latch")
     trigger = latch["triggers"]
     assert any(t.get("trigger") == "state"
@@ -452,14 +511,56 @@ def test_latch_ist_state_trigger_auf_zaehler_mit_ge_zwei():
     assert all(t.get("trigger") != "numeric_state" for t in trigger)
     cond_texts = " ".join(_templates_in(latch["conditions"]))
     assert ">= 2" in cond_texts
+    # Finding 2: der Mess-Anker muss numerisch sein, sonst kein Latch.
+    assert "netto_bei_erstem_sample" in cond_texts and "|float(none)) is not none" in cond_texts
+
+
+def test_latch_setzt_ueberschwelle_guard_zurueck():
+    # Finding 7: sonst bliebe der Guard dauerhaft an (vestigial).
+    assert "input_boolean.byd_knie_ueberschwelle_gesehen" in _turn_off_targets(_auto("byd_knie_latch")["actions"])
 
 
 def test_invalid_naehe_check_ist_fail_safe_float_null():
     inv = _auto("byd_knie_invalid")
-    texts = " ".join(_templates_in(inv["conditions"]))
+    # Naehe-Check liegt jetzt in den Aktionen (choose-Sequenz), nicht in conditions.
+    texts = " ".join(_templates_in(inv["actions"]))
     # float(0) statt float(9): unbekannt zaehlt als nah am Knie -> verwerfen.
     assert "sensor.byd_modul_2_zellmin')|float(0)" in texts
     assert "float(9)" not in texts
+
+
+def test_invalid_neustart_wartet_auf_frische_zelldaten():
+    # Finding 5: der neustart-Zweig darf den Naehe-Check nicht sofort werten
+    # (zellmin nach Boot unavailable -> float(0) invalidierte jeden Restart).
+    inv = _auto("byd_knie_invalid")
+
+    def find_waits(node):
+        found = []
+
+        def walk(n):
+            if isinstance(n, dict):
+                if "wait_template" in n:
+                    found.append(n)
+                for v in n.values():
+                    walk(v)
+            elif isinstance(n, list):
+                for v in n:
+                    walk(v)
+
+        walk(node)
+        return found
+
+    waits = find_waits(inv["actions"])
+    assert any("has_value('sensor.byd_modul_2_zellmin')" in w["wait_template"]
+               and w.get("continue_on_timeout") is True for w in waits)
+
+
+def test_invalid_schaltet_armed_und_ueberschwelle_ab():
+    # Finding 4 + 7: status=invalid muss armed loeschen (Zustandswiderspruch)
+    # und den Ueberschwelle-Guard zuruecksetzen - in BEIDEN choose-Zweigen.
+    off = _turn_off_targets(_auto("byd_knie_invalid")["actions"])
+    assert off.count("input_boolean.byd_knie_armed") >= 2
+    assert off.count("input_boolean.byd_knie_ueberschwelle_gesehen") >= 2
 
 
 def test_invalid_datenluecke_deckt_beide_frische_binaries_ab():


### PR DESCRIPTION
## Worum es geht

Phase-2-Neubau der BYD Modul-2-Frühwarnung (Trend-Monitoring der schwächsten Zelle, KEIN Push/Alarm), portiert von der alten MQTT-Quelle auf die native `byd_battery_box`-Integration (Modbus, 160 Zellen als `cell_voltages`-Attribut). Baut auf dem Monitoring-Package aus PR #51 auf.

## Was drin ist

- `packages/byd_modul2_fruehwarnung.yaml` (neu, kanonischer Name; Template-unique_ids mit `_nativ`-Suffix, entity_ids kanonisch über die Namens-Slugs).
- **Metrik A** `sensor.byd_modul_2_zell_absackung`: schwächste Modul-2-Zelle gegen den Median aller 160 Zellen (mV), nur in standardisierten Betriebspunkten gesampelt (Entladeband ≥ 3 min, SoC 25-85, Zelldaten frisch). Identifiziert dauerhaft **welche** Zelle.
- **Metrik B** `sensor.byd_modul_2_nettoenergie_bis_knie`: Netto-kWh von Vollladung bis LFP-Knie via Zustandsmaschine. Knie-Erkennung per **Bestätigungszähler** (2 Zyklen) statt `for:` (das sich auf eingefrorenen Werten selbst erfüllt), mit **Mess-Anker** am ersten Sample (kein Wartezeit-Offset) und **Plausibilitäts-Floor** (`m2min > 2,5 V`).
- Tests (`tests/test_byd_modul2_fruehwarnung.py`), Doku-Refresh.

## Review

Architektur (Fable) + Implementierung von zwei unabhängigen Modellen reviewt (Cross-Family). Findings eingearbeitet: Mess-Anker aus eigenem Attribut, `has_value(netto)` in der Qualifikation, `cycle_id`-Reset nullt bedingungslos, Invalid schaltet `armed` ab, Neustart-Invalid mit `wait_template`, Metrik-A-Availability-Härtung, Plausibilitäts-Floor (Meta-Review).

## Status

**Tests: 295 passed.** Bereits **live deployed** (Orphan-Purge + Re-Seed) und verifiziert (keine `_2`-Kollision, Automationen geladen, Zustandsmaschine auf `idle`). Der Merge bringt Repo und Live-Stand deckungsgleich.

Kein Push (Trend ohne Baseline); Drift-Regel erst nach Wochen Baseline als eigener PR.
