### PR TITLE
docs(mapping): unique_id von der Entity-ID abgrenzen

### DIFF
--- a/opti_mapping.example.yaml
+++ b/opti_mapping.example.yaml
@@ -14,9 +14,20 @@
 #   opti_battery_power_w  += laden  (positiv = Batterie lädt)
 #
 # Jeder Sensor hat:
-#   unique_id: opti_mapping_<name>
-#   name: "Opti …" → HA leitet daraus sensor.opti_<name> ab
+#   unique_id: opti_mapping_<name>  - interne Kennung, KEINE Entity-ID
+#   name: "Opti …" → HA leitet daraus die Entity-ID sensor.opti_<name> ab
 #   availability: prüft ob die Pflicht-Quelle verfügbar ist
+#
+# Wichtig: Strategie, Dashboard und Doku sprechen die aus dem NAMEN abgeleitete
+# Entity-ID an, nie die unique_id. Beispiel: der Block mit
+# `unique_id: opti_mapping_battery_capacity_kwh` und
+# `name: "Opti Battery Capacity kWh"` erzeugt beim erstmaligen Anlegen die
+# Entity `sensor.opti_battery_capacity_kwh` - und genau die wird überall
+# erwartet. Beim ersten Start also einmal unter Entwicklerwerkzeuge → Zustände
+# gegenprüfen: existiert die ID bereits (etwa aus einem früheren Versuch),
+# hängt HA ein `_2` an, und eine spätere Umbenennung in der UI überschreibt
+# die ID ebenfalls. In beiden Fällen die Entity umbenennen statt die Strategie
+# anzupassen.
 # =============================================================================
 
 template:


### PR DESCRIPTION
Aus Issue #64: Ein Erstaufsetzer las im Dashboard `sensor.opti_battery_capacity_kwh`, fand in `opti_mapping.example.yaml` aber `opti_mapping_battery_capacity_kwh` und hielt eines von beiden für falsch.

Beides ist richtig, nur auf verschiedenen Ebenen: die `unique_id` ist die interne Kennung, die Entity-ID leitet HA aus dem `name:` ab. Der Kopfkommentar erklärt das jetzt an genau diesem Beispiel und nennt die zwei Fälle, in denen die tatsächliche Entity-ID abweicht (Kollision mit angehängtem `_2`, spätere Umbenennung in der UI) samt Handlungsanweisung: Entity umbenennen statt die Strategie anzupassen.

Reine Kommentar-Änderung, kein Sensor und keine Vorlage angefasst.

### Review nach REVIEW_POLICY.md

- Autor/Implementierung: Claude (Fable 5), 24.08.2026
- Unabhängiger Review: GPT-5.6 Sol (Codex), 24.08.2026, Commit-Bereich `9449ffe..d5883a4` (Diff gegen `main`)
- Verdikt: 1 Finding, behoben. Die erste Fassung war zu absolut formuliert ("erzeugt immer"); Kollisionen und UI-Umbenennungen fehlten. Jetzt als Standardfall plus Abweichungen beschrieben.
- Verifikation: `opti_mapping.example.yaml` parst, 431 Tests grün, Privacy-Scan des Diffs sauber.
