### PR TITLE
fix(byd): BMS-Warnungen deduplizieren, KI-Push-Leck im Schattenbetrieb schliessen

### DIFF
--- a/packages/byd_monitoring.yaml
+++ b/packages/byd_monitoring.yaml
@@ -451,12 +451,35 @@ automation:
               - condition: state
                 entity_id: binary_sensor.byd_zelldaten_frisch
                 state: "on"
-          # Native Fehler-/Warnbits: alles ausser Normal/unknown/unavailable.
+          # Native BMS-Warnbits: nur aktive, tatsaechlich neue Token-Mengen.
+          # Die Integration dekodiert dieselbe Bitmaske teils als "x,x", teils
+          # als "x". Sortieren + Deduplizieren macht solche String-Aenderungen
+          # inert. Der persistente Merker faengt Restart-Refires ab, laesst aber
+          # eine nach dem Restart wirklich neue Warnung weiterhin durch.
+          - condition: and
+            conditions:
+              - condition: trigger
+                id: bms_warnung
+              - condition: template
+                value_template: >-
+                  {{ trigger.to_state.state not in ['Normal', 'unknown', 'unavailable'] }}
+              - condition: template
+                value_template: >-
+                  {% set von_roh = trigger.from_state.state
+                    if trigger.from_state is not none else 'unknown' %}
+                  {% set von = von_roh.split(',') | map('trim')
+                    | reject('equalto', '') | unique | sort | list %}
+                  {% set nach = trigger.to_state.state.split(',') | map('trim')
+                    | reject('equalto', '') | unique | sort | list %}
+                  {{ von != nach
+                    and (von_roh not in ['unknown', 'unavailable']
+                      or (nach | join(',')) !=
+                        states('input_text.byd_bms_warnung_zuletzt_gemeldet')) }}
+          # Native Fehlerbits: alles ausser Normal/unknown/unavailable.
           - condition: and
             conditions:
               - condition: trigger
                 id:
-                  - bms_warnung
                   - bms_fehler
                   - bmu_fehler
               - condition: template
@@ -538,13 +561,10 @@ automation:
             } %}{{ t.get(trigger.id, 'BYD-Alarm: ' ~ trigger.id) }}
       - alias: "Push"
         choose:
-          # Kennenlern-Phase: BMS-Warnungen laufen im SCHATTENBETRIEB - nur
+          # BMS-Warnungen bleiben DAUERHAFT im SCHATTENBETRIEB - nur
           # persistent_notification in der HA-UI + Logbuch, KEIN Mobile-Push.
-          # Ob das BMS am Ladeschluss/Balancing routinemaessig Warn-Bits setzt
-          # (z. B. "Cells imbalance"), ist unbekannt.
-          # TODO (nach mindestens einer sauberen Vollladung ohne Warn-Rauschen):
-          # bms_warnung aus dieser Option entfernen -> faellt in den default-
-          # Zweig und pusht dann normal.
+          # Die Live-Diagnose vom 18.7. belegt, dass das BMS am Ladeschluss
+          # routinemaessig Warn-Bits wie "Cells overvoltage" setzen kann.
           - alias: "BMS-Warnung: Schattenbetrieb (kein Push)"
             conditions:
               - condition: trigger
@@ -555,6 +575,13 @@ automation:
                   notification_id: "byd_bms_warnung"
                   title: "BYD BMS-Warnung (Schattenbetrieb)"
                   message: "{{ alarm_text }}"
+              - action: input_text.set_value
+                target:
+                  entity_id: input_text.byd_bms_warnung_zuletzt_gemeldet
+                data:
+                  value: >-
+                    {{ trigger.to_state.state.split(',') | map('trim')
+                      | reject('equalto', '') | unique | sort | join(',') }}
           # Schwere Regeln: eigener Titel (🚨) zur schnellen Triage, aber KEIN
           # iOS-Critical-Override (Ben-Entscheidung 17.7.): kein Durchdringen von
           # Stumm/Fokus/Nachtruhe. Begruendung: aus der Ferne/nachts ist ohnehin
@@ -577,53 +604,95 @@ automation:
                 data:
                   title: "🔋🚨 BYD Akku-Alarm"
                   message: "{{ alarm_text }}"
+              - alias: "KI-Lagebild anstossen (fire-and-forget, Skript existiert nur live)"
+                action: script.turn_on
+                continue_on_error: true
+                target:
+                  entity_id: script.ki_alarm_kontext
+                data:
+                  variables:
+                    alarm_titel: "BYD Akku-Alarm"
+                    hinweis: >-
+                      BYD Battery-Box Premium HVS (LFP, 5 Module, 32 Zellen/Modul =
+                      160 Zellen, 12,8 kWh) am SMA WR. Datenquelle: Integration
+                      byd_battery_box, Modbus nativ - zwei Ebenen: BMU-Poll alle 30 s
+                      (Spannungen 10 mV granular, Temperatur 1 C) und BMS-Detail alle
+                      ~10,5 min (Spannungen 1 mV granular). Zeitkritische Alarme laufen
+                      auf der 30-s-Ebene, die 10-mV-Aufloesung verschiebt deren
+                      Ausloesepunkt um bis zu 10 mV nach oben; der mV-genaue
+                      Grenzwaechter auf der BMS-Ebene faengt das Fenster
+                      3,651-3,659 V ab. BMS-Schutzgrenzen 2,75/3,65 V - die Alarme
+                      liegen bewusst davor. Zellspannungs-Alarme sind SoC-gegated
+                      (<90 %), am Ladeschluss zaehlt nur die BMS-Grenze. Zellspreizung
+                      ist nur in Ruhe und bei SoC 25-85 % vergleichbar. Die Integration
+                      setzt Entities bei Modbus-Abbruch NICHT auf unavailable, sondern
+                      friert sie ein - deshalb pruefen die Alarme zusaetzlich
+                      Frische-Binaries.
+                    daten: >-
+                      Ausgeloest durch Regel: {{ trigger.id }}
+                      {{ alarm_text }}
+
+                      Zellspannung min/max (BMU, 30 s): {{ states('sensor.battery_management_unit_bmu_cell_voltage_min') }} / {{ states('sensor.bmu_cell_voltage_max') }} V
+                      Zellspannung min/max (BMS, mV-genau, ~10,5 min): {{ states('sensor.battery_management_system_1_bms_1_cell_voltage_min') }} / {{ states('sensor.battery_management_system_1_bms_1_cell_voltage_max') }} V
+                      Zellspreizung: {{ states('sensor.battery_management_system_1_bms_1_cells_voltage_delta') }} mV (Ruhe-Median: {{ states('sensor.byd_zellspreizung_ruhe') }} mV)
+                      Zell-Ausreisser: {{ states('sensor.byd_zell_ausreisser') }} mV vom Median ({{ state_attr('sensor.byd_zell_ausreisser', 'richtung') }}, Modul {{ state_attr('sensor.byd_zell_ausreisser', 'modul') }} Zelle {{ state_attr('sensor.byd_zell_ausreisser', 'zelle') }})
+                      SoC: {{ states('sensor.battery_management_unit_state_of_charge') }} %, Leistung: {{ states('sensor.bmu_power') }} W (negativ = Laden)
+                      Zelltemperatur min/max: {{ states('sensor.battery_management_unit_bmu_cell_temperature_min') }} / {{ states('sensor.battery_management_unit_bmu_cell_temperature_max') }} C
+                      Temperatur-Spreizung: {{ states('sensor.byd_temperatur_spreizung') }} K
+                      Balancing: {{ states('sensor.bms_1_cells_balancing') }} Zellen aktiv
+                      SoH: {{ states('sensor.bms_1_state_of_health') }} %
+                      BMS warnings/errors: {{ states('sensor.battery_management_system_1_bms_1_warnings') }} / {{ states('sensor.battery_management_system_1_bms_1_errors') }}
+                      BMU errors: {{ states('sensor.battery_management_unit_errors') }}
+                      Verbindung: {{ states('sensor.battery_management_unit_connection_health') }}
+                      Daten frisch (BMU/Zelldaten): {{ states('binary_sensor.byd_bmu_frisch') }} / {{ states('binary_sensor.byd_zelldaten_frisch') }}
+                      Steuerungs-Modus: {{ states('input_select.akkusteuerung_modus') }}
         default:
           - action: notify.notify
             data:
               title: "🔋 BYD Akku-Alarm"
               message: "{{ alarm_text }}"
-      - alias: "KI-Lagebild anstossen (fire-and-forget, Skript existiert nur live)"
-        action: script.turn_on
-        continue_on_error: true
-        target:
-          entity_id: script.ki_alarm_kontext
-        data:
-          variables:
-            alarm_titel: "BYD Akku-Alarm"
-            hinweis: >-
-              BYD Battery-Box Premium HVS (LFP, 5 Module, 32 Zellen/Modul =
-              160 Zellen, 12,8 kWh) am SMA WR. Datenquelle: Integration
-              byd_battery_box, Modbus nativ - zwei Ebenen: BMU-Poll alle 30 s
-              (Spannungen 10 mV granular, Temperatur 1 C) und BMS-Detail alle
-              ~10,5 min (Spannungen 1 mV granular). Zeitkritische Alarme laufen
-              auf der 30-s-Ebene, die 10-mV-Aufloesung verschiebt deren
-              Ausloesepunkt um bis zu 10 mV nach oben; der mV-genaue
-              Grenzwaechter auf der BMS-Ebene faengt das Fenster
-              3,651-3,659 V ab. BMS-Schutzgrenzen 2,75/3,65 V - die Alarme
-              liegen bewusst davor. Zellspannungs-Alarme sind SoC-gegated
-              (<90 %), am Ladeschluss zaehlt nur die BMS-Grenze. Zellspreizung
-              ist nur in Ruhe und bei SoC 25-85 % vergleichbar. Die Integration
-              setzt Entities bei Modbus-Abbruch NICHT auf unavailable, sondern
-              friert sie ein - deshalb pruefen die Alarme zusaetzlich
-              Frische-Binaries.
-            daten: >-
-              Ausgeloest durch Regel: {{ trigger.id }}
-              {{ alarm_text }}
+          - alias: "KI-Lagebild anstossen (fire-and-forget, Skript existiert nur live)"
+            action: script.turn_on
+            continue_on_error: true
+            target:
+              entity_id: script.ki_alarm_kontext
+            data:
+              variables:
+                alarm_titel: "BYD Akku-Alarm"
+                hinweis: >-
+                  BYD Battery-Box Premium HVS (LFP, 5 Module, 32 Zellen/Modul =
+                  160 Zellen, 12,8 kWh) am SMA WR. Datenquelle: Integration
+                  byd_battery_box, Modbus nativ - zwei Ebenen: BMU-Poll alle 30 s
+                  (Spannungen 10 mV granular, Temperatur 1 C) und BMS-Detail alle
+                  ~10,5 min (Spannungen 1 mV granular). Zeitkritische Alarme laufen
+                  auf der 30-s-Ebene, die 10-mV-Aufloesung verschiebt deren
+                  Ausloesepunkt um bis zu 10 mV nach oben; der mV-genaue
+                  Grenzwaechter auf der BMS-Ebene faengt das Fenster
+                  3,651-3,659 V ab. BMS-Schutzgrenzen 2,75/3,65 V - die Alarme
+                  liegen bewusst davor. Zellspannungs-Alarme sind SoC-gegated
+                  (<90 %), am Ladeschluss zaehlt nur die BMS-Grenze. Zellspreizung
+                  ist nur in Ruhe und bei SoC 25-85 % vergleichbar. Die Integration
+                  setzt Entities bei Modbus-Abbruch NICHT auf unavailable, sondern
+                  friert sie ein - deshalb pruefen die Alarme zusaetzlich
+                  Frische-Binaries.
+                daten: >-
+                  Ausgeloest durch Regel: {{ trigger.id }}
+                  {{ alarm_text }}
 
-              Zellspannung min/max (BMU, 30 s): {{ states('sensor.battery_management_unit_bmu_cell_voltage_min') }} / {{ states('sensor.bmu_cell_voltage_max') }} V
-              Zellspannung min/max (BMS, mV-genau, ~10,5 min): {{ states('sensor.battery_management_system_1_bms_1_cell_voltage_min') }} / {{ states('sensor.battery_management_system_1_bms_1_cell_voltage_max') }} V
-              Zellspreizung: {{ states('sensor.battery_management_system_1_bms_1_cells_voltage_delta') }} mV (Ruhe-Median: {{ states('sensor.byd_zellspreizung_ruhe') }} mV)
-              Zell-Ausreisser: {{ states('sensor.byd_zell_ausreisser') }} mV vom Median ({{ state_attr('sensor.byd_zell_ausreisser', 'richtung') }}, Modul {{ state_attr('sensor.byd_zell_ausreisser', 'modul') }} Zelle {{ state_attr('sensor.byd_zell_ausreisser', 'zelle') }})
-              SoC: {{ states('sensor.battery_management_unit_state_of_charge') }} %, Leistung: {{ states('sensor.bmu_power') }} W (negativ = Laden)
-              Zelltemperatur min/max: {{ states('sensor.battery_management_unit_bmu_cell_temperature_min') }} / {{ states('sensor.battery_management_unit_bmu_cell_temperature_max') }} C
-              Temperatur-Spreizung: {{ states('sensor.byd_temperatur_spreizung') }} K
-              Balancing: {{ states('sensor.bms_1_cells_balancing') }} Zellen aktiv
-              SoH: {{ states('sensor.bms_1_state_of_health') }} %
-              BMS warnings/errors: {{ states('sensor.battery_management_system_1_bms_1_warnings') }} / {{ states('sensor.battery_management_system_1_bms_1_errors') }}
-              BMU errors: {{ states('sensor.battery_management_unit_errors') }}
-              Verbindung: {{ states('sensor.battery_management_unit_connection_health') }}
-              Daten frisch (BMU/Zelldaten): {{ states('binary_sensor.byd_bmu_frisch') }} / {{ states('binary_sensor.byd_zelldaten_frisch') }}
-              Steuerungs-Modus: {{ states('input_select.akkusteuerung_modus') }}
+                  Zellspannung min/max (BMU, 30 s): {{ states('sensor.battery_management_unit_bmu_cell_voltage_min') }} / {{ states('sensor.bmu_cell_voltage_max') }} V
+                  Zellspannung min/max (BMS, mV-genau, ~10,5 min): {{ states('sensor.battery_management_system_1_bms_1_cell_voltage_min') }} / {{ states('sensor.battery_management_system_1_bms_1_cell_voltage_max') }} V
+                  Zellspreizung: {{ states('sensor.battery_management_system_1_bms_1_cells_voltage_delta') }} mV (Ruhe-Median: {{ states('sensor.byd_zellspreizung_ruhe') }} mV)
+                  Zell-Ausreisser: {{ states('sensor.byd_zell_ausreisser') }} mV vom Median ({{ state_attr('sensor.byd_zell_ausreisser', 'richtung') }}, Modul {{ state_attr('sensor.byd_zell_ausreisser', 'modul') }} Zelle {{ state_attr('sensor.byd_zell_ausreisser', 'zelle') }})
+                  SoC: {{ states('sensor.battery_management_unit_state_of_charge') }} %, Leistung: {{ states('sensor.bmu_power') }} W (negativ = Laden)
+                  Zelltemperatur min/max: {{ states('sensor.battery_management_unit_bmu_cell_temperature_min') }} / {{ states('sensor.battery_management_unit_bmu_cell_temperature_max') }} C
+                  Temperatur-Spreizung: {{ states('sensor.byd_temperatur_spreizung') }} K
+                  Balancing: {{ states('sensor.bms_1_cells_balancing') }} Zellen aktiv
+                  SoH: {{ states('sensor.bms_1_state_of_health') }} %
+                  BMS warnings/errors: {{ states('sensor.battery_management_system_1_bms_1_warnings') }} / {{ states('sensor.battery_management_system_1_bms_1_errors') }}
+                  BMU errors: {{ states('sensor.battery_management_unit_errors') }}
+                  Verbindung: {{ states('sensor.battery_management_unit_connection_health') }}
+                  Daten frisch (BMU/Zelldaten): {{ states('binary_sensor.byd_bmu_frisch') }} / {{ states('binary_sensor.byd_zelldaten_frisch') }}
+                  Steuerungs-Modus: {{ states('input_select.akkusteuerung_modus') }}
 
   # -------------------------------------------------------------------------
   # Dead-Man-Watchdog: ZEITbasiert, nicht edge-basiert.

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -393,6 +393,13 @@ input_text:
   akkusteuerung_modbus_letzter_schreibwert:
     name: "Akkusteuerung Modbus Letzter Schreibwert"
     max: 255
+  # Persistenter Dedupe-Merker fuer native BMS-Warnungen. Bewusst KEIN
+  # initial: HA wuerde den Wert bei jedem Neustart ueberschreiben; ohne
+  # initial wird der letzte Wert restauriert. Beim Erststart ist der Merker
+  # leer, die erste aktive Warnung wird daher einmalig verarbeitet.
+  byd_bms_warnung_zuletzt_gemeldet:
+    name: "BYD Zuletzt gemeldete BMS-Warnung"
+    max: 255
 
 input_datetime:
   akkusteuerung_modbus_letzter_schreibzeitpunkt:

--- a/tests/test_byd_monitoring.py
+++ b/tests/test_byd_monitoring.py
@@ -11,6 +11,7 @@ Frische-Binaries (als Bedingung in der Automation), der Dead-Man-Watchdog und
 der E2E-Livetest - nicht diese Datei.
 """
 import datetime as dt
+import types
 
 import jinja2
 
@@ -18,6 +19,7 @@ from .ha_harness import (REPO, TZ, FakeHass, find_template_entity, load_yaml,
                          render, render_native)
 
 PACKAGE = REPO / "packages" / "byd_monitoring.yaml"
+HELPERS = REPO / "packages" / "sma_helpers.yaml"
 
 
 def _entity(kind, unique_id):
@@ -502,6 +504,177 @@ def test_frische_bedingung_fuer_jeden_physikalischen_alarm():
             assert "binary_sensor.byd_bmu_frisch" in entities, ids
         if "zell_bms_grenze_praezise" in ids:
             assert "binary_sensor.byd_zelldaten_frisch" in entities, ids
+
+
+def _bms_warnung_bedingung():
+    for zweig in _alarm_automation()["conditions"][0]["conditions"]:
+        if _condition_trigger_ids_von(zweig) == ["bms_warnung"]:
+            for bedingung in zweig["conditions"]:
+                if (
+                    bedingung.get("condition") == "template"
+                    and "byd_bms_warnung_zuletzt_gemeldet"
+                    in bedingung["value_template"]
+                ):
+                    return bedingung["value_template"]
+    return None
+
+
+def _bms_warnung_darf_laufen(von, nach, merker):
+    template = _bms_warnung_bedingung()
+    assert template is not None, "bms_warnung braucht einen eigenen Dedupe-Zweig"
+    trigger = types.SimpleNamespace(
+        from_state=types.SimpleNamespace(state=von),
+        to_state=types.SimpleNamespace(state=nach),
+    )
+    states = lambda entity_id: (
+        merker if entity_id == "input_text.byd_bms_warnung_zuletzt_gemeldet"
+        else "unknown"
+    )
+    return jinja2.Environment().from_string(template).render(
+        trigger=trigger, states=states
+    ).strip()
+
+
+def test_bms_warnung_dekode_duplikat_startet_keinen_lauf():
+    assert _bms_warnung_darf_laufen(
+        "Cells overvoltage,Cells overvoltage",
+        "Cells overvoltage",
+        "",
+    ) == "False"
+
+
+def test_bms_warnung_reine_token_reihenfolge_startet_keinen_lauf():
+    assert _bms_warnung_darf_laufen(
+        "Cells overvoltage, Cells imbalance",
+        "Cells imbalance,Cells overvoltage",
+        "",
+    ) == "False"
+
+
+def test_bms_warnung_restart_refire_mit_gleichem_merker_startet_keinen_lauf():
+    assert _bms_warnung_darf_laufen(
+        "unknown",
+        "Cells overvoltage",
+        "Cells overvoltage",
+    ) == "False"
+
+
+def test_bms_warnung_restart_mit_neuer_warnung_startet_lauf():
+    assert _bms_warnung_darf_laufen(
+        "unknown",
+        "Cells imbalance, Cells overvoltage",
+        "Cells overvoltage",
+    ) == "True"
+
+
+def test_bms_warnung_nach_normal_darf_trotz_altem_merker_erneut_laufen():
+    assert _bms_warnung_darf_laufen(
+        "Normal",
+        "Cells overvoltage",
+        "Cells overvoltage",
+    ) == "True"
+
+
+def _push_action():
+    return next(action for action in _alarm_automation()["actions"]
+                if action.get("alias") == "Push")
+
+
+def _push_choose():
+    return _push_action()["choose"]
+
+
+def _aktionen(node):
+    gefunden = []
+
+    def walk(wert):
+        if isinstance(wert, dict):
+            if "action" in wert:
+                gefunden.append(wert)
+            for teil in wert.values():
+                walk(teil)
+        elif isinstance(wert, list):
+            for teil in wert:
+                walk(teil)
+
+    walk(node)
+    return gefunden
+
+
+def test_bms_warnung_schattenzweig_ruft_keine_ki_auf():
+    automation = _alarm_automation()
+    push_index = next(
+        index for index, action in enumerate(automation["actions"])
+        if action.get("alias") == "Push"
+    )
+    schatten = next(
+        option for option in _push_choose()
+        if _condition_trigger_ids_von(option["conditions"]) == ["bms_warnung"]
+    )
+    # Bei einem Treffer im Schatten-choose laufen danach weiterhin alle
+    # Top-Level-Aktionen der Automation. Genau dort sass der Live-Fehler.
+    actions = _aktionen(schatten["sequence"])
+    actions.extend(_aktionen(automation["actions"][push_index + 1:]))
+    assert all(
+        action.get("target", {}).get("entity_id") != "script.ki_alarm_kontext"
+        for action in actions
+    )
+    assert all(action["action"] != "notify.notify" for action in actions)
+
+
+def test_bms_warnung_schattenzweig_speichert_normalisierte_tokenmenge():
+    schatten = next(
+        option for option in _push_choose()
+        if _condition_trigger_ids_von(option["conditions"]) == ["bms_warnung"]
+    )
+    merker_action = next(
+        (action for action in _aktionen(schatten["sequence"])
+         if action["action"] == "input_text.set_value"),
+        None,
+    )
+    assert merker_action is not None
+    assert merker_action["target"]["entity_id"] == (
+        "input_text.byd_bms_warnung_zuletzt_gemeldet"
+    )
+    trigger = types.SimpleNamespace(
+        to_state=types.SimpleNamespace(
+            state="Cells overvoltage, Cells imbalance,Cells overvoltage"
+        )
+    )
+    wert = jinja2.Environment().from_string(
+        merker_action["data"]["value"]
+    ).render(trigger=trigger).strip()
+    assert wert == "Cells imbalance,Cells overvoltage"
+
+
+def test_ki_lagebild_laeuft_nur_in_tatsaechlichen_pushzweigen():
+    automation = _alarm_automation()
+    assert all(
+        action.get("target", {}).get("entity_id") != "script.ki_alarm_kontext"
+        for action in automation["actions"]
+    )
+
+    push = _push_choose()
+    push_sequenzen = [
+        option["sequence"] for option in push
+        if any(action["action"] == "notify.notify"
+               for action in _aktionen(option["sequence"]))
+    ]
+    push_sequenzen.append(_push_action()["default"])
+    assert len(push_sequenzen) == 2
+    for sequence in push_sequenzen:
+        actions = _aktionen(sequence)
+        assert any(action["action"] == "notify.notify" for action in actions)
+        assert any(
+            action.get("target", {}).get("entity_id") == "script.ki_alarm_kontext"
+            for action in actions
+        )
+
+
+def test_bms_warnungs_merker_ist_persistent_ohne_initial():
+    helper = load_yaml(HELPERS)["input_text"]["byd_bms_warnung_zuletzt_gemeldet"]
+    assert helper["max"] == 255
+    assert "initial" not in helper
 
 
 def _condition_trigger_ids_von(zweig):


### PR DESCRIPTION
## Problem (18.7. live belegt)
Ein einziges physisches Ereignis (BMS setzte am Ladeschluss das Warn-Bit 'Cells overvoltage') erzeugte DREI Mobile-Pushes - alle vom KI-Lagebild: (1) regulaerer Lauf, (2) Dekode-Artefakt 'x,x'->'x' als neuer Trigger-Lauf, (3) Restart-Refire unknown->Wert. Der deterministische bms_warnung-Push stand korrekt im Schattenbetrieb (0 Pushes), aber script.ki_alarm_kontext hing als Top-Level-Action HINTER dem choose und pushte bei jedem Lauf.

## Fix
- KI-Lagebild-Aufruf nur noch in den echten Push-Zweigen (schwer + default); Schatten-Zweig erzeugt ausschliesslich die persistente HA-Notification.
- Warn-Bit-Dedupe: normalisierte Token-Mengen (split, trim, unique, sort) from vs. to; Dekode-Duplikate sind kein Lauf mehr.
- Persistenter Merker input_text.byd_bms_warnung_zuletzt_gemeldet (KEIN initial:) gegen Restart-Refires - eine nach Restart wirklich NEUE Warnung feuert weiterhin.
- TODO 'bms_warnung spaeter in Push-Zweig entlassen' gestrichen: belegt ist, dass das BMS am Ladeschluss routinemaessig Warn-Bits setzt; Schattenbetrieb bleibt dauerhaft.

## Tests
9 neue Faelle in tests/test_byd_monitoring.py (Duplikat, Refire, neue Warnung nach Restart, Eskalation A->A,B, Schatten ohne KI-Aufruf). Suite gruen.