### PR TITLE
feat(byd): Knie-Spreizung je Vollladung als Trend-Metrik aufzeichnen

### DIFF
--- a/packages/byd_knie_spreizung.yaml
+++ b/packages/byd_knie_spreizung.yaml
@@ -1,0 +1,236 @@
+# =============================================================================
+# BYD Knie-Spreizung als Trend-Metrik
+# -----------------------------------------------------------------------------
+# Rein diagnostischer Latch fuer das obere LFP-Spannungsknie. Die Ruhe-
+# Spreizung ist fuer Ladungs-Ungleichgewicht im flachen Kennlinienbereich blind;
+# hier wird deshalb je Vollladungs-Episode der groesste 160-Zell-Abstand
+# festgehalten.
+#
+# Datenquelle ist ausschliesslich der native BYD-BMS-Snapshot:
+#   sensor.bms_1_cells_average_voltage, Attribut cell_voltages
+#   Format: [{"m": 1..5, "v": [32 Zellspannungen in mV]}, ...]
+#
+# EPISODE / HYSTERESE
+# - Start: erster gueltiger BMS-Snapshot bei SoC >= 95 %
+# - Ende:  erster gueltiger BMS-Snapshot bei SoC < 93 %
+# - 93..95 %: Zustand unveraendert (kein Flattern um die Startschwelle)
+#
+# RESTART-SEMANTIK
+# Trigger-basierte Template-Sensoren stellen Zustand und Attribute wieder her.
+# Der Latch lebt daher nur in this.state / this.attributes. Es gibt bewusst
+# KEINE Input-Helfer und insbesondere kein initial:, das restaurierte Werte bei
+# einem Neustart ueberschreiben koennte.
+#
+# ARCHIV-ENTSCHEIDUNG
+# Die abgeschlossene Vorganger-Episode bleibt als letzte_vollladung_*-Attribute
+# am selben Sensor erhalten. Ein zweiter Sensor muesste beim Abschluss den alten
+# Zustand eines parallel gerenderten Sensors lesen (Cross-Entity-Race). Das
+# Eigenarchiv liest dagegen atomar aus dem vorherigen this-Snapshot.
+# =============================================================================
+
+template:
+  # Trigger direkt auf dem Attribut-Traeger: Ein HA-State-Trigger ohne
+  # attribute:-Einschraenkung feuert auch bei Attribut-Aenderungen. Spreizung
+  # und Ausreisser stammen dadurch garantiert aus demselben BMS-Snapshot.
+  - triggers:
+      - trigger: state
+        entity_id: sensor.bms_1_cells_average_voltage
+    conditions:
+      - condition: template
+        value_template: >
+          {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+          {% set ns = namespace(anzahl=0, module32=0, numerisch=true) %}
+          {% for modul in daten or [] %}
+            {% set laenge = (modul.get('v', []) | length) %}
+            {% set ns.anzahl = ns.anzahl + laenge %}
+            {% if laenge == 32 %}{% set ns.module32 = ns.module32 + 1 %}{% endif %}
+            {% for wert in modul.get('v', []) %}
+              {% if (wert | float(none)) is none %}{% set ns.numerisch = false %}{% endif %}
+            {% endfor %}
+          {% endfor %}
+          {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+          {% set alter = now().timestamp()
+             - as_timestamp(states('sensor.battery_management_unit_updated'), 0) %}
+          {{ ns.anzahl == 160 and ns.module32 == 5 and ns.numerisch
+             and 0 <= soc <= 100 and 0 <= alter < 90 }}
+    sensor:
+      - unique_id: byd_knie_spreizung_peak_mv
+        name: "BYD Knie-Spreizung Peak"
+        unit_of_measurement: "mV"
+        state_class: measurement
+        icon: mdi:chart-line
+        state: >
+          {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+          {% set alle = namespace(v=[]) %}
+          {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+          {% set spreizung = (alle.v | max) - (alle.v | min) %}
+          {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+          {% set aktiv = this.attributes.get('episode_aktiv', false) %}
+          {% set alt = this.state | float(none) %}
+          {% set neuer_peak = soc >= 95
+             and (not aktiv or alt is none or spreizung > alt) %}
+          {% if neuer_peak %}{{ spreizung | round(0) }}
+          {% else %}{{ alt }}{% endif %}
+        attributes:
+          # Der Aktiv-Merker implementiert die 95/93-%-Hysterese. Im Zwischen-
+          # band wird exakt der restaurierte Zustand weitergetragen.
+          episode_aktiv: >
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% if soc < 93 %}{{ false }}
+            {% elif soc >= 95 %}{{ true }}
+            {% else %}{{ this.attributes.get('episode_aktiv', false) }}{% endif %}
+
+          episode_gestartet: >
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set aktiv = this.attributes.get('episode_aktiv', false) %}
+            {% if soc >= 95 and not aktiv %}{{ now().isoformat() }}
+            {% else %}{{ this.attributes.get('episode_gestartet') }}{% endif %}
+
+          # Zeitpunkt und Zellkontext werden NUR zusammen mit einem neuen Peak
+          # ersetzt. Relaxation kann daher weder Wert noch Provenienz verwischen.
+          peak_gemessen: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set alle = namespace(v=[]) %}
+            {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+            {% set spreizung = (alle.v | max) - (alle.v | min) %}
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set aktiv = this.attributes.get('episode_aktiv', false) %}
+            {% if soc >= 95 and (not aktiv or spreizung > (this.state | float(-1))) %}
+              {{ now().isoformat() }}
+            {% else %}{{ this.attributes.get('peak_gemessen') }}{% endif %}
+
+          ausreisser_modul: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set alle = namespace(v=[]) %}
+            {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+            {% set med = alle.v | median %}
+            {% set spreizung = (alle.v | max) - (alle.v | min) %}
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set aktiv = this.attributes.get('episode_aktiv', false) %}
+            {% if soc >= 95 and (not aktiv or spreizung > (this.state | float(-1))) %}
+              {% set ns = namespace(max_abw=-1, modul=0) %}
+              {% for modul in daten %}
+                {% for wert in modul['v'] %}
+                  {% if (wert - med) | abs > ns.max_abw %}
+                    {% set ns.max_abw = (wert - med) | abs %}
+                    {% set ns.modul = modul['m'] %}
+                  {% endif %}
+                {% endfor %}
+              {% endfor %}
+              {{ ns.modul }}
+            {% else %}{{ this.attributes.get('ausreisser_modul') }}{% endif %}
+
+          # Zellindex 1..32 INNERHALB des Moduls, nicht globale 1..160.
+          ausreisser_zelle: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set alle = namespace(v=[]) %}
+            {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+            {% set med = alle.v | median %}
+            {% set spreizung = (alle.v | max) - (alle.v | min) %}
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set aktiv = this.attributes.get('episode_aktiv', false) %}
+            {% if soc >= 95 and (not aktiv or spreizung > (this.state | float(-1))) %}
+              {% set ns = namespace(max_abw=-1, zelle=0) %}
+              {% for modul in daten %}
+                {% for wert in modul['v'] %}
+                  {% if (wert - med) | abs > ns.max_abw %}
+                    {% set ns.max_abw = (wert - med) | abs %}
+                    {% set ns.zelle = loop.index %}
+                  {% endif %}
+                {% endfor %}
+              {% endfor %}
+              {{ ns.zelle }}
+            {% else %}{{ this.attributes.get('ausreisser_zelle') }}{% endif %}
+
+          ausreisser_zellspannung_mv: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set alle = namespace(v=[]) %}
+            {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+            {% set med = alle.v | median %}
+            {% set spreizung = (alle.v | max) - (alle.v | min) %}
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set aktiv = this.attributes.get('episode_aktiv', false) %}
+            {% if soc >= 95 and (not aktiv or spreizung > (this.state | float(-1))) %}
+              {% set ns = namespace(max_abw=-1, wert=0) %}
+              {% for wert in alle.v %}
+                {% if (wert - med) | abs > ns.max_abw %}
+                  {% set ns.max_abw = (wert - med) | abs %}
+                  {% set ns.wert = wert %}
+                {% endif %}
+              {% endfor %}
+              {{ ns.wert }}
+            {% else %}{{ this.attributes.get('ausreisser_zellspannung_mv') }}{% endif %}
+
+          median_mv: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set alle = namespace(v=[]) %}
+            {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+            {% set spreizung = (alle.v | max) - (alle.v | min) %}
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set aktiv = this.attributes.get('episode_aktiv', false) %}
+            {% if soc >= 95 and (not aktiv or spreizung > (this.state | float(-1))) %}
+              {{ (alle.v | median) | round(1) }}
+            {% else %}{{ this.attributes.get('median_mv') }}{% endif %}
+
+          # Vorzeichenbehaftet: positiv = Zelle oberhalb des Medians, negativ =
+          # darunter. Damit bleibt sichtbar, welches Kennlinienende den Peak
+          # treibt, statt nur den Betrag zu speichern.
+          delta_zum_median_mv: >
+            {% set daten = state_attr('sensor.bms_1_cells_average_voltage', 'cell_voltages') %}
+            {% set alle = namespace(v=[]) %}
+            {% for modul in daten %}{% set alle.v = alle.v + (modul['v'] | list) %}{% endfor %}
+            {% set med = alle.v | median %}
+            {% set spreizung = (alle.v | max) - (alle.v | min) %}
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set aktiv = this.attributes.get('episode_aktiv', false) %}
+            {% if soc >= 95 and (not aktiv or spreizung > (this.state | float(-1))) %}
+              {% set ns = namespace(max_abw=-1, delta=0) %}
+              {% for wert in alle.v %}
+                {% if (wert - med) | abs > ns.max_abw %}
+                  {% set ns.max_abw = (wert - med) | abs %}
+                  {% set ns.delta = wert - med %}
+                {% endif %}
+              {% endfor %}
+              {{ ns.delta | round(1) }}
+            {% else %}{{ this.attributes.get('delta_zum_median_mv') }}{% endif %}
+
+          # -----------------------------------------------------------------
+          # Archiv der zuletzt ABGESCHLOSSENEN Episode. Beim ersten Snapshot
+          # unter 93 % wird der vorherige this-Peak atomar kopiert. Danach
+          # bleiben diese Felder bis zum Abschluss der naechsten Episode stehen.
+          # -----------------------------------------------------------------
+          letzte_vollladung_peak_mv: >
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set schliesst = soc < 93 and this.attributes.get('episode_aktiv', false) %}
+            {% if schliesst %}{{ this.state }}
+            {% else %}{{ this.attributes.get('letzte_vollladung_peak_mv') }}{% endif %}
+
+          letzte_vollladung_ausreisser_modul: >
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set schliesst = soc < 93 and this.attributes.get('episode_aktiv', false) %}
+            {% if schliesst %}{{ this.attributes.get('ausreisser_modul') }}
+            {% else %}{{ this.attributes.get('letzte_vollladung_ausreisser_modul') }}{% endif %}
+
+          letzte_vollladung_ausreisser_zelle: >
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set schliesst = soc < 93 and this.attributes.get('episode_aktiv', false) %}
+            {% if schliesst %}{{ this.attributes.get('ausreisser_zelle') }}
+            {% else %}{{ this.attributes.get('letzte_vollladung_ausreisser_zelle') }}{% endif %}
+
+          letzte_vollladung_delta_zum_median_mv: >
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set schliesst = soc < 93 and this.attributes.get('episode_aktiv', false) %}
+            {% if schliesst %}{{ this.attributes.get('delta_zum_median_mv') }}
+            {% else %}{{ this.attributes.get('letzte_vollladung_delta_zum_median_mv') }}{% endif %}
+
+          letzte_vollladung_peak_gemessen: >
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set schliesst = soc < 93 and this.attributes.get('episode_aktiv', false) %}
+            {% if schliesst %}{{ this.attributes.get('peak_gemessen') }}
+            {% else %}{{ this.attributes.get('letzte_vollladung_peak_gemessen') }}{% endif %}
+
+          letzte_vollladung_beendet: >
+            {% set soc = states('sensor.battery_management_unit_state_of_charge') | float(-1) %}
+            {% set schliesst = soc < 93 and this.attributes.get('episode_aktiv', false) %}
+            {% if schliesst %}{{ now().isoformat() }}
+            {% else %}{{ this.attributes.get('letzte_vollladung_beendet') }}{% endif %}

--- a/tests/test_byd_knie_spreizung.py
+++ b/tests/test_byd_knie_spreizung.py
@@ -1,0 +1,241 @@
+"""Tests fuer packages/byd_knie_spreizung.yaml.
+
+Die Harness rendert die echten Jinja-Templates gegen synthetische HA-States.
+Aufeinanderfolgende Trigger werden simuliert, indem state/attributes aus
+Zyklus n als ``this``-Snapshot in Zyklus n+1 eingehen. Damit sind Latch und
+Restore-Verhalten pruefbar; die eigentliche HA-State-Trigger-Ausfuehrung wird
+wie in den Nachbartests ueber Struktur-Asserts abgesichert.
+"""
+import datetime as dt
+import re
+
+import jinja2
+
+from .ha_harness import REPO, TZ, FakeHass, find_template_entity, load_yaml, render, render_native
+
+PACKAGE = REPO / "packages" / "byd_knie_spreizung.yaml"
+AVG = "sensor.bms_1_cells_average_voltage"
+SOC = "sensor.battery_management_unit_state_of_charge"
+BMU_UPDATED = "sensor.battery_management_unit_updated"
+NOW = dt.datetime(2026, 7, 18, 14, 0, 0, tzinfo=TZ)
+
+
+def _config():
+    return load_yaml(PACKAGE)
+
+
+def _entity():
+    return find_template_entity(_config(), "sensor", "byd_knie_spreizung_peak_mv")
+
+
+def _slug(name):
+    return re.sub(r"_+", "_", re.sub(r"[^a-z0-9]+", "_", name.lower())).strip("_")
+
+
+def _cell_voltages(overrides=None, basis=3494):
+    """Fuenf Module mit je 32 Zellen; overrides: (Modul, Zelle) -> mV."""
+    overrides = overrides or {}
+    return [
+        {
+            "m": modul,
+            "v": [overrides.get((modul, zelle), basis) for zelle in range(1, 33)],
+        }
+        for modul in range(1, 6)
+    ]
+
+
+def _sample(spread_mv=40):
+    halb = spread_mv // 2
+    return _cell_voltages({(1, 1): 3494 - halb, (1, 2): 3494 + spread_mv - halb})
+
+
+def _live_peak_sample():
+    # Live-Bild 18.7. nachgestellt: min 3373, max 3630 -> 257 mV.
+    # Median 3494; M5/Z28 liegt +136 mV darueber und ist der groesste
+    # absolute Median-Ausreisser (Gegenseite: -121 mV).
+    return _cell_voltages({(2, 17): 3373, (5, 28): 3630})
+
+
+def _hass(daten, soc, *, prev_state="unknown", prev_attrs=None, now=NOW,
+          updated_age_s=30):
+    updated = (now - dt.timedelta(seconds=updated_age_s)).replace(tzinfo=None).isoformat(sep=" ")
+    return FakeHass(
+        states={AVG: "3.494", SOC: str(soc), BMU_UPDATED: updated},
+        attrs={AVG: {"cell_voltages": daten}},
+        this_state=prev_state,
+        this_attributes=prev_attrs,
+        now=now,
+    )
+
+
+def _step(daten, soc, *, prev_state="unknown", prev_attrs=None, now=NOW):
+    entity = _entity()
+    hass = _hass(daten, soc, prev_state=prev_state, prev_attrs=prev_attrs, now=now)
+    # Echtes HA wertet Zustand und Attribute gegen denselben alten this-Snapshot
+    # aus. Deshalb erst alles rendern, danach als neuen Snapshot zusammenbauen.
+    state = render_native(hass, entity["state"])
+    attrs = {name: render_native(hass, template) for name, template in entity["attributes"].items()}
+    return state, attrs
+
+
+def _walk_templates(node, path=""):
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield from _walk_templates(value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from _walk_templates(value, f"{path}[{index}]")
+    elif isinstance(node, str) and ("{{" in node or "{%" in node):
+        yield path, node
+
+
+def _trigger_block():
+    for block in _config()["template"]:
+        if any(e.get("unique_id") == "byd_knie_spreizung_peak_mv" for e in block.get("sensor", [])):
+            return block
+    raise AssertionError("Trigger-Block der Knie-Spreizung fehlt")
+
+
+def test_package_existiert_und_jinja_parst():
+    assert PACKAGE.exists()
+    env = jinja2.Environment()
+    fehler = []
+    for path, template in _walk_templates(_config()):
+        try:
+            env.parse(template)
+        except jinja2.TemplateSyntaxError:
+            fehler.append(path)
+    assert fehler == []
+
+
+def test_name_erzeugt_stabile_entity_id_und_keine_helfer():
+    assert _slug(_entity()["name"]) == "byd_knie_spreizung_peak"
+    assert set(_config()) == {"template"}
+
+
+def test_trigger_kommt_direkt_vom_cell_voltages_attributtraeger():
+    block = _trigger_block()
+    assert block["triggers"] == [{"trigger": "state", "entity_id": AVG}]
+
+
+def test_sample_condition_verlangt_160_zellen_plausiblen_soc_und_frische_bmu():
+    template = _trigger_block()["conditions"][0]["value_template"]
+    assert render(_hass(_sample(), 95), template) == "True"
+
+    nur_159 = _sample()
+    nur_159[-1]["v"].pop()
+    assert render(_hass(nur_159, 95), template) == "False"
+    nichtnumerisch = _sample()
+    nichtnumerisch[2]["v"][7] = "kaputt"
+    assert render(_hass(nichtnumerisch, 95), template) == "False"
+    assert render(_hass(_sample(), "kaputt"), template) == "False"
+    assert render(_hass(_sample(), 101), template) == "False"
+    assert render(_hass(_sample(), 95, updated_age_s=89), template) == "True"
+    assert render(_hass(_sample(), 95, updated_age_s=90), template) == "False"
+
+
+def test_kaltstart_unter_95_liefert_none_statt_nichtnumerischem_state():
+    # Ein measurement-Sensor mit Einheit darf vor der ersten Vollladung nicht
+    # den restaurierten HA-String "unknown" als Zustand ausgeben.
+    state, attrs = _step(_sample(20), 80)
+    assert state is None
+    assert attrs["episode_aktiv"] is False
+
+
+def test_latch_steigt_beim_neuen_maximum_und_snapshottet_ausreisser():
+    state, attrs = _step(_sample(40), 95)
+    assert float(state) == 40
+    start = attrs["episode_gestartet"]
+
+    peak_time = NOW + dt.timedelta(minutes=11)
+    state, attrs = _step(
+        _live_peak_sample(), 99, prev_state=state, prev_attrs=attrs, now=peak_time
+    )
+    assert float(state) == 257
+    assert attrs["episode_aktiv"] is True
+    assert attrs["episode_gestartet"] == start
+    assert attrs["ausreisser_modul"] == 5
+    assert attrs["ausreisser_zelle"] == 28
+    assert float(attrs["ausreisser_zellspannung_mv"]) == 3630
+    assert float(attrs["median_mv"]) == 3494
+    assert float(attrs["delta_zum_median_mv"]) == 136
+    assert attrs["peak_gemessen"].startswith("2026-07-18T14:11:00")
+
+
+def test_latch_faellt_bei_relaxation_nicht_und_haelt_peak_kontext():
+    state, attrs = _step(_live_peak_sample(), 99)
+    peak_attrs = dict(attrs)
+
+    state, attrs = _step(
+        _sample(20), 100, prev_state=state, prev_attrs=attrs,
+        now=NOW + dt.timedelta(minutes=11),
+    )
+    assert float(state) == 257
+    for name in (
+        "peak_gemessen", "ausreisser_modul", "ausreisser_zelle",
+        "ausreisser_zellspannung_mv", "median_mv", "delta_zum_median_mv",
+    ):
+        assert attrs[name] == peak_attrs[name]
+
+
+def test_latch_ueberlebt_restaurierten_this_snapshot():
+    state, attrs = _step(_live_peak_sample(), 99)
+
+    # Ein neu erzeugter FakeHass bekommt nur den von HA restaurierten
+    # Sensorzustand/-attribute-Snapshot. Ein kleineres Folgesample bleibt inert.
+    restored_state, restored_attrs = _step(
+        _sample(30), 99, prev_state=str(state), prev_attrs=dict(attrs),
+        now=NOW + dt.timedelta(minutes=11),
+    )
+    assert float(restored_state) == 257
+    assert restored_attrs["peak_gemessen"] == attrs["peak_gemessen"]
+    assert restored_attrs["episode_aktiv"] is True
+
+
+def test_hysterese_archiviert_einmal_und_naechste_episode_reset():
+    state, attrs = _step(_sample(40), 95)
+    erster_start = attrs["episode_gestartet"]
+
+    # 94 % beendet die Episode nicht. Beim Wiederanstieg ist es dieselbe
+    # Episode; ein hoeherer Peak darf normal uebernommen werden.
+    state, attrs = _step(_sample(20), 94, prev_state=state, prev_attrs=attrs,
+                         now=NOW + dt.timedelta(minutes=11))
+    assert attrs["episode_aktiv"] is True
+    state, attrs = _step(_sample(50), 95, prev_state=state, prev_attrs=attrs,
+                         now=NOW + dt.timedelta(minutes=22))
+    assert float(state) == 50
+    assert attrs["episode_gestartet"] == erster_start
+    peak_kontext = {
+        "ausreisser_modul": attrs["ausreisser_modul"],
+        "ausreisser_zelle": attrs["ausreisser_zelle"],
+        "delta_zum_median_mv": attrs["delta_zum_median_mv"],
+        "peak_gemessen": attrs["peak_gemessen"],
+    }
+
+    # Erst < 93 % schliesst und archiviert. Ein weiteres tiefes Sample darf
+    # Abschlusszeit und Archiv nicht erneut schreiben.
+    close_time = NOW + dt.timedelta(minutes=33)
+    state, attrs = _step(_sample(10), 92.9, prev_state=state, prev_attrs=attrs,
+                         now=close_time)
+    assert float(state) == 50
+    assert attrs["episode_aktiv"] is False
+    assert float(attrs["letzte_vollladung_peak_mv"]) == 50
+    assert attrs["letzte_vollladung_ausreisser_modul"] == peak_kontext["ausreisser_modul"]
+    assert attrs["letzte_vollladung_ausreisser_zelle"] == peak_kontext["ausreisser_zelle"]
+    assert attrs["letzte_vollladung_delta_zum_median_mv"] == peak_kontext["delta_zum_median_mv"]
+    assert attrs["letzte_vollladung_peak_gemessen"] == peak_kontext["peak_gemessen"]
+    assert attrs["letzte_vollladung_beendet"].startswith("2026-07-18T14:33:00")
+    archiv = {k: v for k, v in attrs.items() if k.startswith("letzte_vollladung_")}
+
+    state, attrs = _step(_sample(5), 90, prev_state=state, prev_attrs=attrs,
+                         now=NOW + dt.timedelta(minutes=44))
+    assert {k: v for k, v in attrs.items() if k.startswith("letzte_vollladung_")} == archiv
+
+    # Das erste Sample >=95 startet neu und darf niedriger als der alte Peak
+    # sein. Das Archiv der abgeschlossenen Episode bleibt vergleichbar stehen.
+    state, attrs = _step(_sample(30), 95, prev_state=state, prev_attrs=attrs,
+                         now=NOW + dt.timedelta(days=1))
+    assert float(state) == 30
+    assert attrs["episode_aktiv"] is True
+    assert attrs["episode_gestartet"] != erster_start
+    assert {k: v for k, v in attrs.items() if k.startswith("letzte_vollladung_")} == archiv


### PR DESCRIPTION
## Motivation (18.7. live belegt)
Die Ruhe-Zellspreizung ist im flachen LFP-Bereich fuer Ladungs-Ungleichgewicht praktisch blind (heute 3 mV in Ruhe). Das aussagekraeftige Signal zeigt sich nur am Ladeschluss im Spannungsknie: heute 257 mV Peak-Spreizung; Treiber Modul 5, Zelle 28 (+136 mV ueber Median). Bisher wird das nirgends persistiert - kein Trend ueber Vollladungen vergleichbar.

## Umsetzung
Neues Package packages/byd_knie_spreizung.yaml: trigger-basierter Template-Sensor 'BYD Knie-Spreizung Peak' als Latch je Vollladungs-Episode (Hysterese: Start SoC >= 95, Ende < 93), Attribute: Ausreisser-Modul/-Zelle/-Spannung, Delta zum Median (vorzeichenbehaftet), Zeitstempel, plus Archiv der letzten abgeschlossenen Episode (letzte_vollladung_*). Quelle: sensor.bms_1_cells_average_voltage Attribut cell_voltages (Format live verifiziert, 5 Module x 32 Zellen in mV); Gate auf Datenvaliditaet + Frische. Restart-durabel via restauriertem this-State, KEIN initial:.

## Tests
Neue tests/test_byd_knie_spreizung.py (Latch steigt/haelt, Episode-Hysterese, Archiv-Kopie beim Abschluss, Validitaets-Gate). Suite gruen.