### PR TITLE
fix(strategie): Ueberschuss-Veto mit Knappheits-Gate - Export sticht den Ziel-SoC nur bei knappem Rest-Forecast

### DIFF
--- a/automations/opti_ki_analyse.yaml
+++ b/automations/opti_ki_analyse.yaml
@@ -118,14 +118,16 @@
           8. EV-Schnelllade-Sperre (evcc laedt now/minpv) -> nur Laden
           (reine Entladesperre, PV-Laden bleibt moeglich). 9. PV-Ueberschuss
           -> Dynamisch. 10. Akku voll -> Dynamisch. 11. Peak-Leiter L3/L4
-          (halten) -> nur Laden. 12. Unter Ziel-SoC tags -> Dynamisch.
-          13. Ueber Ziel-SoC -> nur Entladen (preisunabhaengig, Ziel-SoC
-          enthaelt die Wirtschaftlichkeit). 14. Default -> Dynamisch, ABER nur bei
-          vorhandenem Preisniveau: fehlt es (Preisquelle ausgefallen) UND greift
-          kein hoeher priorisierter preisunabhaengiger Zweig, bleibt ein passiver
-          Modus (Dynamisch/nur Entladen) stehen, waehrend Netzladen/nur
-          Laden/Pause auf Dynamisch zurueckfallen. Die Zweige 1-13 gelten
-          unveraendert weiter.
+          (halten) -> nur Laden. 12. Ueberschuss-Veto (laufender Netzexport,
+          und der Rest-Forecast fuellt den Akku nicht mehr sicher) ->
+          Dynamisch, sticht den Ziel-SoC-Deckel. 13. Unter Ziel-SoC tags
+          -> Dynamisch. 14. Ueber Ziel-SoC -> nur Entladen (preisunabhaengig,
+          Ziel-SoC enthaelt die Wirtschaftlichkeit). 15. Default -> Dynamisch,
+          ABER nur bei vorhandenem Preisniveau: fehlt es (Preisquelle
+          ausgefallen) UND greift kein hoeher priorisierter preisunabhaengiger
+          Zweig, bleibt ein passiver Modus (Dynamisch/nur Entladen) stehen,
+          waehrend Netzladen/nur Laden/Pause auf Dynamisch zurueckfallen. Die
+          Zweige 1-14 gelten unveraendert weiter.
 
           REGELN: Nutze nur die gelieferten Zahlen, ergaenze keine Fakten.
           unavailable-Minuten sind Datenluecken, kein Anlagenverhalten -

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -774,8 +774,8 @@
                 entity_id: input_select.akkusteuerung_modus
 
         # ---------------------------------------------------------------------
-        # Ueberschuss-Veto (2026-08-15): laufender Netzexport sticht den
-        # Ziel-SoC-Deckel. Belegter Ausloeser 15.08.2026: 48,1 kWh PV, davon
+        # Ueberschuss-Veto (2026-08-15, Knappheits-Gate 2026-08-16): belegter
+        # Ausloeser 15.08.2026 waren 48,1 kWh PV, davon
         # 19,3 kWh ins Netz, SoC-Peak nur 91 % um 15:17. Der Ziel-SoC lief der
         # Realitaet als Treppe hinterher (50 % um 06:00, 95 % erst um 15:07,
         # dazwischen ein Rueckschritt 80 -> 70 % um 12:54) und zwang den Akku in
@@ -783,11 +783,15 @@
         # ~2 h 25 min) ueber Zweig "nur Entladen: SOC ueber Ziel-SoC" auf
         # Ladeleistung 0 - bei gleichzeitig 1,9 bis 5,5 kW Export.
         #
-        # Solange exportiert wird, ist Laden immer richtig: die kWh ist der
-        # Abendpreis minus Einspeiseverguetung wert (15.08.: 38-41 ct gegen
-        # 10 ct). Der Ziel-SoC-Deckel haelt Kapazitaet fuer spaetere PV frei -
-        # ein Ziel, das bei laufendem Export gegenstandslos ist, weil die
-        # Energie ohnehin gerade weggeht.
+        # Laufender Export ist nur dann ein wirtschaftlicher Verlust, wenn der
+        # prognostizierte Rest-Ueberschuss den Akku nicht mehr sicher fuellt.
+        # Reicht die Rest-PV aus, ist Mittagsexport gewollter Aufschub: der Akku
+        # wird spaeter trotzdem voll, und frueheres Laden kostet nur
+        # Hoch-SoC-Stunden. Seit 16.08.2026 unterdrueckt deshalb das
+        # Knappheits-Gate im binary_sensor.opti_ueberschuss_veto_aktiv den Zweig
+        # bei positiv belegtem Tages-Ueberfluss. Der Sensor enthaelt auch das
+        # 20-%-Halteband und die bewusste Fail-Open-Richtung fuer Forecast-Daten;
+        # die Bedingungen dieser Automation bleiben dadurch unveraendert.
         #
         # POSITION (bewusst genau hier, Cross-Review Fable 5 + GPT-5.6 Sol,
         # 15.08.2026): hinter allem, was Vorrang behalten muss - MinSOC-Schutz,

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -93,6 +93,16 @@
         - "on"
         - "off"
       id: "PV-70%-Überschuss geändert"
+    # Wirtschaftliches Überschuss-Veto (2026-08-15). Ebenfalls beide Flanken:
+    # ohne die Off-Flanke bliebe der Modus nach Wegfall des Überschusses bis zum
+    # nächsten zufälligen SoC-Event auf "Dynamisch" stehen.
+    - trigger: state
+      entity_id:
+        - binary_sensor.opti_ueberschuss_veto_aktiv
+      to:
+        - "on"
+        - "off"
+      id: "Überschuss-Veto geändert"
     # Prognose-Scores statt PV-Forecast-Bewertungslabels
     - trigger: state
       entity_id:
@@ -760,6 +770,72 @@
             - action: input_select.select_option
               data:
                 option: "Akku nur Laden"
+              target:
+                entity_id: input_select.akkusteuerung_modus
+
+        # ---------------------------------------------------------------------
+        # Ueberschuss-Veto (2026-08-15): laufender Netzexport sticht den
+        # Ziel-SoC-Deckel. Belegter Ausloeser 15.08.2026: 48,1 kWh PV, davon
+        # 19,3 kWh ins Netz, SoC-Peak nur 91 % um 15:17. Der Ziel-SoC lief der
+        # Realitaet als Treppe hinterher (50 % um 06:00, 95 % erst um 15:07,
+        # dazwischen ein Rueckschritt 80 -> 70 % um 12:54) und zwang den Akku in
+        # drei Fenstern (08:47-09:19, 10:10-11:13, 12:54-13:45, zusammen
+        # ~2 h 25 min) ueber Zweig "nur Entladen: SOC ueber Ziel-SoC" auf
+        # Ladeleistung 0 - bei gleichzeitig 1,9 bis 5,5 kW Export.
+        #
+        # Solange exportiert wird, ist Laden immer richtig: die kWh ist der
+        # Abendpreis minus Einspeiseverguetung wert (15.08.: 38-41 ct gegen
+        # 10 ct). Der Ziel-SoC-Deckel haelt Kapazitaet fuer spaetere PV frei -
+        # ein Ziel, das bei laufendem Export gegenstandslos ist, weil die
+        # Energie ohnehin gerade weggeht.
+        #
+        # POSITION (bewusst genau hier, Cross-Review Fable 5 + GPT-5.6 Sol,
+        # 15.08.2026): hinter allem, was Vorrang behalten muss - MinSOC-Schutz,
+        # beide Netzlade-Zweige, Peak-Leiter L1/L2, Balancing-Watchdog,
+        # maxsoc-Ladedeckel, Winter-/Prognose-Ladebloecke, EV-Sperre und die
+        # Halte-Stufen L3/L4. Er verdeckt ausschliesslich die beiden
+        # Ziel-SoC-Zweige und den Default. Die EV-Sperre steht bewusst davor:
+        # sonst entlaedt der Akku bei evcc-Schnellladung ins Auto.
+        #
+        # Gegen maxsoc doppelt gesichert: eigene Bedingung soc < maxsoc, und der
+        # Ladedeckel-Zweig steht ohnehin frueher (dessen 3-%-Halteband gewinnt
+        # damit im Bereich maxsoc-3..maxsoc). Kein Lade-/Entlade-Zyklus.
+        #
+        # Preisunabhaengig, sticht also auch den Preisniveau-Default-Guard:
+        # faellt die Preisreihe bei laufendem Export aus, wird 'Akku Dynamisch'
+        # gesetzt statt den passiven Modus zu halten. Gewollt - 'Dynamisch'
+        # erzwingt keinen Netzbezug (siehe Guard-Kommentar weiter unten), und
+        # ueberschuessige PV zu speichern braucht keinen Preis.
+        #
+        # Im evcc-PV-Modus (nicht: Schnellladung) konkurrieren Auto und Akku um
+        # denselben Ueberschuss. Die Formel regelt das von selbst richtig: der
+        # Wallbox-Verbrauch senkt den Export, das Auto hat damit Vorrang und der
+        # Akku bekommt nur, was uebrig bleibt.
+        # ---------------------------------------------------------------------
+        - alias: "Modus 'Dynamisch': echter Netz-Ueberschuss sticht Ziel-SoC-Deckel"
+          conditions:
+            - condition: state
+              entity_id: input_boolean.opti_pv_ueberschuss_ladung
+              state: "on"
+            - condition: sun
+              after: sunrise
+              before: sunset
+            # Entprelltes, akkuunabhaengiges Signal (opti_derived.yaml), gleiche
+            # Bauart wie die beiden Abregelungs-Waechter darueber.
+            - condition: state
+              entity_id: binary_sensor.opti_ueberschuss_veto_aktiv
+              state: "on"
+            # Kein Laden ueber den harten Deckel. numeric_state kann nicht gegen
+            # eine Entity-Obergrenze pruefen, daher Template.
+            - condition: template
+              value_template: >-
+                {{ has_value('sensor.opti_soc')
+                   and has_value('input_number.maxsoc')
+                   and (states('sensor.opti_soc') | float) < (states('input_number.maxsoc') | float(95)) }}
+          sequence:
+            - action: input_select.select_option
+              data:
+                option: "Akku Dynamisch"
               target:
                 entity_id: input_select.akkusteuerung_modus
 

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -174,9 +174,62 @@ Stufe gegen die Roh-`ratio` festhält.
 Die Modus-Automation vergleicht den realen SoC mit `sensor.opti_target_soc` — mit einem
 zusätzlichen **Band H = 3 %** als zweiter Schutzschicht gegen Pendeln direkt an der Ziel-Kante:
 
-- **SoC < Ziel − 3** → *Akku Dynamisch* (lädt Richtung Ziel, Option 19)
-- **SoC > Ziel + 3** → *Akku nur Entladen* (genug Reserve, Option 20)
+- **SoC < Ziel − 3** → *Akku Dynamisch* (lädt Richtung Ziel, Option 20)
+- **SoC > Ziel + 3** → *Akku nur Entladen* (genug Reserve, Option 21)
 - **innerhalb ±3 % um das Ziel** → neutrale Zone → Default *Akku Dynamisch* (bei fehlendem Preisniveau bleibt stattdessen ein passiver Modus stehen, s. [Default](#default--akku-dynamisch))
+
+### Das Überschuss-Veto: laufender Export sticht den Deckel (Option 19)
+
+Der Ziel-SoC hält Kapazität für später am Tag frei. Dieses Ziel ist gegenstandslos, sobald
+gerade **ins Netz eingespeist wird** — die Energie geht in diesem Moment ohnehin weg. Bis
+August 2026 fehlte diese Einsicht in der Kette, mit messbarer Folge.
+
+**Belegter Auslöser, 15.08.2026:** 48,1 kWh PV-Erzeugung, davon 19,3 kWh ins Netz, Netzbezug
+0,7 kWh, kein E-Auto-Laden. Der SoC erreichte trotzdem nur 91 % (um 15:17) und fiel danach
+wieder. Der Ziel-SoC lief der Realität als Treppe hinterher — 50 % um 06:00, 95 % erst um
+15:07, dazwischen ein Rückschritt von 80 auf 70 % um 12:54, weil die Restprognose wieder
+stieg. In drei Fenstern (08:47–09:19, 10:10–11:13, 12:54–13:45, zusammen ~2 h 25 min) zwang
+Option 21 den Akku auf Ladeleistung 0 — bei gleichzeitig 1,9 bis 5,5 kW Export.
+
+Ökonomisch ist das eindeutig: solange exportiert wird, ist jede gespeicherte kWh den
+Abendpreis minus Einspeisevergütung wert (am 15.08.: 38–41 ct gegen 10 ct, also ~28 ct/kWh).
+
+**Warum die bestehenden Überschuss-Zweige (14/15) das nicht abgefangen haben:** ihre Grenzen
+sind *Abregelungs*-Schwellen — das 70-%-Einspeiselimit (live 18.000 W) und die WR-AC-Grenze
+(9.500 W). Eine Anlage mit ~8,3 kW Peak erreicht sie nie; beide Signale waren den ganzen Tag
+`off`. Sie schützen vor Abregelung, nicht vor Verschenken.
+
+Option 19 ergänzt daher das **wirtschaftliche** Signal
+`binary_sensor.opti_ueberschuss_veto_aktiv`: gleiche Bauart wie die Abregelungs-Wächter
+(Akku herausgerechnet, Hysterese, beidseitige Entprellung), aber mit einer Schwelle im Bereich
+weniger hundert Watt (`input_number.akkusteuerung_ueberschuss_veto_grenze`, Vorgabe 500 W ein /
+250 W aus) und 60 s statt 30 s Entprellung, weil die Schwelle unterhalb der
+Hausgrundlast-Schwankung liegt.
+
+Die Akku-Herausrechnung (`Export + Batterieleistung`, positiv = laden) ist hier keine Kopie aus
+Bequemlichkeit, sondern notwendig: das Laden senkt den gemessenen Export und würde die eigene
+Freigabe sonst beenden — genau die Selbstschwingung vom 03.07.2026.
+
+**Was das Veto NICHT sticht** (Position bewusst spät in der Kette, cross-model geprüft):
+MinSOC-Schutz, beide Netzlade-Zweige, Peak-Leiter L1/L2, Balancing-Watchdog, den harten
+`maxsoc`-Ladedeckel, die Winter-/Prognose-Ladeblöcke, die EV-Sperre und die Halte-Stufen
+L3/L4. Es verdeckt ausschließlich die Ziel-SoC-Zweige und den Default. Gegen `maxsoc` ist es
+doppelt gesichert: eigene Bedingung `SoC < maxsoc` plus der früher stehende Ladedeckel.
+
+Da es preisunabhängig ist, sticht es auch den Preisniveau-Default-Guard: fällt die Preisreihe
+bei laufendem Export aus, wird *Akku Dynamisch* gesetzt, statt den passiven Modus zu halten.
+Gewollt — *Dynamisch* erzwingt keinen Netzbezug, und überschüssige PV zu speichern braucht
+keinen Preis.
+
+Im evcc-**PV**-Modus (nicht Schnellladung) konkurrieren Auto und Akku um denselben Überschuss.
+Die Formel regelt das von selbst: der Wallbox-Verbrauch senkt den Export, das Auto hat damit
+Vorrang, der Akku bekommt den Rest.
+
+**Bewusst nicht gebaut:** ein Tages-Latch, der den Ziel-SoC monoton steigend hält (gegen den
+Rückschritt um 12:54). Nach dem Veto bleibt sein Nutzen auf den schmalen Streifen „Export
+unter der Schwelle" beschränkt, er entkernt die gewollte Puffer-Funktion der Kennlinie, und
+Template-Attribute überleben weder einen Neustart im `unavailable`-Zustand noch einen Reload
+zuverlässig — er wäre ohnehin nur best effort.
 
 ### Nachbauen über die zwei Repos
 
@@ -730,6 +783,11 @@ Export ist über den Akku rückgekoppelt (Laden drückt ihn unter die Grenze und
 eigene Freigabe sofort wieder beenden - live beobachtetes Minutentakt-Flattern).
 Entprellung 30 s beidseitig plus Hysterese-Band, wie in der bewährten Opti-2.0-Automatik.
 
+**Abgrenzung:** Diese Option und Option 15 sind **Abregelungs**-Wächter — ihre Grenzen liegen
+beim Einspeiselimit bzw. der WR-AC-Grenze und lösen bei kleineren Anlagen im Normalbetrieb nie
+aus. Das *wirtschaftliche* Überschuss-Signal (jeder nennenswerte Export ist ladewürdig) ist
+Option 19.
+
 ---
 
 #### Option 15 — Bei AC-Überschuss laden (nur tagsüber)
@@ -791,11 +849,32 @@ preislich kaum über der aktuellen EXPENSIVE-Stunde, kostet die Entladesperre nu
 **Warum:** Auch bei günstigem Preis wird nicht in die für Peaks reservierte Energie
 entladen, solange der SoC die Gesamt-Reserve noch nicht deutlich übersteigt.
 Trifft keine der vier Leiter-Stufen zu, fällt die Prüfung durch zu den normalen
-Ziel-SoC-Optionen (Option 19/20).
+Ziel-SoC-Optionen (Option 20/21) — davor greift jedoch das Überschuss-Veto (Option 19).
 
 ---
 
-#### Option 19 — Dynamisch laden wenn SoC zwischen MinSOC und Ziel-SoC (nur tagsüber)
+#### Option 19 — Echter Netz-Überschuss sticht den Ziel-SoC-Deckel (nur tagsüber)
+
+| Eigenschaft | Wert |
+|---|---|
+| Bedingung | `input_boolean.opti_pv_ueberschuss_ladung` = on, `binary_sensor.opti_ueberschuss_veto_aktiv` = on, SoC < `maxsoc`, tagsüber |
+| Preis | irrelevant |
+| Tageszeit | nach Sonnenaufgang bis Sonnenuntergang |
+| Gesetzter Modus | **Akku Dynamisch** |
+
+**Warum:** Solange ins Netz eingespeist wird, ist der Zweck des Ziel-SoC-Deckels — Kapazität
+für später freihalten — gegenstandslos: die Energie geht ohnehin gerade weg. Jede stattdessen
+gespeicherte kWh ist Abendpreis minus Einspeisevergütung wert. Ausführliche Herleitung samt
+Live-Beleg vom 15.08.2026 im Abschnitt
+**[Das Überschuss-Veto](#das-überschuss-veto-laufender-export-sticht-den-deckel-option-19)**.
+
+Der Zweig steht bewusst hinter allen Zweigen, die aus einem anderen Grund laden, halten oder
+bewusst entladen (MinSOC, Netzladen, L1–L4, Balancing, `maxsoc`-Deckel, Prognose-Ladeblöcke,
+EV-Sperre) und verdeckt ausschließlich die Ziel-SoC-Optionen und den Default.
+
+---
+
+#### Option 20 — Dynamisch laden wenn SoC zwischen MinSOC und Ziel-SoC (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -812,7 +891,7 @@ erklärt. Das **−3 %-Band** (H) verhindert Modus-Pendeln direkt an der Ziel-Ka
 
 ---
 
-#### Option 20 — Nur Entladen wenn SoC über Ziel-SoC
+#### Option 21 — Nur Entladen wenn SoC über Ziel-SoC
 
 | Eigenschaft | Wert |
 |---|---|
@@ -825,6 +904,10 @@ erklärt. Das **−3 %-Band** (H) verhindert Modus-Pendeln direkt an der Ziel-Ka
 für die Nacht. Weiteres Laden aus dem Netz wäre Verschwendung — stattdessen wird der
 Überschuss verbraucht bzw. eingespeist. Das **+3 %-Band** (H) sorgt zusammen mit der
 Ziel-SoC-Hysterese dafür, dass der Modus an der Grenze nicht flattert.
+
+**Grenze der Option:** „stattdessen eingespeist" ist nur solange richtig, wie es nichts zu
+speichern gibt. Läuft echter Netzexport, greift bereits Option 19 davor und lädt — sonst
+verschenkte dieser Zweig genau die Energie, für die der Akku da ist (Live-Beleg 15.08.2026).
 
 ---
 

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -178,58 +178,67 @@ zusätzlichen **Band H = 3 %** als zweiter Schutzschicht gegen Pendeln direkt an
 - **SoC > Ziel + 3** → *Akku nur Entladen* (genug Reserve, Option 21)
 - **innerhalb ±3 % um das Ziel** → neutrale Zone → Default *Akku Dynamisch* (bei fehlendem Preisniveau bleibt stattdessen ein passiver Modus stehen, s. [Default](#default--akku-dynamisch))
 
-### Das Überschuss-Veto: laufender Export sticht den Deckel (Option 19)
+### Das Überschuss-Veto: Knappheit entscheidet über den Ziel-SoC-Deckel (Option 19)
 
-Der Ziel-SoC hält Kapazität für später am Tag frei. Dieses Ziel ist gegenstandslos, sobald
-gerade **ins Netz eingespeist wird** — die Energie geht in diesem Moment ohnehin weg. Bis
-August 2026 fehlte diese Einsicht in der Kette, mit messbarer Folge.
+Der Ziel-SoC hält Kapazität für spätere PV frei und vermeidet unnötige Hoch-SoC-Stunden.
+Aktueller Netzexport ist deshalb nur dann ein wirtschaftlicher Verlust, wenn der prognostizierte Rest-Überschuss des Tages den Akku nicht mehr sicher füllt.
+Reicht die Rest-PV sicher aus, ist Mittagsexport gewollter Aufschub: Der Akku wird später trotzdem voll, der Tagesgesamtexport bleibt gleich und die Ziel-SoC-Rampe erfüllt ihren Zweck.
 
-**Belegter Auslöser, 15.08.2026:** 48,1 kWh PV-Erzeugung, davon 19,3 kWh ins Netz, Netzbezug
-0,7 kWh, kein E-Auto-Laden. Der SoC erreichte trotzdem nur 91 % (um 15:17) und fiel danach
-wieder. Der Ziel-SoC lief der Realität als Treppe hinterher — 50 % um 06:00, 95 % erst um
-15:07, dazwischen ein Rückschritt von 80 auf 70 % um 12:54, weil die Restprognose wieder
-stieg. In drei Fenstern (08:47–09:19, 10:10–11:13, 12:54–13:45, zusammen ~2 h 25 min) zwang
-Option 21 den Akku auf Ladeleistung 0 — bei gleichzeitig 1,9 bis 5,5 kW Export.
+**Belegter Knappheitsfall, 15.08.2026:** An diesem Tag wurden 48,1 kWh PV erzeugt und 19,3 kWh ins Netz eingespeist, bei 0,7 kWh Netzbezug und ohne E-Auto-Laden.
+Der SoC erreichte trotzdem nur 91 % um 15:17 und fiel danach wieder.
+Der Ziel-SoC lief der Realität als Treppe hinterher: 50 % um 06:00, 95 % erst um 15:07 und dazwischen ein Rückschritt von 80 auf 70 % um 12:54, weil die Restprognose wieder stieg.
+In drei Fenstern von 08:47-09:19, 10:10-11:13 und 12:54-13:45, zusammen rund 2 h 25 min, zwang Option 21 den Akku bei gleichzeitig 1,9 bis 5,5 kW Export auf Ladeleistung 0.
+Unter dieser Knappheit war jede noch gespeicherte kWh den Abendpreis minus Einspeisevergütung wert, am 15.08. also 38-41 ct gegen 10 ct und damit rund 28 ct/kWh.
 
-Ökonomisch ist das eindeutig: solange exportiert wird, ist jede gespeicherte kWh den
-Abendpreis minus Einspeisevergütung wert (am 15.08.: 38–41 ct gegen 10 ct, also ~28 ct/kWh).
+**Gegenbeispiel Reichtag, 16.08.2026:** Der prognostizierte Rest-Überschuss `pv_surplus_kwh` lag bei 51,5 kWh, während `needed_full_kwh` nur 4,5 kWh bis 100 % SoC auswies.
+Frühes Laden trotz Mittagsexport hätte den Akku nicht voller gemacht, sondern nur die Dauer bei hohem SoC verlängert.
 
-**Warum die bestehenden Überschuss-Zweige (14/15) das nicht abgefangen haben:** ihre Grenzen
-sind *Abregelungs*-Schwellen — das 70-%-Einspeiselimit (live 18.000 W) und die WR-AC-Grenze
-(9.500 W). Eine Anlage mit ~8,3 kW Peak erreicht sie nie; beide Signale waren den ganzen Tag
-`off`. Sie schützen vor Abregelung, nicht vor Verschenken.
+**Warum die bestehenden Überschuss-Zweige 14 und 15 das nicht abfangen:** Ihre Grenzen sind Abregelungs-Schwellen, nämlich das 70-%-Einspeiselimit mit live 18.000 W und die WR-AC-Grenze mit 9.500 W.
+Eine Anlage mit rund 8,3 kW Peak erreicht sie nie, und beide Signale waren am 15.08. den ganzen Tag `off`.
+Sie schützen vor Abregelung, nicht vor dem wirtschaftlichen Knappheitsfall.
 
-Option 19 ergänzt daher das **wirtschaftliche** Signal
-`binary_sensor.opti_ueberschuss_veto_aktiv`: gleiche Bauart wie die Abregelungs-Wächter
-(Akku herausgerechnet, Hysterese, beidseitige Entprellung), aber mit einer Schwelle im Bereich
-weniger hundert Watt (`input_number.akkusteuerung_ueberschuss_veto_grenze`, Vorgabe 500 W ein /
-250 W aus) und 60 s statt 30 s Entprellung, weil die Schwelle unterhalb der
-Hausgrundlast-Schwankung liegt.
+Option 19 nutzt dafür `binary_sensor.opti_ueberschuss_veto_aktiv`.
+Sein Leistungssignal rechnet den Akku und Netzbezug als `Export - Import + Batterieleistung` heraus, wobei positive Batterieleistung Laden bedeutet.
+Diese Rückrechnung ist notwendig, weil das Laden den gemessenen Export senkt und die eigene Freigabe sonst beendet, wie bei der Selbstschwingung vom 03.07.2026.
+Der Sensor schaltet oberhalb von `input_number.akkusteuerung_ueberschuss_veto_grenze` ein, hält bis `input_number.akkusteuerung_ueberschuss_veto_aus_grenze` und entprellt beide Flanken 60 s lang.
+Empfohlene Leistungswerte sind 500 W zum Einschalten und 250 W zum Ausschalten.
 
-Die Akku-Herausrechnung (`Export + Batterieleistung`, positiv = laden) ist hier keine Kopie aus
-Bequemlichkeit, sondern notwendig: das Laden senkt den gemessenen Export und würde die eigene
-Freigabe sonst beenden — genau die Selbstschwingung vom 03.07.2026.
+Seit 16.08.2026 ergänzt ein Knappheits-Gate dieses reale Leistungssignal.
+Beim Einschalten gilt die strikte Bedingung `pv_surplus_kwh < needed_full_kwh * knappheit_faktor`.
+Der Faktor kommt aus `input_number.akkusteuerung_ueberschuss_veto_knappheit_faktor`, hat den Bereich 1 bis 10 in Schritten von 0,5 und verwendet keinen `initial`-Wert.
+Ein Erststart fällt deshalb auf das Minimum 1 und lässt das Veto nur bei echter Unterdeckung zu, was die konservativste Einstellung in Richtung Ziel-SoC-Rampe ist.
+Der empfohlene Betriebswert ist 3 als Pessimismus-Puffer gegen Forecast-Optimismus, gestützt durch den Knappheitsfall vom 15.08.
 
-**Was das Veto NICHT sticht** (Position bewusst spät in der Kette, cross-model geprüft):
-MinSOC-Schutz, beide Netzlade-Zweige, Peak-Leiter L1/L2, Balancing-Watchdog, den harten
-`maxsoc`-Ladedeckel, die Winter-/Prognose-Ladeblöcke, die EV-Sperre und die Halte-Stufen
-L3/L4. Es verdeckt ausschließlich die Ziel-SoC-Zweige und den Default. Gegen `maxsoc` ist es
-doppelt gesichert: eigene Bedingung `SoC < maxsoc` plus der früher stehende Ladedeckel.
+War das Veto bereits an, bleibt das Gate offen, solange `pv_surplus_kwh < needed_full_kwh * knappheit_faktor * 1.2` gilt.
+Es schließt erst ab der oberen Grenze von 120 %.
+Das feste 20-%-Halteband verhindert eine Selbstabschaltung im Minuten- bis Viertelstundentakt, weil Laden den SoC hebt und dadurch `needed_full_kwh` senkt.
+Der Sensorzustand selbst liefert das notwendige Gedächtnis über das vorhandene `war_an`-Muster.
 
-Da es preisunabhängig ist, sticht es auch den Preisniveau-Default-Guard: fällt die Preisreihe
-bei laufendem Export aus, wird *Akku Dynamisch* gesetzt, statt den passiven Modus zu halten.
-Gewollt — *Dynamisch* erzwingt keinen Netzbezug, und überschüssige PV zu speichern braucht
-keinen Preis.
+Die Fail-Richtung des Forecast-Gates ist bewusst offen und damit das Gegenteil der Messquellen-Prüfung.
+Fehlen `pv_surplus_kwh` oder `needed_full_kwh`, oder sind sie nicht numerisch, verhält sich das Veto wie vor dem Gate.
+Das Gate darf den real gemessenen Export nur unterdrücken, wenn der Forecast den Tagesüberfluss positiv belegt.
+Der Verlustfall kostet Geld, während eine Fehlauslösung nur zusätzliche Hoch-SoC-Stunden kostet.
+Fehlen dagegen Export, Import oder Batterieleistung, bleibt der gesamte Binary Sensor fail-safe aus, weil dann der reale Messbeleg fehlt.
 
-Im evcc-**PV**-Modus (nicht Schnellladung) konkurrieren Auto und Akku um denselben Überschuss.
-Die Formel regelt das von selbst: der Wallbox-Verbrauch senkt den Export, das Auto hat damit
-Vorrang, der Akku bekommt den Rest.
+Der Sonderfall `needed_full_kwh <= 0` schließt das Gate, weil der Akku rechnerisch bereits voll ist.
+`needed_full_kwh` rechnet bis 100 % und nicht bis `maxsoc`; die Differenz deckt der Faktor ab.
+Die Attribute `knappheit_faktor`, `pv_surplus_kwh`, `needed_full_kwh` und `knappheit_gate_offen` machen die Entscheidung beobachtbar.
+`knappheit_gate_offen` zeigt den wirksamen Zustand einschließlich des 20-%-Haltebands und des vorherigen Veto-Zustands.
 
-**Bewusst nicht gebaut:** ein Tages-Latch, der den Ziel-SoC monoton steigend hält (gegen den
-Rückschritt um 12:54). Nach dem Veto bleibt sein Nutzen auf den schmalen Streifen „Export
-unter der Schwelle" beschränkt, er entkernt die gewollte Puffer-Funktion der Kennlinie, und
-Template-Attribute überleben weder einen Neustart im `unavailable`-Zustand noch einen Reload
-zuverlässig — er wäre ohnehin nur best effort.
+**Was das Veto nicht sticht:** MinSOC-Schutz, beide Netzlade-Zweige, Peak-Leiter L1/L2, Balancing-Watchdog, den harten `maxsoc`-Ladedeckel, die Winter-/Prognose-Ladeblöcke, die EV-Sperre und die Halte-Stufen L3/L4.
+Es verdeckt ausschließlich die Ziel-SoC-Zweige und den Default.
+Gegen `maxsoc` ist es doppelt gesichert: durch die eigene Bedingung `SoC < maxsoc` und durch den früher stehenden Ladedeckel.
+
+Bei offenem Knappheits-Gate ist das Veto preisunabhängig und sticht auch den Preisniveau-Default-Guard.
+Fällt die Preisreihe in diesem Zustand aus, wird *Akku Dynamisch* gesetzt, statt den passiven Modus zu halten.
+Das ist beabsichtigt, weil *Dynamisch* keinen Netzbezug erzwingt und das Speichern knapper überschüssiger PV keinen Preis benötigt.
+
+Im evcc-**PV**-Modus, nicht bei Schnellladung, konkurrieren Auto und Akku um denselben Überschuss.
+Der Wallbox-Verbrauch senkt den Export, sodass das Auto Vorrang hat und der Akku nur den Rest bekommt.
+
+**Bewusst nicht gebaut:** Ein Tages-Latch würde den Ziel-SoC nach dem Rückschritt um 12:54 monoton steigend halten, aber die gewollte Puffer-Funktion der Kennlinie entkernen.
+Das Knappheits-Gate erhält diese Funktion gezielt an Reichtagen.
+Template-Attribute überleben zudem weder einen Neustart im Zustand `unavailable` noch einen Reload zuverlässig, sodass ein solches Latch nur best effort wäre.
 
 ### Nachbauen über die zwei Repos
 
@@ -783,10 +792,8 @@ Export ist über den Akku rückgekoppelt (Laden drückt ihn unter die Grenze und
 eigene Freigabe sofort wieder beenden - live beobachtetes Minutentakt-Flattern).
 Entprellung 30 s beidseitig plus Hysterese-Band, wie in der bewährten Opti-2.0-Automatik.
 
-**Abgrenzung:** Diese Option und Option 15 sind **Abregelungs**-Wächter — ihre Grenzen liegen
-beim Einspeiselimit bzw. der WR-AC-Grenze und lösen bei kleineren Anlagen im Normalbetrieb nie
-aus. Das *wirtschaftliche* Überschuss-Signal (jeder nennenswerte Export ist ladewürdig) ist
-Option 19.
+**Abgrenzung:** Diese Option und Option 15 sind **Abregelungs**-Wächter - ihre Grenzen liegen beim Einspeiselimit beziehungsweise der WR-AC-Grenze und lösen bei kleineren Anlagen im Normalbetrieb nie aus.
+Das wirtschaftliche Knappheitssignal, das nennenswerten Export nur bei prognostizierter Unterdeckung als ladewürdig einstuft, ist Option 19.
 
 ---
 
@@ -853,7 +860,7 @@ Ziel-SoC-Optionen (Option 20/21) — davor greift jedoch das Überschuss-Veto (O
 
 ---
 
-#### Option 19 — Echter Netz-Überschuss sticht den Ziel-SoC-Deckel (nur tagsüber)
+#### Option 19 - Echter Netz-Überschuss sticht den Ziel-SoC-Deckel (nur tagsüber)
 
 | Eigenschaft | Wert |
 |---|---|
@@ -862,15 +869,12 @@ Ziel-SoC-Optionen (Option 20/21) — davor greift jedoch das Überschuss-Veto (O
 | Tageszeit | nach Sonnenaufgang bis Sonnenuntergang |
 | Gesetzter Modus | **Akku Dynamisch** |
 
-**Warum:** Solange ins Netz eingespeist wird, ist der Zweck des Ziel-SoC-Deckels — Kapazität
-für später freihalten — gegenstandslos: die Energie geht ohnehin gerade weg. Jede stattdessen
-gespeicherte kWh ist Abendpreis minus Einspeisevergütung wert. Ausführliche Herleitung samt
-Live-Beleg vom 15.08.2026 im Abschnitt
-**[Das Überschuss-Veto](#das-überschuss-veto-laufender-export-sticht-den-deckel-option-19)**.
+**Warum:** Netzexport ist nur dann ein wirtschaftlicher Verlust, wenn der prognostizierte Rest-Überschuss den Akku nicht mehr sicher füllt.
+Das Knappheits-Gate im Binary Sensor sperrt Option 19 an Reichtagen und lässt sie bei Unterdeckung oder fehlenden Forecast-Daten zu.
+Die ausführliche Herleitung mit den Beispielen vom 15.08. und 16.08. steht im Abschnitt **[Das Überschuss-Veto](#das-überschuss-veto-knappheit-entscheidet-über-den-ziel-soc-deckel-option-19)**.
 
-Der Zweig steht bewusst hinter allen Zweigen, die aus einem anderen Grund laden, halten oder
-bewusst entladen (MinSOC, Netzladen, L1–L4, Balancing, `maxsoc`-Deckel, Prognose-Ladeblöcke,
-EV-Sperre) und verdeckt ausschließlich die Ziel-SoC-Optionen und den Default.
+Der Zweig steht bewusst hinter allen Zweigen, die aus einem anderen Grund laden, halten oder bewusst entladen: MinSOC, Netzladen, L1-L4, Balancing, `maxsoc`-Deckel, Prognose-Ladeblöcke und EV-Sperre.
+Er verdeckt ausschließlich die Ziel-SoC-Optionen und den Default.
 
 ---
 

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -91,15 +91,19 @@ template:
           hysterese_w: 300
 
       # -----------------------------------------------------------------------
-      # 0a-2. Wirtschaftliches Ueberschuss-Signal (2026-08-15)
+      # 0a-2. Wirtschaftliches Ueberschuss-Signal (2026-08-15/16)
       #    Die beiden Sensoren oben sind ABREGELUNGS-Waechter: ihre Grenzen sind
       #    das 70%-Einspeiselimit (live 18000 W) und die WR-AC-Grenze (9500 W).
       #    Eine Anlage mit ~8,3 kW Peak erreicht sie nie - beide Signale waren am
       #    15.08.2026 durchgehend off, waehrend 19,3 kWh ins Netz gingen und der
       #    Ziel-SoC-Deckel den Akku in drei Fenstern (zusammen ~2 h 25 min) auf
-      #    Ladeleistung 0 zwang. Es fehlte also das wirtschaftliche Signal:
-      #    solange ueberhaupt exportiert wird, ist jede in den Akku geladene kWh
-      #    den Abendpreis minus Einspeiseverguetung wert (15.08.: ~28 ct/kWh).
+      #    Ladeleistung 0 zwang. Es fehlte also das wirtschaftliche Signal fuer
+      #    einen Knappheitstag: nur wenn der prognostizierte Rest-Ueberschuss den
+      #    Akku nicht mehr sicher fuellt, ist aktueller Export ein Verlust. Reicht
+      #    die Rest-PV dagegen sicher aus, ist der Export gewollter Aufschub und
+      #    das Veto wuerde nur unnoetige Hoch-SoC-Stunden verursachen. Am
+      #    16.08.2026 standen 51,5 kWh Rest-Ueberschuss nur 4,5 kWh Bedarf bis
+      #    voll gegenueber - das Veto muss an so einem Reichtag gesperrt bleiben.
       #
       #    Gleiche Bauart wie oben - bewusst, nicht aus Bequemlichkeit: die
       #    Akku-Herausrechnung (Export + Batterieleistung, positiv = laden) ist
@@ -122,7 +126,21 @@ template:
       #      (Wandlungsverluste ~5-10 %, bei Volllast bis ~200 W).
       #    - 60 s statt 30 s beidseitig: die Schwelle liegt hier unterhalb der
       #      Hausgrundlast-Schwankung (~700-1500 W), also naeher am Rauschen.
-      #    Quellen unavailable -> off (fail-safe, wie oben).
+      #    - Knappheits-Gate (2026-08-16): offen bei Rest-Ueberschuss kleiner
+      #      als Bedarf bis voll mal Faktor. War das Veto bereits an, bleibt es
+      #      bis Faktor mal 1,2 offen. Das feste 20-%-Halteband verhindert, dass
+      #      das Laden durch steigenden SoC und sinkenden Bedarf seine eigene
+      #      Freigabe im ~15-Minuten-Takt beendet. `knappheit_gate_offen` zeigt
+      #      den wirksamen Gate-Zustand inklusive dieses Haltebands.
+      #    - Fail-Richtungen bewusst gegensaetzlich: Messquellen unavailable
+      #      -> off (fail-safe, kein Laden ohne realen Messbeleg). Fehlende oder
+      #      nicht numerische Forecast-Werte -> Knappheits-Gate offen, also das
+      #      bisherige Veto-Verhalten. Nur ein positiv belegter Tages-Ueberfluss
+      #      darf den real gemessenen Export unterdruecken. Der Verlustfall vom
+      #      15.08. kostet Geld, eine Fehlausloesung nur Hoch-SoC-Stunden.
+      #    - needed_full_kwh rechnet bis 100 %, nicht bis maxsoc. Ein Wert <= 0
+      #      bedeutet rechnerisch voll und schliesst das Gate; die Differenz zu
+      #      maxsoc deckt der Knappheits-Faktor ab.
       # -----------------------------------------------------------------------
       - unique_id: opti_ueberschuss_veto_aktiv
         name: "Opti Ueberschuss Veto Aktiv"
@@ -141,7 +159,18 @@ template:
           {% set ein = states('input_number.akkusteuerung_ueberschuss_veto_grenze')|float(999999) %}
           {% set aus = states('input_number.akkusteuerung_ueberschuss_veto_aus_grenze')|float(ein) %}
           {% set war_an = this is defined and this.state == 'on' %}
-          {{ ok and (export_ohne_akku > ein
+          {% set surplus = state_attr('sensor.opti_forecast_score', 'pv_surplus_kwh')|float(none) %}
+          {% set needed = state_attr('sensor.opti_forecast_score', 'needed_full_kwh')|float(none) %}
+          {% set f = states('input_number.akkusteuerung_ueberschuss_veto_knappheit_faktor')|float(1) %}
+          {% if needed is not none and needed <= 0 %}
+            {% set knappheit_gate_offen = false %}
+          {% elif surplus is none or needed is none %}
+            {% set knappheit_gate_offen = true %}
+          {% else %}
+            {% set knappheit_gate_offen = surplus < needed * f
+                or (war_an and surplus < needed * f * 1.2) %}
+          {% endif %}
+          {{ ok and knappheit_gate_offen and (export_ohne_akku > ein
                      or (aus > 0 and export_ohne_akku >= aus and war_an)) }}
         attributes:
           export_ohne_akku_w: >
@@ -150,6 +179,25 @@ template:
                    + states('sensor.opti_battery_power_w')|float(0)] | max | round(0) }}
           grenze_ein_w: "{{ states('input_number.akkusteuerung_ueberschuss_veto_grenze') }}"
           grenze_aus_w: "{{ states('input_number.akkusteuerung_ueberschuss_veto_aus_grenze') }}"
+          knappheit_faktor: >
+            {{ states('input_number.akkusteuerung_ueberschuss_veto_knappheit_faktor')|float(1) }}
+          pv_surplus_kwh: >
+            {{ state_attr('sensor.opti_forecast_score', 'pv_surplus_kwh') }}
+          needed_full_kwh: >
+            {{ state_attr('sensor.opti_forecast_score', 'needed_full_kwh') }}
+          knappheit_gate_offen: >
+            {% set surplus = state_attr('sensor.opti_forecast_score', 'pv_surplus_kwh')|float(none) %}
+            {% set needed = state_attr('sensor.opti_forecast_score', 'needed_full_kwh')|float(none) %}
+            {% set f = states('input_number.akkusteuerung_ueberschuss_veto_knappheit_faktor')|float(1) %}
+            {% set war_an = this is defined and this.state == 'on' %}
+            {% if needed is not none and needed <= 0 %}
+              {{ false }}
+            {% elif surplus is none or needed is none %}
+              {{ true }}
+            {% else %}
+              {{ surplus < needed * f
+                 or (war_an and surplus < needed * f * 1.2) }}
+            {% endif %}
 
       # -----------------------------------------------------------------------
       # 0b. PV-Reichtag fuer den Wiederauflade-Horizont der Peak-Reserve.
@@ -991,8 +1039,9 @@ template:
           {%- elif soc > 99 %}Akku Dynamisch
           {%- elif aktiv and hv_cur and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Akku nur Laden
           {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Akku nur Laden
-          {# Ueberschuss-Veto (2026-08-15): laufender Netzexport sticht den
-             Ziel-SoC-Deckel. Position identisch zur Strategie - hinter L3/L4,
+          {# Ueberschuss-Veto (2026-08-15/16): knapper Resttag und laufender
+             Netzexport stechen den Ziel-SoC-Deckel. Das Knappheits-Gate lebt
+             im Binary Sensor. Position identisch zur Strategie - hinter L3/L4,
              vor den Ziel-SoC-Zweigen (Paritaet). #}
           {%- elif ueb and day and veto and hv_maxsoc and soc >= 0 and soc < maxsoc %}Akku Dynamisch
           {%- elif soc > minsoc and soc < target - H and day %}Akku Dynamisch

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -108,6 +108,15 @@ template:
       #    beenden. Die Summe bleibt beim Anladen invariant.
       #
       #    Abweichungen zu den Abregelungs-Waechtern:
+      #    - Import-Term (2026-08-15, Review Fable 5): erst
+      #      `export - import + battery` ist exakt `PV - Hauslast`. Ohne ihn
+      #      meldet der Sensor beim Netzladen Ueberschuss, wo gerade Strom
+      #      gekauft wird (Export 0, battery +3000 -> 3000 W). Folgenlos, weil
+      #      beide Netzlade-Zweige in der choose-Kette vor dem Veto-Zweig
+      #      stehen und first-match gilt - aber beim Wegfall der
+      #      Preisberechtigung koennte das Veto ~60-120 s lang faelschlich
+      #      'Dynamisch' setzen. Im Zielregime (Export > 0 => Import = 0)
+      #      aendert der Term nichts.
       #    - Aus-Grenze als eigener Helfer statt fester Differenz: das Band muss
       #      die Messpunkt-Unschaerfe DC-Batterieleistung vs. AC-Export tragen
       #      (Wandlungsverluste ~5-10 %, bei Volllast bis ~200 W).
@@ -124,8 +133,10 @@ template:
           seconds: 60
         state: >
           {% set ok = has_value('sensor.opti_grid_export_w')
+                      and has_value('sensor.opti_grid_import_w')
                       and has_value('sensor.opti_battery_power_w') %}
           {% set export_ohne_akku = [0, states('sensor.opti_grid_export_w')|float(0)
+                                        - states('sensor.opti_grid_import_w')|float(0)
                                         + states('sensor.opti_battery_power_w')|float(0)] | max %}
           {% set ein = states('input_number.akkusteuerung_ueberschuss_veto_grenze')|float(999999) %}
           {% set aus = states('input_number.akkusteuerung_ueberschuss_veto_aus_grenze')|float(ein) %}
@@ -135,6 +146,7 @@ template:
         attributes:
           export_ohne_akku_w: >
             {{ [0, states('sensor.opti_grid_export_w')|float(0)
+                   - states('sensor.opti_grid_import_w')|float(0)
                    + states('sensor.opti_battery_power_w')|float(0)] | max | round(0) }}
           grenze_ein_w: "{{ states('input_number.akkusteuerung_ueberschuss_veto_grenze') }}"
           grenze_aus_w: "{{ states('input_number.akkusteuerung_ueberschuss_veto_aus_grenze') }}"
@@ -520,6 +532,11 @@ template:
             {% endif %}
             {% set net_available = [0, restproduktion - (hausverbrauch / 1000 * remaining_hours)] | max %}
             {{ (0 if cap_kwh <= 0 else net_available / cap_kwh) | round(3) }}
+          # EXTERNER KONSUMENT (2026-08-15): /config/packages/luxusverbraucher.yaml
+          # liest dieses Attribut als "kommt heute noch nennenswert PV?" fuer die
+          # Entfeuchter-Abschaltung. Umbenennen oder Semantik aendern bricht die
+          # dortige Automation STILL - sie liegt ausserhalb dieses Repos und
+          # damit ausserhalb der Testsuite. Bei Aenderungen mitziehen.
           net_available_kwh: >
             {% set restproduktion = states('sensor.opti_forecast_effective_remaining_kwh') | float(0) %}
             {% set hausverbrauch  = states('sensor.opti_house_consumption_60min_w') | float(states('sensor.opti_house_consumption_w') | float(1500)) %}

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -91,6 +91,55 @@ template:
           hysterese_w: 300
 
       # -----------------------------------------------------------------------
+      # 0a-2. Wirtschaftliches Ueberschuss-Signal (2026-08-15)
+      #    Die beiden Sensoren oben sind ABREGELUNGS-Waechter: ihre Grenzen sind
+      #    das 70%-Einspeiselimit (live 18000 W) und die WR-AC-Grenze (9500 W).
+      #    Eine Anlage mit ~8,3 kW Peak erreicht sie nie - beide Signale waren am
+      #    15.08.2026 durchgehend off, waehrend 19,3 kWh ins Netz gingen und der
+      #    Ziel-SoC-Deckel den Akku in drei Fenstern (zusammen ~2 h 25 min) auf
+      #    Ladeleistung 0 zwang. Es fehlte also das wirtschaftliche Signal:
+      #    solange ueberhaupt exportiert wird, ist jede in den Akku geladene kWh
+      #    den Abendpreis minus Einspeiseverguetung wert (15.08.: ~28 ct/kWh).
+      #
+      #    Gleiche Bauart wie oben - bewusst, nicht aus Bequemlichkeit: die
+      #    Akku-Herausrechnung (Export + Batterieleistung, positiv = laden) ist
+      #    der live erprobte Fix gegen die Selbstschwingung vom 03.07., denn das
+      #    Laden selbst senkt den Export und wuerde sonst die eigene Freigabe
+      #    beenden. Die Summe bleibt beim Anladen invariant.
+      #
+      #    Abweichungen zu den Abregelungs-Waechtern:
+      #    - Aus-Grenze als eigener Helfer statt fester Differenz: das Band muss
+      #      die Messpunkt-Unschaerfe DC-Batterieleistung vs. AC-Export tragen
+      #      (Wandlungsverluste ~5-10 %, bei Volllast bis ~200 W).
+      #    - 60 s statt 30 s beidseitig: die Schwelle liegt hier unterhalb der
+      #      Hausgrundlast-Schwankung (~700-1500 W), also naeher am Rauschen.
+      #    Quellen unavailable -> off (fail-safe, wie oben).
+      # -----------------------------------------------------------------------
+      - unique_id: opti_ueberschuss_veto_aktiv
+        name: "Opti Ueberschuss Veto Aktiv"
+        icon: mdi:battery-plus-variant
+        delay_on:
+          seconds: 60
+        delay_off:
+          seconds: 60
+        state: >
+          {% set ok = has_value('sensor.opti_grid_export_w')
+                      and has_value('sensor.opti_battery_power_w') %}
+          {% set export_ohne_akku = [0, states('sensor.opti_grid_export_w')|float(0)
+                                        + states('sensor.opti_battery_power_w')|float(0)] | max %}
+          {% set ein = states('input_number.akkusteuerung_ueberschuss_veto_grenze')|float(999999) %}
+          {% set aus = states('input_number.akkusteuerung_ueberschuss_veto_aus_grenze')|float(ein) %}
+          {% set war_an = this is defined and this.state == 'on' %}
+          {{ ok and (export_ohne_akku > ein
+                     or (aus > 0 and export_ohne_akku >= aus and war_an)) }}
+        attributes:
+          export_ohne_akku_w: >
+            {{ [0, states('sensor.opti_grid_export_w')|float(0)
+                   + states('sensor.opti_battery_power_w')|float(0)] | max | round(0) }}
+          grenze_ein_w: "{{ states('input_number.akkusteuerung_ueberschuss_veto_grenze') }}"
+          grenze_aus_w: "{{ states('input_number.akkusteuerung_ueberschuss_veto_aus_grenze') }}"
+
+      # -----------------------------------------------------------------------
       # 0b. PV-Reichtag fuer den Wiederauflade-Horizont der Peak-Reserve.
       #     Entscheidungs-Hysterese ohne Datenpuffer: ab Score 10 an, bei
       #     vorherigem on bis Score 9 halten, ab Score 8 aus. Bei fehlendem
@@ -897,6 +946,8 @@ template:
           {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
           {% set ev = states('input_boolean.opti_ev_akku_pause') == 'on'
                       and is_state('binary_sensor.opti_ev_schnellladung', 'on') %}
+          {% set maxsoc = states('input_number.maxsoc')|float(95) %}
+          {% set veto = is_state('binary_sensor.opti_ueberschuss_veto_aktiv','on') %}
           {% if soc >= 0 and soc < minsoc %}Akku nur Laden
           {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) - stopband and cur < eeg and fenster %}Akku Netzladen
           {%- elif prog and aktiv and hv_cur and soc >= 0 and soc < ges_res - stopband and avg is not none and (avg - cur) >= spread and fenster %}Akku Netzladen
@@ -919,6 +970,10 @@ template:
           {%- elif soc > 99 %}Akku Dynamisch
           {%- elif aktiv and hv_cur and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Akku nur Laden
           {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Akku nur Laden
+          {# Ueberschuss-Veto (2026-08-15): laufender Netzexport sticht den
+             Ziel-SoC-Deckel. Position identisch zur Strategie - hinter L3/L4,
+             vor den Ziel-SoC-Zweigen (Paritaet). #}
+          {%- elif ueb and day and veto and soc >= 0 and soc < maxsoc %}Akku Dynamisch
           {%- elif soc > minsoc and soc < target - H and day %}Akku Dynamisch
           {# Asymmetrische Hysterese gegen Ziel-SoC-Flattern (v.a. mittags, wenn
              PV den SoC ueber die Schwelle drueckt): rein bei target+H, drin
@@ -973,6 +1028,8 @@ template:
             {% set fenster = (minv is none) or (cur <= minv + 0.5) %}
             {% set ev = states('input_boolean.opti_ev_akku_pause') == 'on'
                         and is_state('binary_sensor.opti_ev_schnellladung', 'on') %}
+            {% set maxsoc = states('input_number.maxsoc')|float(95) %}
+            {% set veto = is_state('binary_sensor.opti_ueberschuss_veto_aktiv','on') %}
             {% if soc >= 0 and soc < minsoc %}MinSOC-Schutz (SoC<{{minsoc}})
             {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) - stopband and cur < eeg and fenster %}Negativpreis-Laden ({{cur}}ct < EEG {{eeg}}ct)
             {%- elif prog and aktiv and hv_cur and soc >= 0 and soc < ges_res - stopband and avg is not none and (avg - cur) >= spread and fenster %}Peak-Vorladen (Spread {{(avg - cur)|round(1)}}ct, bis {{ges_res}}%)
@@ -992,6 +1049,7 @@ template:
             {%- elif soc > 99 %}Akku voll
             {%- elif aktiv and hv_cur and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Peak-Leiter L3 (halten fuer VE, Reserve {{ve_res}}%, Spread {{(ve_avg - cur)|round(1)}}ct)
             {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Peak-Leiter L4 (halten fuer Peaks, Reserve {{ges_res}}%)
+            {%- elif ueb and day and veto and soc >= 0 and soc < maxsoc %}Ueberschuss-Veto ({{ state_attr('binary_sensor.opti_ueberschuss_veto_aktiv','export_ohne_akku_w') }}W Export sticht Ziel-SoC {{target}}%)
             {%- elif soc > minsoc and soc < target - H and day %}dyn bis Ziel (tag)
             {%- elif soc > target + (0 if is_state('input_select.akkusteuerung_modus','Akku nur Entladen') else H) %}ueber Ziel-SoC
             {%- elif soc >= 0 and not has_value('sensor.opti_price_level')

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -947,6 +947,10 @@ template:
           {% set ev = states('input_boolean.opti_ev_akku_pause') == 'on'
                       and is_state('binary_sensor.opti_ev_schnellladung', 'on') %}
           {% set maxsoc = states('input_number.maxsoc')|float(95) %}
+          {# hv_maxsoc spiegelt das has_value-Gate des Automation-Zweigs: ohne
+             maxsoc faellt der Zweig dort ZU (fail-safe), die Vorschau muss
+             dasselbe tun statt mit dem Default 95 weiterzurechnen. #}
+          {% set hv_maxsoc = has_value('input_number.maxsoc') %}
           {% set veto = is_state('binary_sensor.opti_ueberschuss_veto_aktiv','on') %}
           {% if soc >= 0 and soc < minsoc %}Akku nur Laden
           {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) - stopband and cur < eeg and fenster %}Akku Netzladen
@@ -973,7 +977,7 @@ template:
           {# Ueberschuss-Veto (2026-08-15): laufender Netzexport sticht den
              Ziel-SoC-Deckel. Position identisch zur Strategie - hinter L3/L4,
              vor den Ziel-SoC-Zweigen (Paritaet). #}
-          {%- elif ueb and day and veto and soc >= 0 and soc < maxsoc %}Akku Dynamisch
+          {%- elif ueb and day and veto and hv_maxsoc and soc >= 0 and soc < maxsoc %}Akku Dynamisch
           {%- elif soc > minsoc and soc < target - H and day %}Akku Dynamisch
           {# Asymmetrische Hysterese gegen Ziel-SoC-Flattern (v.a. mittags, wenn
              PV den SoC ueber die Schwelle drueckt): rein bei target+H, drin
@@ -1029,6 +1033,10 @@ template:
             {% set ev = states('input_boolean.opti_ev_akku_pause') == 'on'
                         and is_state('binary_sensor.opti_ev_schnellladung', 'on') %}
             {% set maxsoc = states('input_number.maxsoc')|float(95) %}
+            {# hv_maxsoc spiegelt das has_value-Gate des Automation-Zweigs: ohne
+               maxsoc faellt der Zweig dort ZU (fail-safe), die Vorschau muss
+               dasselbe tun statt mit dem Default 95 weiterzurechnen. #}
+            {% set hv_maxsoc = has_value('input_number.maxsoc') %}
             {% set veto = is_state('binary_sensor.opti_ueberschuss_veto_aktiv','on') %}
             {% if soc >= 0 and soc < minsoc %}MinSOC-Schutz (SoC<{{minsoc}})
             {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) - stopband and cur < eeg and fenster %}Negativpreis-Laden ({{cur}}ct < EEG {{eeg}}ct)
@@ -1049,7 +1057,7 @@ template:
             {%- elif soc > 99 %}Akku voll
             {%- elif aktiv and hv_cur and soc >= 0 and price == 'EXPENSIVE' and ve_avg is not none and (ve_avg - cur) >= halte_spread %}Peak-Leiter L3 (halten fuer VE, Reserve {{ve_res}}%, Spread {{(ve_avg - cur)|round(1)}}ct)
             {%- elif aktiv and soc >= 0 and p_n and soc <= ges_res + band %}Peak-Leiter L4 (halten fuer Peaks, Reserve {{ges_res}}%)
-            {%- elif ueb and day and veto and soc >= 0 and soc < maxsoc %}Ueberschuss-Veto ({{ state_attr('binary_sensor.opti_ueberschuss_veto_aktiv','export_ohne_akku_w') }}W Export sticht Ziel-SoC {{target}}%)
+            {%- elif ueb and day and veto and hv_maxsoc and soc >= 0 and soc < maxsoc %}Ueberschuss-Veto ({{ state_attr('binary_sensor.opti_ueberschuss_veto_aktiv','export_ohne_akku_w') }}W Export sticht Ziel-SoC {{target}}%)
             {%- elif soc > minsoc and soc < target - H and day %}dyn bis Ziel (tag)
             {%- elif soc > target + (0 if is_state('input_select.akkusteuerung_modus','Akku nur Entladen') else H) %}ueber Ziel-SoC
             {%- elif soc >= 0 and not has_value('sensor.opti_price_level')

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -107,6 +107,36 @@ input_number:
     unit_of_measurement: W
     mode: box
 
+  # Wirtschaftliches Ueberschuss-Veto (2026-08-15): die beiden Grenzen oben sind
+  # ABREGELUNGS-Schwellen (70%-Einspeiselimit, WR-AC-Grenze) und liegen bei einer
+  # Anlage mit ~8 kW Peak so hoch, dass ihre Signale nie ausloesen. Diese Grenze
+  # ist die wirtschaftliche: jede kWh, die bei laufendem Netzexport NICHT in den
+  # Akku geht, ist Einspeiseverguetung statt Abendpreis - am 15.08.2026 gingen so
+  # 19,3 kWh ins Netz, waehrend der Ziel-SoC-Deckel den Akku ~2,5 h auf
+  # Ladeleistung 0 zwang. Sie dient nur der Signalstabilitaet, nicht der
+  # Wirtschaftlichkeit: oekonomisch waere jedes Watt Export ladewuerdig.
+  akkusteuerung_ueberschuss_veto_grenze:
+    name: "Akkusteuerung Überschuss-Veto Grenze"
+    min: 100
+    max: 5000
+    step: 50
+    unit_of_measurement: W
+    mode: box
+    icon: mdi:transmission-tower-export
+
+  # Ausschaltschwelle des Vetos (Hysterese-Unterkante). Bewusst als eigener
+  # Helfer statt fester Differenz: der Abstand zur Einschaltgrenze muss die
+  # Messpunkt-Unschaerfe zwischen DC-Batterieleistung und AC-Export abdecken
+  # (Wandlungsverluste ~5-10 %, bei Volllast bis ~200 W).
+  akkusteuerung_ueberschuss_veto_aus_grenze:
+    name: "Akkusteuerung Überschuss-Veto Aus-Grenze"
+    min: 0
+    max: 5000
+    step: 50
+    unit_of_measurement: W
+    mode: box
+    icon: mdi:transmission-tower-export
+
   # --- SoC-Grenzen ---
   minsoc:
     name: "Akku Min SoC"

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -110,11 +110,11 @@ input_number:
   # Wirtschaftliches Ueberschuss-Veto (2026-08-15): die beiden Grenzen oben sind
   # ABREGELUNGS-Schwellen (70%-Einspeiselimit, WR-AC-Grenze) und liegen bei einer
   # Anlage mit ~8 kW Peak so hoch, dass ihre Signale nie ausloesen. Diese Grenze
-  # ist die wirtschaftliche: jede kWh, die bei laufendem Netzexport NICHT in den
-  # Akku geht, ist Einspeiseverguetung statt Abendpreis - am 15.08.2026 gingen so
-  # 19,3 kWh ins Netz, waehrend der Ziel-SoC-Deckel den Akku ~2,5 h auf
-  # Ladeleistung 0 zwang. Sie dient nur der Signalstabilitaet, nicht der
-  # Wirtschaftlichkeit: oekonomisch waere jedes Watt Export ladewuerdig.
+  # ist die wirtschaftliche Leistungsschwelle. Bei prognostizierter Knappheit ist
+  # jede kWh, die bei laufendem Netzexport NICHT in den Akku geht,
+  # Einspeiseverguetung statt Abendpreis - am 15.08.2026 gingen so 19,3 kWh ins
+  # Netz, waehrend der Ziel-SoC-Deckel den Akku ~2,5 h auf Ladeleistung 0 zwang.
+  # An einem Reichtag sperrt der Knappheits-Faktor unten dieses Veto dagegen.
   # min bewusst 200 statt 0: ein input_number ohne gespeicherten Zustand startet
   # auf seinem Minimum. Kein `initial:` - das ueberschriebe den restaurierten Wert
   # bei JEDEM Neustart (dieselbe Falle, die am Modus-Select entfernt wurde). Der
@@ -144,6 +144,22 @@ input_number:
     unit_of_measurement: W
     mode: box
     icon: mdi:transmission-tower-export
+
+  # Knappheits-Gate fuer das Ueberschuss-Veto (2026-08-16): das Veto sticht den
+  # Ziel-SoC nur noch, wenn der prognostizierte Rest-Ueberschuss des Tages kleiner
+  # ist als dieser Faktor mal der Energiebedarf bis Akku voll. Kein `initial:` -
+  # das ueberschriebe den restaurierten Wert bei jedem Neustart. Der Erststart
+  # faellt deshalb auf min 1: Veto nur bei echter Unterdeckung, also die
+  # konservativste Einstellung in Richtung Ziel-SoC-Rampe. Empfohlener
+  # Betriebswert: 3 als Pessimismus-Puffer gegen Forecast-Optimismus, belegt am
+  # Knappheitstag 15.08.2026.
+  akkusteuerung_ueberschuss_veto_knappheit_faktor:
+    name: "Akkusteuerung Überschuss-Veto Knappheits-Faktor"
+    min: 1
+    max: 10
+    step: 0.5
+    mode: box
+    icon: mdi:scale-balance
 
   # --- SoC-Grenzen ---
   minsoc:

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -115,9 +115,14 @@ input_number:
   # 19,3 kWh ins Netz, waehrend der Ziel-SoC-Deckel den Akku ~2,5 h auf
   # Ladeleistung 0 zwang. Sie dient nur der Signalstabilitaet, nicht der
   # Wirtschaftlichkeit: oekonomisch waere jedes Watt Export ladewuerdig.
+  # min bewusst 200 statt 0: ein input_number ohne gespeicherten Zustand startet
+  # auf seinem Minimum. Kein `initial:` - das ueberschriebe den restaurierten Wert
+  # bei JEDEM Neustart (dieselbe Falle, die am Modus-Select entfernt wurde). Der
+  # Erststart-Wert muss deshalb ueber `min` brauchbar sein. Empfohlener
+  # Betriebswert: 500 W.
   akkusteuerung_ueberschuss_veto_grenze:
     name: "Akkusteuerung Überschuss-Veto Grenze"
-    min: 100
+    min: 200
     max: 5000
     step: 50
     unit_of_measurement: W
@@ -128,9 +133,12 @@ input_number:
   # Helfer statt fester Differenz: der Abstand zur Einschaltgrenze muss die
   # Messpunkt-Unschaerfe zwischen DC-Batterieleistung und AC-Export abdecken
   # (Wandlungsverluste ~5-10 %, bei Volllast bis ~200 W).
+  # min 100 aus demselben Grund: beim Erststart faellt der Helfer sonst auf 0 und
+  # das Halteband waere wirkungslos (das Template wertet `aus > 0` aus).
+  # Empfohlener Betriebswert: 250 W.
   akkusteuerung_ueberschuss_veto_aus_grenze:
     name: "Akkusteuerung Überschuss-Veto Aus-Grenze"
-    min: 0
+    min: 100
     max: 5000
     step: 50
     unit_of_measurement: W

--- a/tests/test_strategie_paritaet.py
+++ b/tests/test_strategie_paritaet.py
@@ -1,14 +1,14 @@
 """Paritaets-Test: echte Steuer-Automation vs. Spiegel-Sensor.
 
 Die Steuerung lebt in automations/opti_strategie.yaml (action-Alias
-"Zwischen Speicherszenarien waehlen": choose-Kette mit 21 Optionen + default).
+"Zwischen Speicherszenarien waehlen": choose-Kette mit 22 Optionen + default).
 Ihr Spiegel ist der Vorschau-Sensor opti_strategie_vorschau in
 packages/opti_derived.yaml (state-if/elif-Kette + grund-Attribut). Der
 YAML-Kommentar verlangt manuelle Spiegelung ("MUSS mitgespiegelt werden") -
 ohne diesen Test laesst eine Aenderung an der Automation alle Tests gruen,
 obwohl die Steuerung von der Vorschau abweicht.
 
-Der Test baut fuer JEDE der 21 choose-Optionen + den Default eine Fixture
+Der Test baut fuer JEDE der 22 choose-Optionen + den Default eine Fixture
 (FakeHass-Zustand), die genau diesen Zweig trifft, und prueft:
   (i)   Automation-choose-Kette (eigener Evaluator) -> getroffener Zweig-Index
         + gesetzter Modus.
@@ -199,10 +199,17 @@ BRANCHES = [
       "input_boolean.opti_prognose_netzladen": "off",
       "_attrs": reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0)},
      "Akku nur Laden", "Peak-Leiter L4"),
-    (19, "dyn_bis_ziel",
+    (19, "ueberschuss_veto_sticht_ziel_soc",
+     # Identische Lage wie 'ueber_ziel_soc' (soc 70 > target 60), aber tagsueber
+     # mit laufendem Netzexport: das Veto muss VOR dem Ziel-SoC-Zweig greifen
+     # und laden statt entladen. Das ist der Fall vom 15.08.2026.
+     {"sun.sun": "above_horizon", "sensor.opti_soc": "70", "sensor.opti_target_soc": "60",
+      "binary_sensor.opti_ueberschuss_veto_aktiv": "on"},
+     "Akku Dynamisch", "Ueberschuss-Veto"),
+    (20, "dyn_bis_ziel",
      {"sun.sun": "above_horizon", "sensor.opti_soc": "40", "sensor.opti_target_soc": "60"},
      "Akku Dynamisch", "dyn bis Ziel"),
-    (20, "ueber_ziel_soc",
+    (21, "ueber_ziel_soc",
      {"sensor.opti_soc": "70", "sensor.opti_target_soc": "60"},
      "Akku nur Entladen", "ueber Ziel-SoC"),
 ]
@@ -262,3 +269,69 @@ def test_struktur_alle_choose_optionen_abgedeckt():
         "neue/entfernte Option in opti_strategie.yaml nicht im Paritaets-Test gespiegelt")
     # Zweig-Indizes lueckenlos 0..N-1 (kein Tippfehler in der BRANCHES-Tabelle).
     assert [b[0] for b in BRANCHES] == list(range(len(BRANCHES)))
+
+
+# --- Vorrang-Regeln des Ueberschuss-Vetos (2026-08-15) ----------------------
+# Das Veto darf AUSSCHLIESSLICH die Ziel-SoC-Zweige stechen. Alles, was den Akku
+# aus einem anderen Grund am Laden hindert oder bewusst entlaedt, muss gewinnen.
+# Cross-Review Fable 5 + GPT-5.6 Sol, 15.08.2026.
+
+VETO_LAGE = {
+    "sun.sun": "above_horizon",
+    "binary_sensor.opti_ueberschuss_veto_aktiv": "on",
+    "sensor.opti_target_soc": "60",
+}
+
+
+def test_veto_sticht_ziel_soc_deckel():
+    """Der Fall vom 15.08.2026: SoC ueber Ziel-SoC, aber Export laeuft."""
+    hass = _make_hass({**VETO_LAGE, "sensor.opti_soc": "70"})
+    zweig, modus = _evaluate_automation(hass)
+    assert modus == "Akku Dynamisch"
+    assert _vorschau(hass, "state") == "Akku Dynamisch"
+    # Ohne Veto waere es der Ziel-SoC-Zweig mit 'nur Entladen'.
+    ohne = _make_hass({**VETO_LAGE, "sensor.opti_soc": "70",
+                       "binary_sensor.opti_ueberschuss_veto_aktiv": "off"})
+    assert _evaluate_automation(ohne)[1] == "Akku nur Entladen"
+
+
+def test_veto_laedt_nicht_ueber_maxsoc():
+    """Harter Deckel bleibt hart: bei SoC >= maxsoc gewinnt der Ladedeckel."""
+    hass = _make_hass({**VETO_LAGE, "sensor.opti_soc": "96"})
+    zweig, modus = _evaluate_automation(hass)
+    assert modus == "Akku nur Entladen"
+    assert _vorschau(hass, "state") == "Akku nur Entladen"
+    assert "Ladedeckel" in _vorschau(hass, "grund")
+
+
+def test_ev_sperre_gewinnt_gegen_veto():
+    """Sonst entlaedt der Akku bei evcc-Schnellladung ins Auto."""
+    hass = _make_hass({**VETO_LAGE, "sensor.opti_soc": "70",
+                       "input_boolean.opti_ev_akku_pause": "on",
+                       "binary_sensor.opti_ev_schnellladung": "on"})
+    assert _evaluate_automation(hass)[1] == "Akku nur Laden"
+    assert "EV-Sperre" in _vorschau(hass, "grund")
+
+
+def test_peak_entladung_gewinnt_gegen_veto():
+    """L1: bei VERY_EXPENSIVE wird entladen, auch wenn gerade exportiert wird."""
+    hass = _make_hass({**LEITER_BASE, **VETO_LAGE, "sensor.opti_soc": "85",
+                       "sensor.opti_price_level": "VERY_EXPENSIVE",
+                       "_attrs": reserve_attrs(ve=30.0, min_vor=50.0, avg=200.0)})
+    assert _evaluate_automation(hass)[1] == "Akku nur Entladen"
+    assert "Peak-Leiter L1" in _vorschau(hass, "grund")
+
+
+def test_veto_nur_tagsueber():
+    """Nachts gibt es keinen PV-Ueberschuss; ein haengendes Signal darf den
+    Ziel-SoC-Zweig nicht aushebeln."""
+    hass = _make_hass({**VETO_LAGE, "sensor.opti_soc": "70",
+                       "sun.sun": "below_horizon"})
+    assert _evaluate_automation(hass)[1] == "Akku nur Entladen"
+
+
+def test_veto_respektiert_toggle():
+    """Globaler PV-Ueberschuss-Schalter aus -> kein Veto."""
+    hass = _make_hass({**VETO_LAGE, "sensor.opti_soc": "70",
+                       "input_boolean.opti_pv_ueberschuss_ladung": "off"})
+    assert _evaluate_automation(hass)[1] == "Akku nur Entladen"

--- a/tests/test_strategie_paritaet.py
+++ b/tests/test_strategie_paritaet.py
@@ -335,3 +335,15 @@ def test_veto_respektiert_toggle():
     hass = _make_hass({**VETO_LAGE, "sensor.opti_soc": "70",
                        "input_boolean.opti_pv_ueberschuss_ladung": "off"})
     assert _evaluate_automation(hass)[1] == "Akku nur Entladen"
+
+
+def test_veto_paritaet_bei_maxsoc_unavailable():
+    """Review-Finding 15.08.2026: der Automation-Zweig ist per `has_value` auf
+    maxsoc gegatet und faellt bei unavailable zu. Die Vorschau rechnete dagegen
+    mit dem Default 95 weiter und meldete 'Akku Dynamisch', waehrend real
+    'nur Entladen' lief - eine echte Paritaetsverletzung."""
+    hass = _make_hass({**VETO_LAGE, "sensor.opti_soc": "70",
+                       "input_number.maxsoc": "unavailable"})
+    _, auto_modus = _evaluate_automation(hass)
+    assert auto_modus == _vorschau(hass, "state")
+    assert auto_modus == "Akku nur Entladen"

--- a/tests/test_strategie_vorschau.py
+++ b/tests/test_strategie_vorschau.py
@@ -10,6 +10,8 @@ BASIS = {
     "sensor.opti_price_current_ct_kwh": "30",
     "binary_sensor.opti_ueberschuss_70_aktiv": "off",
     "binary_sensor.opti_ueberschuss_ac_aktiv": "off",
+    # Wirtschaftliches Ueberschuss-Veto default aus (Fixtures schalten es an).
+    "binary_sensor.opti_ueberschuss_veto_aktiv": "off",
     "sensor.opti_peak_reserve_soc": "unavailable",
     "binary_sensor.opti_peak_reserve_aktiv": "off",
     "binary_sensor.opti_winter_charging_allowed": "on",

--- a/tests/test_ueberschuss_entprellung.py
+++ b/tests/test_ueberschuss_entprellung.py
@@ -153,3 +153,82 @@ def test_automation_conditions_nutzen_binaersensoren():
     assert "sensor.opti_grid_export_w" not in c70
     assert "binary_sensor.opti_ueberschuss_ac_aktiv" in cac
     assert "sensor.opti_pv_power_w" not in cac
+
+
+# --- Wirtschaftliches Ueberschuss-Veto (2026-08-15) -------------------------
+# Die beiden Sensoren oben sind Abregelungs-Waechter (18000 / 9500 W) und lagen
+# am 15.08.2026 durchgehend off, waehrend 19,3 kWh ins Netz gingen und der
+# Ziel-SoC-Deckel den Akku ~2,5 h auf Ladeleistung 0 zwang. Dieser Sensor ist
+# das fehlende wirtschaftliche Signal.
+
+VETO_BASIS = {
+    "sensor.opti_grid_export_w": "0",
+    "sensor.opti_battery_power_w": "0",
+    "input_number.akkusteuerung_ueberschuss_veto_grenze": "500",
+    "input_number.akkusteuerung_ueberschuss_veto_aus_grenze": "250",
+}
+
+
+def bveto(this_state="off", **overrides):
+    states = dict(VETO_BASIS)
+    states.update(overrides)
+    hass = FakeHass(states=states, this_state=this_state)
+    return render(hass, _entity("opti_ueberschuss_veto_aktiv")["state"])
+
+
+def test_veto_ein_ueber_grenze():
+    assert bveto(**{"sensor.opti_grid_export_w": "600"}) == "True"
+
+
+def test_veto_bleibt_aus_unter_grenze():
+    assert bveto(**{"sensor.opti_grid_export_w": "400"}) == "False"
+
+
+def test_veto_haltet_im_hysteresband():
+    # Zwischen Aus- und Ein-Grenze bleibt ein bereits aktives Veto an ...
+    assert bveto(this_state="on", **{"sensor.opti_grid_export_w": "300"}) == "True"
+    # ... springt aber aus dem Aus-Zustand nicht an.
+    assert bveto(this_state="off", **{"sensor.opti_grid_export_w": "300"}) == "False"
+
+
+def test_veto_aus_unter_aus_grenze():
+    assert bveto(this_state="on", **{"sensor.opti_grid_export_w": "100"}) == "False"
+
+
+def test_veto_akkuunabhaengig_laden_zaehlt_dazu():
+    # DER Rueckkopplungsfall: der Akku laedt mit 3 kW und drueckt den gemessenen
+    # Export auf 0. Ohne Akku waeren es 3 kW -> das Signal darf sich nicht selbst
+    # abschalten, sonst schwingt der Modus (Live-Bug vom 03.07.2026).
+    assert bveto(this_state="on", **{"sensor.opti_grid_export_w": "0",
+                                     "sensor.opti_battery_power_w": "3000"}) == "True"
+
+
+def test_veto_entladen_wird_rausgerechnet():
+    # Akku entlaedt 800 W in den Export: gemessen 900 W, ohne Akku nur 100 W.
+    assert bveto(**{"sensor.opti_grid_export_w": "900",
+                    "sensor.opti_battery_power_w": "-800"}) == "False"
+
+
+def test_veto_fail_safe_bei_unavailable():
+    for quelle in ("sensor.opti_grid_export_w", "sensor.opti_battery_power_w"):
+        assert bveto(this_state="on", **{quelle: "unavailable"}) == "False", quelle
+
+
+def test_veto_delay_on_off_60s():
+    # 60 s statt 30 s: die Schwelle liegt unter der Hausgrundlast-Schwankung.
+    entity = _entity("opti_ueberschuss_veto_aktiv")
+    assert entity["delay_on"] == {"seconds": 60}
+    assert entity["delay_off"] == {"seconds": 60}
+
+
+def test_veto_trigger_und_condition_in_automation():
+    from .ha_harness import find_automation_condition
+    cfg = _automation()
+    assert "binary_sensor.opti_ueberschuss_veto_aktiv" in _flat(cfg[0]["triggers"])
+    cond = _flat(find_automation_condition(
+        cfg, "Modus 'Dynamisch': echter Netz-Ueberschuss sticht Ziel-SoC-Deckel"))
+    assert "binary_sensor.opti_ueberschuss_veto_aktiv" in cond
+    # Kein Rohwert-Vergleich im Zweig (Entprellung lebt im Sensor).
+    assert "sensor.opti_grid_export_w" not in cond
+    # Harter maxsoc-Deckel bleibt gewahrt.
+    assert "input_number.maxsoc" in cond

--- a/tests/test_ueberschuss_entprellung.py
+++ b/tests/test_ueberschuss_entprellung.py
@@ -163,6 +163,7 @@ def test_automation_conditions_nutzen_binaersensoren():
 
 VETO_BASIS = {
     "sensor.opti_grid_export_w": "0",
+    "sensor.opti_grid_import_w": "0",
     "sensor.opti_battery_power_w": "0",
     "input_number.akkusteuerung_ueberschuss_veto_grenze": "500",
     "input_number.akkusteuerung_ueberschuss_veto_aus_grenze": "250",
@@ -247,3 +248,37 @@ def test_veto_helfer_erststart_werte_brauchbar():
     assert ein["min"] >= 200, "Erststart-Schwelle zu tief"
     assert aus["min"] > 0, "Halteband beim Erststart wirkungslos"
     assert aus["min"] < ein["min"], "Aus-Grenze muss unter der Ein-Grenze liegen"
+
+
+# --- Import-Term (Review Fable 5, 2026-08-15) -------------------------------
+# Erst `export - import + battery` ist exakt `PV - Hauslast`. Ohne den
+# Import-Term meldet der Sensor beim Netzladen Ueberschuss, wo gerade Strom
+# gekauft wird.
+
+def test_veto_netzladen_ist_kein_ueberschuss():
+    """DER Fall: Akku laedt mit 3 kW aus dem Netz. Export 0, Import 3000,
+    battery +3000. Ohne Import-Term ergaebe die Formel 3000 W 'Ueberschuss'."""
+    assert bveto(**{"sensor.opti_grid_export_w": "0",
+                    "sensor.opti_grid_import_w": "3000",
+                    "sensor.opti_battery_power_w": "3000"}) == "False"
+
+
+def test_veto_netzbezug_haus_ist_kein_ueberschuss():
+    # Nacht: PV 0, Hauslast 1000 W aus dem Netz, Akku idle.
+    assert bveto(this_state="on", **{"sensor.opti_grid_export_w": "0",
+                                     "sensor.opti_grid_import_w": "1000",
+                                     "sensor.opti_battery_power_w": "0"}) == "False"
+
+
+def test_veto_import_sensor_unavailable_fail_safe():
+    assert bveto(this_state="on", **{"sensor.opti_grid_export_w": "2000",
+                                     "sensor.opti_grid_import_w": "unavailable"}) == "False"
+
+
+def test_veto_im_zielregime_unveraendert():
+    # Export > 0 => Import = 0: der Term aendert nichts am bisherigen Verhalten.
+    assert bveto(**{"sensor.opti_grid_export_w": "600",
+                    "sensor.opti_grid_import_w": "0"}) == "True"
+    assert bveto(**{"sensor.opti_grid_export_w": "0",
+                    "sensor.opti_grid_import_w": "0",
+                    "sensor.opti_battery_power_w": "3000"}) == "True"

--- a/tests/test_ueberschuss_entprellung.py
+++ b/tests/test_ueberschuss_entprellung.py
@@ -167,13 +167,16 @@ VETO_BASIS = {
     "sensor.opti_battery_power_w": "0",
     "input_number.akkusteuerung_ueberschuss_veto_grenze": "500",
     "input_number.akkusteuerung_ueberschuss_veto_aus_grenze": "250",
+    "input_number.akkusteuerung_ueberschuss_veto_knappheit_faktor": "3",
 }
 
 
-def bveto(this_state="off", **overrides):
+def bveto(this_state="off", forecast_attrs=None, **overrides):
     states = dict(VETO_BASIS)
     states.update(overrides)
-    hass = FakeHass(states=states, this_state=this_state)
+    attrs = ({"sensor.opti_forecast_score": forecast_attrs}
+             if forecast_attrs is not None else {})
+    hass = FakeHass(states=states, attrs=attrs, this_state=this_state)
     return render(hass, _entity("opti_ueberschuss_veto_aktiv")["state"])
 
 
@@ -250,6 +253,17 @@ def test_veto_helfer_erststart_werte_brauchbar():
     assert aus["min"] < ein["min"], "Aus-Grenze muss unter der Ein-Grenze liegen"
 
 
+def test_veto_knappheits_faktor_helfer_hat_konservativen_erststart():
+    cfg = load_yaml(REPO / "packages" / "sma_helpers.yaml")["input_number"]
+    faktor = cfg["akkusteuerung_ueberschuss_veto_knappheit_faktor"]
+    assert "initial" not in faktor
+    assert faktor["min"] == 1
+    assert faktor["max"] == 10
+    assert faktor["step"] == 0.5
+    assert faktor["mode"] == "box"
+    assert "unit_of_measurement" not in faktor
+
+
 # --- Import-Term (Review Fable 5, 2026-08-15) -------------------------------
 # Erst `export - import + battery` ist exakt `PV - Hauslast`. Ohne den
 # Import-Term meldet der Sensor beim Netzladen Ueberschuss, wo gerade Strom
@@ -282,3 +296,68 @@ def test_veto_im_zielregime_unveraendert():
     assert bveto(**{"sensor.opti_grid_export_w": "0",
                     "sensor.opti_grid_import_w": "0",
                     "sensor.opti_battery_power_w": "3000"}) == "True"
+
+
+# --- Knappheits-Gate (2026-08-16) ------------------------------------------
+
+def test_veto_knappheits_gate_zu_am_reichtag_trotz_export():
+    attrs = {"pv_surplus_kwh": 51.5, "needed_full_kwh": 4.5}
+    assert bveto(forecast_attrs=attrs,
+                 **{"sensor.opti_grid_export_w": "600"}) == "False"
+
+
+def test_veto_knappheits_gate_offen_bei_unterdeckung():
+    attrs = {"pv_surplus_kwh": 10.0, "needed_full_kwh": 4.5}
+    assert bveto(forecast_attrs=attrs,
+                 **{"sensor.opti_grid_export_w": "600"}) == "True"
+
+
+def test_veto_knappheits_gate_halteband_verhindert_selbstabschaltung():
+    # Bei Faktor 3 liegt 15 kWh zwischen der Ein-Schwelle 13,5 kWh und der
+    # Halte-Schwelle 16,2 kWh. Nur ein bereits aktives Veto darf offen bleiben.
+    attrs = {"pv_surplus_kwh": 15.0, "needed_full_kwh": 4.5}
+    assert bveto(this_state="on", forecast_attrs=attrs,
+                 **{"sensor.opti_grid_export_w": "600"}) == "True"
+    assert bveto(this_state="off", forecast_attrs=attrs,
+                 **{"sensor.opti_grid_export_w": "600"}) == "False"
+
+
+def test_veto_knappheits_gate_fail_open_bei_fehlendem_forecast():
+    # Fehlende Attribute und explizite None-Werte duerfen den real gemessenen
+    # Export nicht unterdruecken.
+    assert bveto(**{"sensor.opti_grid_export_w": "600"}) == "True"
+    attrs = {"pv_surplus_kwh": None, "needed_full_kwh": None}
+    assert bveto(forecast_attrs=attrs,
+                 **{"sensor.opti_grid_export_w": "600"}) == "True"
+
+
+def test_veto_knappheits_gate_zu_wenn_akku_rechnerisch_voll():
+    attrs = {"pv_surplus_kwh": 0.0, "needed_full_kwh": 0.0}
+    assert bveto(this_state="on", forecast_attrs=attrs,
+                 **{"sensor.opti_grid_export_w": "600"}) == "False"
+
+
+def test_veto_knappheits_faktor_kommt_aus_helfer():
+    attrs = {"pv_surplus_kwh": 10.0, "needed_full_kwh": 4.0}
+    assert bveto(forecast_attrs=attrs,
+                 **{"sensor.opti_grid_export_w": "600",
+                    "input_number.akkusteuerung_ueberschuss_veto_knappheit_faktor": "2"}) == "False"
+    assert bveto(forecast_attrs=attrs,
+                 **{"sensor.opti_grid_export_w": "600",
+                    "input_number.akkusteuerung_ueberschuss_veto_knappheit_faktor": "3"}) == "True"
+
+
+def test_veto_knappheits_attribute_sind_beobachtbar():
+    entity = _entity("opti_ueberschuss_veto_aktiv")
+    hass = FakeHass(
+        states=VETO_BASIS,
+        attrs={"sensor.opti_forecast_score": {
+            "pv_surplus_kwh": 15.0,
+            "needed_full_kwh": 4.5,
+        }},
+        this_state="on",
+    )
+    assert render(hass, entity["attributes"]["knappheit_faktor"]) == "3.0"
+    assert render(hass, entity["attributes"]["pv_surplus_kwh"]) == "15.0"
+    assert render(hass, entity["attributes"]["needed_full_kwh"]) == "4.5"
+    assert render(hass, entity["attributes"]["knappheit_gate_offen"]) == "True"

--- a/tests/test_ueberschuss_entprellung.py
+++ b/tests/test_ueberschuss_entprellung.py
@@ -232,3 +232,18 @@ def test_veto_trigger_und_condition_in_automation():
     assert "sensor.opti_grid_export_w" not in cond
     # Harter maxsoc-Deckel bleibt gewahrt.
     assert "input_number.maxsoc" in cond
+
+
+def test_veto_helfer_erststart_werte_brauchbar():
+    """Review-Finding 15.08.2026: ein input_number ohne gespeicherten Zustand
+    startet auf `min`. Ohne brauchbare Minima stuende das Veto beim Erststart auf
+    einer unsinnigen Schwelle - und `aus = 0` haette das Halteband abgeschaltet.
+    `initial:` ist bewusst KEINE Loesung (ueberschreibt den restaurierten Wert bei
+    jedem Neustart), deshalb muessen die Minima selbst tragen."""
+    cfg = load_yaml(REPO / "packages" / "sma_helpers.yaml")["input_number"]
+    ein = cfg["akkusteuerung_ueberschuss_veto_grenze"]
+    aus = cfg["akkusteuerung_ueberschuss_veto_aus_grenze"]
+    assert "initial" not in ein and "initial" not in aus
+    assert ein["min"] >= 200, "Erststart-Schwelle zu tief"
+    assert aus["min"] > 0, "Halteband beim Erststart wirkungslos"
+    assert aus["min"] < ein["min"], "Aus-Grenze muss unter der Ein-Grenze liegen"


### PR DESCRIPTION
## Problem

Am 15.08. gingen 19,3 kWh fuer 10 ct ins Netz, waehrend der Ziel-SoC-Deckel den Akku ~2,5 h auf Ladeleistung 0 hielt - dafuer kam das Ueberschuss-Veto (Commits 1-3).
Am 16.08. (Reichtag, 51,5 kWh Rest-Ueberschuss vs. 4,5 kWh Bedarf) zeigte sich die Kehrseite: das Veto feuerte bei jedem Export > 500 W und lud den Akku ab Mittag voll - nur Hoch-SoC-Stunden, kein wirtschaftlicher Gewinn.

## Aenderung (Commit 4)

Knappheits-Gate im Binary Sensor: Veto nur noch bei `pv_surplus_kwh < needed_full_kwh * Faktor` (neuer Helfer, Betriebswert 3, Erststart 1). 20-%-Halteband gegen Selbstabschaltung beim Laden, Fail-Open bei fehlendem Forecast (der 15.08.-Verlustfall bleibt gefangen). Ausserdem: KI-Prompt-Leiter um das Veto ergaenzt (fehlte seit 15.08.), Doku korrigiert.

## Evidenz

- Testsuite: 461 passed (inkl. 7 neue Gate-Tests).
- Live seit 16.08.: Gate zu bei 10,7 kW Export (surplus 44,1 / needed 2,3 / f=3), Modus fiel korrekt auf "nur Entladen" zurueck, Akku 0 W. Beim Deploy nachgezogen: der Import-Term-Fix (1ada9e5) war committet, aber nie deployed.
- Bekannter HA-Quirk: Attribut `knappheit_faktor` erscheint erst nach der ersten Helfer-Aenderung (Initial-Render, selbstheilend, rein kosmetisch).

## Cross-Model-Review (REVIEW_POLICY)

- Commit 9449ffe: Implementierung GPT-5.6 Sol, unabhaengiges Review Fable 5 (Anthropic), 16.08.2026, Diff origin/main..9449ffe. Verdict: angenommen; 1 Minor (ungenaue Doku-Formulierung zum Halteband-Takt) vor Commit gefixt.
- Von Fable 5 verfasste Anteile (Doku-Satz, KI-Leiter-Renummerierung): Punktreview GPT-5.6 Sol via codex-ask, 16.08.2026, beide Pruefpunkte OK.
- Commits c73dd8b/30a73c1/1ada9e5 tragen laut Code-Kommentar den Cross-Review-Vermerk Fable 5 + GPT-5.6 Sol vom 15.08.2026 (Session vom 15.08.).
