### PR TITLE
chore: CI, Test-Abhaengigkeiten und Entwickler-Einstieg

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      # fetch-depth: 0 ist Pflicht - der Privacy-Scan in
+      # tests/test_opti_mapping.py prueft die Commit-Historie auf echte
+      # WR-Seriennummern und bricht bei flachem Checkout bewusst ab.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Abhaengigkeiten installieren
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Testsuite
+        run: python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ha-opti-akkusteuerung
 
+[![Tests](https://github.com/Optic00/ha-opti-akkusteuerung/actions/workflows/tests.yml/badge.svg)](https://github.com/Optic00/ha-opti-akkusteuerung/actions/workflows/tests.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 Prognosebasierte Akku-Ladesteuerung für Home Assistant - die Strategie ist hardware-agnostisch (Canonical-`opti_*`-Layer), als Referenz-Adapter dient der **SMA STP SE Hybrid-Wechselrichter** (direkt über Modbus, ohne Grid Guard Code).
 
 > ⚠️ **Disclaimer:** Dieses Projekt wird nicht von SMA begleitet oder supportet. Nutzung auf eigene Gefahr. Kein persönlicher Support, aber die Community hilft gerne über [Issues](https://github.com/Optic00/ha-opti-akkusteuerung/issues).
@@ -120,6 +123,46 @@ Der frühere manuelle Weg mit Flachdateien liegt zur Referenz unter [`old/README
 
 Die Strategie-Automation entscheidet den **Modus** via `input_select.akkusteuerung_modus` und berührt keine Hardware direkt; ein nachgelagerter Cleanup pflegt nur Booster und Ladepreis. Eine vollständige, laienverständliche Block-für-Block-Erklärung aller Entscheidungsoptionen, der Preisstufenlogik (`sensor.opti_price_level`), des MinSOC-Schutzes, der Wintermodus-Blöcke und der Bausteine (P10-Sicherheitsnetz, Decision-Trace, Balancing-Watchdog):
 **[docs/strategie-logik.md](docs/strategie-logik.md)**
+
+---
+
+## Entwicklung & Tests
+
+Für die reine Nutzung wird kein Python gebraucht - das Repo liefert HA-YAML aus.
+Wer aber an den Templates oder der Strategie schraubt, sollte die Testsuite laufen lassen:
+Sie rendert die Jinja-Templates aus den aktiven `packages/` und die Bedingungen aus `automations/` gegen einen nachgebauten HA-Zustand und prüft die Ergebnisse; `legacy/` und `old/` sind bewusst nicht abgedeckt, das sind Archive.
+Damit fallen kaputte Templates auf, bevor sie in einer echten Anlage landen.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt
+
+pytest -q                                  # alles
+pytest -q tests/test_strategie_paritaet.py  # einzelne Datei
+```
+
+Getestet gegen Python 3.11 bis 3.14; `requirements-dev.txt` braucht nur `pytest`, `Jinja2` und `PyYAML`.
+Dieselben Tests laufen bei jedem Pull Request und bei jedem Push auf `main` automatisch über [GitHub Actions](.github/workflows/tests.yml).
+
+**Was die Suite abdeckt** (`tests/`, aktuell über 400 Tests):
+
+| Bereich | Beispiele |
+|---|---|
+| Template-Syntax | `test_yaml_jinja_parst.py` prüft jedes Jinja-Template in `packages/*.yaml`, `automations/*.yaml` und der Beispiel-Mapping-Datei mit echtem Jinja2 auf Syntax |
+| Strategie-Entscheidungen | `test_strategie_paritaet.py`, `test_strategie_fail_safe.py`, `test_strategie_vorschau.py` |
+| Abgeleitete Sensoren | `test_derived_sensoren.py`, `test_price_level.py`, `test_target_soc_hysterese.py`, `test_peak_reserve.py` |
+| BYD-Monitoring | `test_byd_monitoring.py`, `test_byd_modul2_fruehwarnung.py`, `test_byd_knie_spreizung.py` |
+| Mapping & Privacy | `test_opti_mapping.py` scannt alle getrackten Dateien **und die Commit-Historie** auf echte WR-Seriennummern |
+
+12 Tests überspringen sich selbst, solange `packages/opti_mapping.yaml` fehlt - sie prüfen ein echtes, ausgefülltes Mapping und können deshalb weder in CI noch in einem frischen Clone laufen.
+Das ist erwartet, kein Fehler.
+
+Der HA-Nachbau steckt in `tests/ha_harness.py`.
+Er bildet die Filter und das Rundungsverhalten von Home Assistant nach, ist aber kein vollständiges HA:
+Verhalten, das an echten Integrationen hängt, muss weiterhin an der Anlage verifiziert werden.
+
+Vor dem Merge eines nicht-trivialen Pull Requests gilt zusätzlich die [Cross-Model Review Policy](REVIEW_POLICY.md).
 
 ---
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+# Test-Abhaengigkeiten fuer die Jinja-/YAML-Testsuite (tests/).
+# Laufzeit-Abhaengigkeiten gibt es keine: das Repo liefert HA-YAML aus,
+# Python wird ausschliesslich zum Testen und fuer tools/backtest.py gebraucht.
+#
+# Installation: python3 -m pip install -r requirements-dev.txt
+
+pytest>=8.0
+Jinja2>=3.1
+PyYAML>=6.0

--- a/tests/test_charge_power.py
+++ b/tests/test_charge_power.py
@@ -75,10 +75,12 @@ def _charge_hass_mit_vorschau(states):
 
 
 def _mutant_cfg(old, new):
-    """opti_derived.yaml nach /private/tmp kopieren, Konstante mutieren, laden."""
+    """opti_derived.yaml in eine Temp-Datei kopieren, Konstante mutieren, laden."""
     src = YAML.read_text(encoding="utf-8")
     assert old in src, f"Mutations-Anker {old!r} nicht im Template gefunden"
-    fd, path = tempfile.mkstemp(suffix=".yaml", dir="/private/tmp")
+    # Kein fixes dir=: /private/tmp gibt es nur auf macOS, auf Linux (CI)
+    # schlaegt mkstemp damit fehl. Der Plattform-Default respektiert TMPDIR.
+    fd, path = tempfile.mkstemp(suffix=".yaml")
     os.close(fd)
     p = pathlib.Path(path)
     try:

--- a/tests/test_forecast_effective.py
+++ b/tests/test_forecast_effective.py
@@ -57,10 +57,12 @@ def _states(remaining="10", estimate10=None, alpha=None):
 
 
 def _mutant_cfg(old, new):
-    """opti_derived.yaml nach /private/tmp kopieren, Konstante mutieren, laden."""
+    """opti_derived.yaml in eine Temp-Datei kopieren, Konstante mutieren, laden."""
     src = YAML.read_text(encoding="utf-8")
     assert old in src, f"Mutations-Anker {old!r} nicht im Template gefunden"
-    fd, path = tempfile.mkstemp(suffix=".yaml", dir="/private/tmp")
+    # Kein fixes dir=: /private/tmp gibt es nur auf macOS, auf Linux (CI)
+    # schlaegt mkstemp damit fehl. Der Plattform-Default respektiert TMPDIR.
+    fd, path = tempfile.mkstemp(suffix=".yaml")
     os.close(fd)
     p = pathlib.Path(path)
     try:

--- a/tests/test_target_soc_hysterese.py
+++ b/tests/test_target_soc_hysterese.py
@@ -61,10 +61,12 @@ def _states(remaining, cap="10"):
 
 
 def _mutant_cfg(old, new):
-    """opti_derived.yaml nach /private/tmp kopieren, Konstante mutieren, laden."""
+    """opti_derived.yaml in eine Temp-Datei kopieren, Konstante mutieren, laden."""
     src = YAML.read_text(encoding="utf-8")
     assert old in src, f"Mutations-Anker {old!r} nicht im Template gefunden"
-    fd, path = tempfile.mkstemp(suffix=".yaml", dir="/private/tmp")
+    # Kein fixes dir=: /private/tmp gibt es nur auf macOS, auf Linux (CI)
+    # schlaegt mkstemp damit fehl. Der Plattform-Default respektiert TMPDIR.
+    fd, path = tempfile.mkstemp(suffix=".yaml")
     os.close(fd)
     p = pathlib.Path(path)
     try:


### PR DESCRIPTION
## Summary

Die Testsuite existierte bereits (413 Tests), war für Außenstehende aber nicht benutzbar: keine deklarierten Abhängigkeiten, keine Ausführungsanleitung und keine automatische Ausführung bei Pull Requests. Dieser PR ergänzt nur den Einstieg, er ändert keine Strategie-, Package- oder Automations-Logik.

- `requirements-dev.txt`: `pytest`, `Jinja2`, `PyYAML`. Laufzeit-Abhängigkeiten gibt es keine, das Repo liefert HA-YAML aus.
- `.github/workflows/tests.yml`: erste CI im Repo. pytest bei jedem Pull Request, bei Push auf `main` und manuell. Matrix Python 3.11/3.12/3.13/3.14, `fail-fast: false`, pip-Cache, `permissions: contents: read`, Concurrency-Cancel.
- `README.md`: neuer Abschnitt „Entwicklung & Tests" mit Setup, Abdeckungs-Übersicht, Erklärung der 12 erwarteten Skips und der Einordnung, dass `tests/ha_harness.py` kein vollständiges HA ist. Dazu Tests- und Lizenz-Badge.

`fetch-depth: 0` ist dabei nicht optional: der Privacy-Scan in `tests/test_opti_mapping.py` prüft die Commit-Historie auf echte WR-Seriennummern und bricht bei flachem Checkout bewusst mit `RuntimeError` ab. Ein Standard-Checkout hätte den ersten CI-Lauf rot gemacht. Der Grund steht als Kommentar im Workflow.

Dazu kommt ein Folge-Commit (`4f3aca1`), den erst die CI erzwungen hat: drei Test-Helfer legten ihre Mutations-Kopie von `opti_derived.yaml` per `tempfile.mkstemp(dir="/private/tmp")` ab. Diesen Pfad gibt es nur auf macOS, unter Linux scheiterten dadurch 5 Tests mit `FileNotFoundError`. Der Bug ist älter als dieser PR, lokal auf macOS war die Suite über alle Python-Versionen grün. Genau dafür ist die CI da.

Bewusst nicht angefasst: 12 Tests überspringen sich ohne das gitignorete `packages/opti_mapping.yaml`. Sie stattdessen gegen `opti_mapping.example.yaml` laufen zu lassen schlägt fehl, weil sie auf das reale `sensor.sn_<seriennummer>_...`-Muster prüfen. Der Vertrag der Beispiel-Mapping-Datei ist damit in CI nicht abgedeckt, obwohl genau diese Datei jeder Neu-Installierer anfasst. Das zu schließen hieße Tests umschreiben und gehört nicht in diesen PR.

## Verification

- Testsuite lokal grün gegen Python 3.9, 3.10, 3.11, 3.12, 3.13 und 3.14 (413 passed mit privatem Mapping).
- CI-Lauf simuliert: frischer Clone des Branches, volle Matrix 3.11/3.12/3.13/3.14, jeweils `400 passed, 12 skipped`.
- Der im README beschriebene Weg (`python3 -m venv .venv` → `pip install -r requirements-dev.txt` → `pytest -q`) einmal wörtlich aus einem frischen Clone durchgespielt, funktioniert.
- Flacher Checkout (`git clone --depth 1`) reproduziert: `test_pr_historie_und_worktree_enthalten_keine_wr_seriennummern` schlägt fehl. Mit `fetch-depth: 0` grün. Das war der Beleg für die Checkout-Konfiguration.
- Workflow-YAML parst, alle im README verlinkten Pfade existieren.
- **Echter CI-Lauf grün:** Run `30167325831`, alle vier Jobs (Python 3.11/3.12/3.13/3.14) `success`, jeweils `400 passed, 12 skipped`. Der vorherige Lauf `30167237146` war rot und hat den macOS-Pfad-Bug aufgedeckt.
- Der Pfad-Fix zusätzlich lokal mit gesetztem Fremd-`TMPDIR` verifiziert (39 passed), damit keine neue Abhängigkeit vom Default-Temp-Verzeichnis entsteht.
- Privacy: keine echten Entitäts-IDs oder Seriennummern im Diff, `packages/opti_mapping.yaml` bleibt gitignored, `test_opti_mapping.py`-Scan über Worktree und Historie grün.
- Live-Evidenz entfällt: der PR ändert nichts, was in der Anlage läuft.

## Cross-model review

Select exactly one status:

- [x] Required and completed
- [ ] Exempt: editorial-only change with no technical, process, or
      operational meaning
- [ ] Independent reviewer unavailable after a reasonable authentication or
      connectivity attempt

Primary author/implementer model: Claude Opus 5 (`claude-opus-5`)

Reviewer model: GPT-5.6 Sol (`gpt-5.6-sol`, via `codex exec --ephemeral`, read-only)

Review date: 2026-07-25

Commit range: d2d78b0..4f3aca1 (in zwei Durchgängen: d2d78b0..2455b9b, danach 4f3aca1 einzeln)

Verdict: Keine Critical- und keine Important-Findings in beiden Durchgängen. Drei Minor-Findings im ersten Durchgang, alle vor dem Push gefixt. Zweiter Durchgang ohne Findings.

Findings and disposition:

1. Minor, gefixt: README behauptete „bei jedem Push", der Workflow triggert bei Push aber nur auf `main`. Formulierung auf „bei jedem Pull Request und bei jedem Push auf `main`" korrigiert.
2. Minor, gefixt: README nannte „Python 3.11 bis 3.14", die Matrix ließ 3.12 aus. Statt die Doku abzuschwächen wurde 3.12 in die Matrix aufgenommen, damit die Aussage wörtlich stimmt.
3. Minor, gefixt: README überzeichnete die Template-Abdeckung („jedes Jinja-Template in jeder YAML-Datei"). `test_yaml_jinja_parst.py` deckt tatsächlich `packages/*.yaml`, `automations/*.yaml` und `opti_mapping.example.yaml` ab, und zwar als Syntax-Prüfung statt Rendering; `legacy/` und `old/` sind bewusst ausgenommen. Beide betroffenen Stellen präzisiert.

Zweiter Durchgang zu `4f3aca1` (Pfad-Fix), keine Findings. Bestätigt: `load_yaml` löst keine Pfade relativ zur YAML-Position auf, das Aufräumen der Temp-Datei greift auch auf dem Fehlerpfad, keine weiteren plattformspezifischen Annahmen in `tests/` und `tools/` (geprüft mit `TMPDIR=/tmp TZ=UTC LC_ALL=C`), und die fünf Mutations-Tests schlagen bei unterdrückter Mutation weiterhin fehl, sind also nicht zu Leerläufern geworden.

Explizit als korrekt bestätigt wurden im ersten Durchgang: Workflow-Schema und Action-Inputs, das Verhalten des Privacy-Scans beim `pull_request`-Event (detached Merge-Commit, `origin/main` vorhanden), die Versions-Untergrenzen in `requirements-dev.txt`, das Fehlen einer Injection-Fläche über `github`-Kontext-Expressions, und die Zahl von exakt 12 Skips.

Unavailability reason: entfällt, Review wurde durchgeführt.
