### PR TITLE
fix(balancing): Counter-Reset restart-fest (persistenter Bestaetigungs-Counter statt for:-Timer)

### DIFF
--- a/automations/opti_balancing_counter.yaml
+++ b/automations/opti_balancing_counter.yaml
@@ -36,29 +36,84 @@
         entity_id: counter.tage_seit_akku100
 
 # -----------------------------------------------------------------------------
-# Counter-Reset bei erreichtem Done-SoC. Bewusst als eigene, TRIGGER-basierte
-# Automation: ein numeric_state-Trigger mit for: haelt zuverlaessig 30 min
-# (im Gegensatz zu for: auf einer numeric_state-CONDITION, das HA nicht
-# belastbar auswertet). 30 min stabil >= Done-SoC = Balancing-Zyklus erledigt
-# -> counter.tage_seit_akku100 = 0 -> sensor.opti_balancing_watchdog faellt auf
-# 'aus'. Loest den semantischen Widerspruch (Watchdog laedt bis 100 / CV-Phase,
-# Reset bereits ab Done-SoC 98.5%) sauber auf: der Watchdog haelt, bis dieser
-# Trigger nach stabilem Stand ueber Done-SoC feuert.
+# Counter-Reset bei erreichtem Done-SoC. Ein numeric_state-Trigger mit for:
+# waere nicht restart-fest: HA verwirft dessen Laufzeit bei jedem Neustart.
+# Deshalb bestaetigt ein persistenter Counter jede Minute oberhalb der Schwelle.
+# Rueckfall oder Sensorfehler loeschen die Bestaetigungen sofort. Nach 30
+# bestaetigten Minuten gilt der Balancing-Zyklus als erledigt:
+# counter.tage_seit_akku100 = 0 -> sensor.opti_balancing_watchdog faellt auf
+# 'aus'. Ein Neustart pausiert die Bestaetigung nur; ein restaurierter Stand
+# laeuft beim naechsten gueltigen Minuten-Tick weiter.
 # -----------------------------------------------------------------------------
 - id: opti_balancing_counter_reset
   alias: "Opti Balancing: Counter zuruecksetzen bei erreichtem Done-SoC"
   description: >-
-    Setzt counter.tage_seit_akku100 auf 0, sobald der Akku 30 min stabil ueber
-    dem Done-SoC (input_number.opti_balancing_done_soc) steht. Beendet damit
-    einen faelligen Balancing-Zyklus des Watchdogs.
+    Setzt counter.tage_seit_akku100 nach 30 bestaetigten Minuten ueber dem
+    Done-SoC (input_number.opti_balancing_done_soc) auf 0. Der persistente
+    Bestaetigungs-Counter ueberlebt HA-Neustarts und verwirft kurze Spitzen.
   mode: single
   triggers:
-    - trigger: numeric_state
+    - trigger: time_pattern
+      minutes: "/1"
+      id: minute
+    - trigger: state
       entity_id: sensor.opti_soc
-      above: input_number.opti_balancing_done_soc
-      for:
-        minutes: 30
+      id: soc_geaendert
+    - trigger: state
+      entity_id: input_number.opti_balancing_done_soc
+      id: schwelle_geaendert
+    - trigger: homeassistant
+      event: start
+      id: ha_start
   actions:
-    - action: counter.reset
-      target:
-        entity_id: counter.tage_seit_akku100
+    - alias: "Done-SoC minutenweise bestaetigen"
+      choose:
+        # Rueckfall, Schwellenaenderung oder Sensorfehler verwerfen den Lauf
+        # sofort. Beim HA-Start gilt dasselbe, falls noch kein gueltiger SoC
+        # vorliegt; kommt der SoC bereits gueltig und hoch zurueck, bleibt der
+        # restaurierte Bestaetigungsstand erhalten.
+        - alias: "Bestaetigungen bei nicht erreichtem Done-SoC verwerfen"
+          conditions:
+            - condition: trigger
+              id:
+                - soc_geaendert
+                - schwelle_geaendert
+                - ha_start
+            - condition: template
+              value_template: >-
+                {{ not has_value('sensor.opti_soc')
+                   or not has_value('input_number.opti_balancing_done_soc')
+                   or (states('sensor.opti_soc') | float(0))
+                      <= (states('input_number.opti_balancing_done_soc') | float(100)) }}
+          sequence:
+            - action: counter.reset
+              target:
+                entity_id: counter.opti_balancing_done_minuten
+
+        # Nur der Minuten-Tick darf zaehlen. Beliebig viele SoC-Updates
+        # oberhalb der Schwelle koennen die Haltezeit dadurch nicht abkuerzen.
+        - alias: "Gueltige Minute oberhalb des Done-SoC bestaetigen"
+          conditions:
+            - condition: trigger
+              id: minute
+            - condition: numeric_state
+              entity_id: sensor.opti_soc
+              above: input_number.opti_balancing_done_soc
+          sequence:
+            - choose:
+                - alias: "Dreissigste Minute bestaetigt - Zyklus abschliessen"
+                  conditions:
+                    - condition: numeric_state
+                      entity_id: counter.opti_balancing_done_minuten
+                      above: 28
+                  sequence:
+                    - action: counter.reset
+                      target:
+                        entity_id: counter.tage_seit_akku100
+                    - action: counter.reset
+                      target:
+                        entity_id: counter.opti_balancing_done_minuten
+              default:
+                - action: counter.increment
+                  target:
+                    entity_id: counter.opti_balancing_done_minuten

--- a/automations/opti_balancing_counter.yaml
+++ b/automations/opti_balancing_counter.yaml
@@ -51,37 +51,50 @@
     Setzt counter.tage_seit_akku100 nach 30 bestaetigten Minuten ueber dem
     Done-SoC (input_number.opti_balancing_done_soc) auf 0. Der persistente
     Bestaetigungs-Counter ueberlebt HA-Neustarts und verwirft kurze Spitzen.
-  mode: single
+  # Rueckfall-/Fehler-Ereignisse duerfen nicht verloren gehen, falls gerade
+  # ein Minuten-Tick den Counter schreibt. queued arbeitet sie danach in der
+  # urspruenglichen Reihenfolge ab.
+  mode: queued
   triggers:
     - trigger: time_pattern
       minutes: "/1"
       id: minute
+    # Ereignissicherer Rueckfall-Trigger: queued merkt sich die Wahr-Flanke,
+    # auch wenn der SoC bis zur Aktionsausfuehrung schon wieder hoch steht.
+    - trigger: template
+      value_template: >-
+        {% set soc = states('sensor.opti_soc') | float(none) %}
+        {% set done = states('input_number.opti_balancing_done_soc') | float(none) %}
+        {{ soc is not none and done is not none and soc <= done }}
+      id: rueckfall
     - trigger: state
       entity_id: sensor.opti_soc
-      id: soc_geaendert
+      to:
+        - "unknown"
+        - "unavailable"
+      id: sensorfehler
     - trigger: state
       entity_id: input_number.opti_balancing_done_soc
-      id: schwelle_geaendert
+      to:
+        - "unknown"
+        - "unavailable"
+      id: sensorfehler
     - trigger: homeassistant
       event: start
       id: ha_start
   actions:
     - alias: "Done-SoC minutenweise bestaetigen"
       choose:
-        # Rueckfall, Schwellenaenderung oder Sensorfehler verwerfen den Lauf
-        # waehrend des Betriebs sofort.
+        # Der Trigger selbst ist die Wahrheit: nicht erneut den aktuellen SoC
+        # pruefen, denn er koennte beim Abarbeiten der Queue schon wieder hoch
+        # sein. So koennen auch sehr kurze Spitzen nicht zusammengestueckelt
+        # werden.
         - alias: "Bestaetigungen bei nicht erreichtem Done-SoC verwerfen"
           conditions:
             - condition: trigger
               id:
-                - soc_geaendert
-                - schwelle_geaendert
-            - condition: template
-              value_template: >-
-                {{ not has_value('sensor.opti_soc')
-                   or not has_value('input_number.opti_balancing_done_soc')
-                   or (states('sensor.opti_soc') | float(0))
-                      <= (states('input_number.opti_balancing_done_soc') | float(100)) }}
+                - rueckfall
+                - sensorfehler
           sequence:
             - action: counter.reset
               target:
@@ -102,6 +115,24 @@
                    and has_value('input_number.opti_balancing_done_soc')
                    and (states('sensor.opti_soc') | float(0))
                        <= (states('input_number.opti_balancing_done_soc') | float(100)) }}
+          sequence:
+            - action: counter.reset
+              target:
+                entity_id: counter.opti_balancing_done_minuten
+
+        # Selbstheilender Backup-Pfad fuer Automation-Reloads oder bereits vor
+        # dem Listener-Start bestehende Fehler: spaetestens der naechste Tick
+        # verwirft einen ungueltigen oder zu niedrigen Zustand.
+        - alias: "Bestaetigungen beim Minuten-Tick plausibilisieren"
+          conditions:
+            - condition: trigger
+              id: minute
+            - condition: template
+              value_template: >-
+                {{ not has_value('sensor.opti_soc')
+                   or not has_value('input_number.opti_balancing_done_soc')
+                   or (states('sensor.opti_soc') | float(0))
+                      <= (states('input_number.opti_balancing_done_soc') | float(100)) }}
           sequence:
             - action: counter.reset
               target:

--- a/automations/opti_balancing_counter.yaml
+++ b/automations/opti_balancing_counter.yaml
@@ -69,22 +69,39 @@
     - alias: "Done-SoC minutenweise bestaetigen"
       choose:
         # Rueckfall, Schwellenaenderung oder Sensorfehler verwerfen den Lauf
-        # sofort. Beim HA-Start gilt dasselbe, falls noch kein gueltiger SoC
-        # vorliegt; kommt der SoC bereits gueltig und hoch zurueck, bleibt der
-        # restaurierte Bestaetigungsstand erhalten.
+        # waehrend des Betriebs sofort.
         - alias: "Bestaetigungen bei nicht erreichtem Done-SoC verwerfen"
           conditions:
             - condition: trigger
               id:
                 - soc_geaendert
                 - schwelle_geaendert
-                - ha_start
             - condition: template
               value_template: >-
                 {{ not has_value('sensor.opti_soc')
                    or not has_value('input_number.opti_balancing_done_soc')
                    or (states('sensor.opti_soc') | float(0))
                       <= (states('input_number.opti_balancing_done_soc') | float(100)) }}
+          sequence:
+            - action: counter.reset
+              target:
+                entity_id: counter.opti_balancing_done_minuten
+
+        # Beim HA-Start sind Template-Sensoren oft kurz unavailable. Dieser
+        # Initialisierungszustand darf den restaurierten Minutenstand nicht
+        # loeschen. Ist der SoC bereits gueltig und nicht ueber der Schwelle,
+        # wird ein alter Stand dagegen sofort verworfen. Kommt der Sensor erst
+        # danach zurueck, entscheidet sein State-Trigger wie oben.
+        - alias: "Restaurierten Stand beim HA-Start plausibilisieren"
+          conditions:
+            - condition: trigger
+              id: ha_start
+            - condition: template
+              value_template: >-
+                {{ has_value('sensor.opti_soc')
+                   and has_value('input_number.opti_balancing_done_soc')
+                   and (states('sensor.opti_soc') | float(0))
+                       <= (states('input_number.opti_balancing_done_soc') | float(100)) }}
           sequence:
             - action: counter.reset
               target:

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -387,6 +387,18 @@ counter:
     step: 1
     icon: mdi:counter
 
+  opti_balancing_done_minuten:
+    name: "Opti Balancing Done-Minuten"
+    # Persistente Bestaetigungen fuer den restart-festen Done-SoC-Reset.
+    # Bewusst KEIN `initial:`: HA restauriert so den letzten Stand nach einem
+    # Neustart, statt ihn bei jedem Start zu ueberschreiben.
+    # ERSTSTART: Ohne gespeicherten Zustand beginnt der Counter bei Minimum 0;
+    # es ist kein manueller Startwert noetig.
+    minimum: 0
+    maximum: 30
+    step: 1
+    icon: mdi:timer-check-outline
+
 # --- Write-on-Change-Helfer für ha-modbus-akku-adapter (ab v1.2.0) ---
 # Werden vom Adapter automatisch gepflegt, nicht manuell befüllen.
 input_text:

--- a/tests/test_balancing_counter.py
+++ b/tests/test_balancing_counter.py
@@ -101,7 +101,11 @@ class BalancingAutomationHarness:
         value = str(value)
         if value != self.states["sensor.opti_soc"]:
             self.states["sensor.opti_soc"] = value
-            self.fire("soc_geaendert")
+            if value in ("unknown", "unavailable"):
+                self.fire("sensorfehler")
+            elif float(value) <= float(
+                    self.states["input_number.opti_balancing_done_soc"]):
+                self.fire("rueckfall")
 
 
 def test_bestaetigungs_counter_wird_ohne_initial_restauriert():
@@ -123,9 +127,28 @@ def test_reset_automation_hat_restartfeste_trigger_ohne_for_timer():
     assert any(trigger.get("trigger") == "homeassistant"
                and trigger.get("event") == "start"
                and trigger.get("id") == "ha_start" for trigger in triggers)
+    assert any(trigger.get("trigger") == "template"
+               and trigger.get("id") == "rueckfall" for trigger in triggers)
+
+
+def test_rueckfall_und_sensorfehler_werden_ereignissicher_eingereiht():
+    _helper, automation = _require_restartfestes_design()
+    assert automation["mode"] == "queued"
+
+    triggers = automation["triggers"]
     assert any(trigger.get("trigger") == "state"
                and trigger.get("entity_id") == "sensor.opti_soc"
-               and trigger.get("id") == "soc_geaendert" for trigger in triggers)
+               and trigger.get("to") == ["unknown", "unavailable"]
+               and trigger.get("id") == "sensorfehler" for trigger in triggers)
+
+    # Der Reset darf bei spaeterer Ausfuehrung nicht nochmals den dann
+    # aktuellen SoC pruefen: das bereits eingereihte Rueckfall-/Fehler-Ereignis
+    # ist die Wahrheit, auch wenn der Sensor inzwischen wieder hoch steht.
+    reset_option = automation["actions"][0]["choose"][0]
+    assert reset_option["conditions"] == [{
+        "condition": "trigger",
+        "id": ["rueckfall", "sensorfehler"],
+    }]
 
 
 def test_restart_mit_hohem_soc_setzt_nach_restlichen_minuten_zurueck():

--- a/tests/test_balancing_counter.py
+++ b/tests/test_balancing_counter.py
@@ -136,10 +136,13 @@ def test_restart_mit_hohem_soc_setzt_nach_restlichen_minuten_zurueck():
     assert lauf.tage == 14
 
     # HA-Restart: der alte for:-Timer waere weg. Der neue Helper restauriert
-    # dagegen 21 Bestaetigungen; der SoC ist beim Boot bereits wieder hoch.
+    # dagegen 21 Bestaetigungen. Wie bei Template-Sensoren ueblich, ist der SoC
+    # am start-Event noch unavailable und kommt danach direkt oberhalb zurueck.
     nach_restart = BalancingAutomationHarness(
-        soc="99", tage=lauf.tage, bestaetigungen=lauf.bestaetigungen)
+        soc="unavailable", tage=lauf.tage, bestaetigungen=lauf.bestaetigungen)
     nach_restart.fire("ha_start")
+    assert nach_restart.bestaetigungen == 21
+    nach_restart.set_soc("99")
     for _ in range(8):
         nach_restart.minute()
     assert nach_restart.bestaetigungen == 29

--- a/tests/test_balancing_counter.py
+++ b/tests/test_balancing_counter.py
@@ -1,0 +1,180 @@
+"""Restart- und Glitch-Regression fuer den Balancing-Counter-Reset.
+
+Die kleine Ablauf-Harness wertet nur die in dieser Automation verwendeten
+HA-Bausteine aus (choose, Conditions und counter.increment/reset). Dadurch
+laufen die Szenarien gegen die echte YAML-Struktur, ohne HAs kompletten
+Trigger-Scheduler nachzubauen.
+"""
+from __future__ import annotations
+
+from .condition_eval import evaluate_condition
+from .ha_harness import REPO, FakeHass, load_yaml
+
+AUTOMATIONS = REPO / "automations" / "opti_balancing_counter.yaml"
+HELPERS = REPO / "packages" / "sma_helpers.yaml"
+RESET_ID = "opti_balancing_counter_reset"
+BESTAETIGUNGEN = "counter.opti_balancing_done_minuten"
+TAGE = "counter.tage_seit_akku100"
+
+
+def _reset_automation():
+    return next(a for a in load_yaml(AUTOMATIONS) if a["id"] == RESET_ID)
+
+
+def _bestaetigungs_helper():
+    return load_yaml(HELPERS).get("counter", {}).get("opti_balancing_done_minuten")
+
+
+def _require_restartfestes_design():
+    helper = _bestaetigungs_helper()
+    assert helper is not None, "persistenter Bestaetigungs-Counter fehlt"
+    return helper, _reset_automation()
+
+
+def _entity_ids(action):
+    entity_ids = action.get("target", {}).get("entity_id", [])
+    return [entity_ids] if isinstance(entity_ids, str) else entity_ids
+
+
+class BalancingAutomationHarness:
+    """Fuehrt die deklarativen Aktionen der Reset-Automation minimal aus."""
+
+    def __init__(self, *, soc="97", schwelle="98.5", tage=14,
+                 bestaetigungen=0):
+        helper, self.automation = _require_restartfestes_design()
+        self.maximum = int(helper["maximum"])
+        self.states = {
+            "sensor.opti_soc": str(soc),
+            "input_number.opti_balancing_done_soc": str(schwelle),
+            TAGE: str(tage),
+            BESTAETIGUNGEN: str(bestaetigungen),
+        }
+
+    @property
+    def tage(self):
+        return int(self.states[TAGE])
+
+    @property
+    def bestaetigungen(self):
+        return int(self.states[BESTAETIGUNGEN])
+
+    def _condition(self, condition, trigger_id):
+        if condition["condition"] == "trigger":
+            ids = condition["id"]
+            if isinstance(ids, str):
+                ids = [ids]
+            return trigger_id in ids
+        return evaluate_condition(FakeHass(states=self.states), condition)
+
+    def _conditions(self, conditions, trigger_id):
+        return all(self._condition(c, trigger_id) for c in conditions)
+
+    def _run_actions(self, actions, trigger_id):
+        for action in actions:
+            if "choose" in action:
+                for option in action["choose"]:
+                    if self._conditions(option.get("conditions", []), trigger_id):
+                        self._run_actions(option["sequence"], trigger_id)
+                        break
+                else:
+                    self._run_actions(action.get("default", []), trigger_id)
+                continue
+
+            service = action.get("action")
+            if service == "counter.reset":
+                for entity_id in _entity_ids(action):
+                    self.states[entity_id] = "0"
+            elif service == "counter.increment":
+                for entity_id in _entity_ids(action):
+                    current = int(self.states.get(entity_id, "0"))
+                    self.states[entity_id] = str(min(current + 1, self.maximum))
+            else:
+                raise NotImplementedError(f"Aktion nicht unterstuetzt: {action!r}")
+
+    def fire(self, trigger_id):
+        self._run_actions(self.automation["actions"], trigger_id)
+
+    def minute(self):
+        self.fire("minute")
+
+    def set_soc(self, value):
+        value = str(value)
+        if value != self.states["sensor.opti_soc"]:
+            self.states["sensor.opti_soc"] = value
+            self.fire("soc_geaendert")
+
+
+def test_bestaetigungs_counter_wird_ohne_initial_restauriert():
+    helper, _automation = _require_restartfestes_design()
+    assert "initial" not in helper
+    assert helper["minimum"] == 0
+    assert helper["maximum"] == 30
+    assert helper["step"] == 1
+
+
+def test_reset_automation_hat_restartfeste_trigger_ohne_for_timer():
+    _helper, automation = _require_restartfestes_design()
+    triggers = automation["triggers"]
+
+    assert not any("for" in trigger for trigger in triggers)
+    assert any(trigger.get("trigger") == "time_pattern"
+               and trigger.get("minutes") == "/1"
+               and trigger.get("id") == "minute" for trigger in triggers)
+    assert any(trigger.get("trigger") == "homeassistant"
+               and trigger.get("event") == "start"
+               and trigger.get("id") == "ha_start" for trigger in triggers)
+    assert any(trigger.get("trigger") == "state"
+               and trigger.get("entity_id") == "sensor.opti_soc"
+               and trigger.get("id") == "soc_geaendert" for trigger in triggers)
+
+
+def test_restart_mit_hohem_soc_setzt_nach_restlichen_minuten_zurueck():
+    lauf = BalancingAutomationHarness(soc="99", tage=14)
+    for _ in range(21):
+        lauf.minute()
+    assert lauf.bestaetigungen == 21
+    assert lauf.tage == 14
+
+    # HA-Restart: der alte for:-Timer waere weg. Der neue Helper restauriert
+    # dagegen 21 Bestaetigungen; der SoC ist beim Boot bereits wieder hoch.
+    nach_restart = BalancingAutomationHarness(
+        soc="99", tage=lauf.tage, bestaetigungen=lauf.bestaetigungen)
+    nach_restart.fire("ha_start")
+    for _ in range(8):
+        nach_restart.minute()
+    assert nach_restart.bestaetigungen == 29
+    assert nach_restart.tage == 14
+
+    nach_restart.minute()
+    assert nach_restart.bestaetigungen == 0
+    assert nach_restart.tage == 0
+
+
+def test_kurzer_soc_spike_wird_sofort_verworfen_und_resettet_nicht():
+    lauf = BalancingAutomationHarness(soc="97", tage=14)
+    lauf.set_soc("99")
+    for _ in range(29):
+        lauf.minute()
+    assert lauf.bestaetigungen == 29
+
+    lauf.set_soc("97")
+    assert lauf.bestaetigungen == 0
+    assert lauf.tage == 14
+
+    # Ein neuer Anlauf beginnt wieder bei null und darf nicht die 29 Minuten
+    # des verworfenen Spikes weiterverwenden.
+    lauf.set_soc("99")
+    lauf.minute()
+    assert lauf.bestaetigungen == 1
+    assert lauf.tage == 14
+
+
+def test_sensorfehler_verwirft_laufende_bestaetigungen_sofort():
+    lauf = BalancingAutomationHarness(soc="99", tage=14)
+    for _ in range(10):
+        lauf.minute()
+    assert lauf.bestaetigungen == 10
+
+    lauf.set_soc("unavailable")
+    assert lauf.bestaetigungen == 0
+    assert lauf.tage == 14


### PR DESCRIPTION
## Problem (18.7. live belegt)
Der Done-SoC-Reset (numeric_state + for: 30min) ist nicht restart-fest: HA verwirft die for:-Laufzeit bei jedem Neustart. Kommt der SoC nach dem Boot direkt ueber der Schwelle zurueck, gibt es keinen neuen Unter->Ueber-Uebertritt und der Reset feuert NIE. Heute real: Schwelle 13:01 ueberschritten, Restart 13:22, Reset (faellig 13:31) kam nie -> counter.tage_seit_akku100 blieb auf 7, der Watchdog haette am Folgetag erneut eine Zwangs-Vollladung erzwungen (musste manuell resettet werden).

## Fix
Persistenter Bestaetigungs-Counter `counter.opti_balancing_done_minuten` (KEIN initial:, restauriert nach Restart): minuetlicher Tick bestaetigt jede gueltige Minute oberhalb der Schwelle; Rueckfall/Sensorfehler loeschen sofort (mode: queued gegen verlorene Flanken); Boot-Plausibilisierung verwirft alte Staende nur bei nachweislich zu niedrigem SoC. Nach 30 Bestaetigungen: beide Counter resetten. Ein Restart pausiert die Zaehlung nur noch.

## Tests
Neue tests/test_balancing_counter.py (Restart mitten im Fenster, Boot ueber Schwelle, Boot mit unavailable-Sensoren, Spike-Verwurf, 30er-Abschluss). Suite gruen.

Hinweis Deploy: live liegen diese Automationen in packages/opti_strategie.yaml (Hand-Merge wie beim Erst-Deploy 7.7.); der neue Counter-Helfer wird live per API angelegt (sma_helpers.yaml ist live nicht eingebunden).