### PR TITLE
fix(onboarding): Ueberschuss-Grenze 0 heisst aus, Ladepreis darf negativ werden

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -150,6 +150,13 @@ der Wert jeden weiteren Neustart:
 | `input_number.opti_balancing_intervall_tage` | 0 Tage (= Watchdog aus) | 14 Tage |
 | `input_number.opti_balancing_karenz_tage` | 0 Tage | 3 Tage |
 | `input_number.opti_balancing_max_ct` | 0 ct/kWh (= kein bezahltes Netzladen) | 25 ct/kWh |
+| `input_number.opti_balancing_spreizungs_schwelle` | 0 mV (= bedarfsgesteuertes Balancing aus) | 35 mV |
+| `input_number.opti_balancing_bedarf_cooldown_tage` | 0 Tage | 5 Tage |
+| `input_number.akkusteuerung_wr_70proz_ueberschuss_grenze` | 0 W (= Override aus) | deine Einspeise-Abregelgrenze |
+| `input_number.akkusteuerung_wr_ac_ueberschuss_grenze` | 0 W (= Override aus) | AC-Nennleistung deines WR |
+| `input_number.opti_forecast_optimismus` | 0 % (= konservativ, kann so bleiben) | 40 % |
+| `input_number.ladepreis` | -1 EUR/kWh | nichts tun, wird automatisch gefüllt |
+| `input_number.mindestpreisdifferenz_lade_entladepreis` | 0 EUR/kWh | 0.08 EUR/kWh |
 | `input_boolean.opti_balancing_netzladen` | aus (= Balancing rein per PV) | nach Wunsch an |
 
 Die `opti_balancing_*`-Helfer steuern den **Balancing-/Deep-Charge-Watchdog**
@@ -165,6 +172,28 @@ daher nicht restart-dauerhaft. Der Schalter
 BMS-Balancing auch aus dem **Netz** laden darf; ohne ihn balancet er rein per PV. Er ist
 bewusst von `opti_prognose_netzladen` entkoppelt, damit Balancing-Netzladen unabhängig vom
 allgemeinen Prognose-Netzladen freigegeben werden kann.
+
+Die beiden **Überschuss-Grenzen** gehören zum Einspeise-Override: liegt die jeweilige
+Messgröße über der Grenze, lädt die Strategie auch über den Ziel-SoC hinaus, statt den
+Überschuss abregeln zu lassen.
+Die beiden Signale messen dabei Unterschiedliches.
+`wr_70proz_ueberschuss_grenze` vergleicht die **Netzeinspeisung ohne Akkueingriff**
+(Export plus Batterieleistung) und gehört auf die Leistung, ab der deine Einspeisung
+begrenzt wird - bei einer 70%-Regel also 0,7 × kWp in Watt.
+`wr_ac_ueberschuss_grenze` vergleicht die **PV-Leistung ohne Akkueingriff** und gehört auf
+die AC-Nennleistung deines Wechselrichters.
+Beide gelten bei **0 als nicht konfiguriert und schalten den Override ab** - sonst würde
+eine Grenze von 0 W jeden Export als Überschuss werten.
+Wirksam wird der Override ohnehin erst, wenn `input_boolean.opti_pv_ueberschuss_ladung`
+eingeschaltet ist (Schritt 9).
+
+`input_number.ladepreis` musst du **nicht** selbst setzen.
+Die Strategie schreibt dort den aktuellen Strompreis hinein, wenn sie den manuellen
+Netzlade-Booster (`input_boolean.hausakku_aus_netz_laden`) bei einem SoC über 99 % selbst
+abschaltet - negative Börsenpreise eingeschlossen, deshalb reicht der Helfer ins Negative.
+Zusammen mit `mindestpreisdifferenz_lade_entladepreis` ergibt er
+`sensor.opti_mindestentladepreis_ct_kwh`, der bislang nur informativ ist: er zeigt an und
+triggert die Automation, sperrt aber kein Entladen.
 
 **9. Einschalten:** die Strategie-Automation bleibt wirkungslos, solange ihr Master-Schalter
 aus ist - und frisch angelegte `input_boolean`-Helfer starten **aus** (kein `initial:`, siehe Schritt 8). Über die HA-Oberfläche auf **an** stellen:

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -271,7 +271,7 @@ Empfohlener Startwert aus dem Winter-Backtest-Sweep: **5 ct**.
 **Tuning-Runde Winter-Backtest (2026-07-02).**
 Beide Hebel wurden per gestuftem Parameter-Sweep gegen einen 120-Tage-Winter-Backtest (Nov 2025 - Feb 2026, echte Preise/Last/PV) kalibriert; `opti_netzlade_spread_ct` = 10 wurde dabei bestätigt (15 drückt die VE-Abdeckung unter die Vorgabe).
 Gewinner-Kombination: `opti_peak_min_aufschlag_ct` = 5, `opti_halte_spread_ct` = 5, `opti_netzlade_spread_ct` = 10.
-Die ersten beiden Helfer haben Template-Fallbacks (10 ct bzw. 3 ct) - diese gelten aber nur, wenn der jeweilige Helfer gar nicht existiert. Ein bereits angelegter Helfer gewinnt immer gegen den Fallback, auch mit dem Erststart-Wert 0 (siehe Erststart-Werte-Tabelle im README). Nach dem ersten Anlegen der Helfer also aktiv auf die empfohlenen Startwerte setzen, sonst steuert die Strategie mit 0 statt mit 5.
+Die ersten beiden Helfer haben Template-Fallbacks (10 ct bzw. 3 ct) - diese gelten aber nur, wenn der jeweilige Helfer gar nicht existiert. Ein bereits angelegter Helfer gewinnt immer gegen den Fallback, auch mit dem Erststart-Wert 0 (siehe Erststart-Werte-Tabelle in [installation.md](installation.md)). Nach dem ersten Anlegen der Helfer also aktiv auf die empfohlenen Startwerte setzen, sonst steuert die Strategie mit 0 statt mit 5.
 Ergebnis: VE-Stunden-Abdeckung aus dem Akku steigt von 26.2 % (alt) auf 32.9 %, die Mehrkosten der Peak-Allokation sinken von 17.07 EUR auf 3.61 EUR pro Winter (inkl. Rest-SoC-Korrektur), die PV-Verdrängung von 131 kWh auf 53 kWh.
 Das ursprüngliche Ziel "billiger als alt bei mehr VE-Abdeckung" wurde damit **nicht** erreicht - die Peak-Allokation kostet im Backtest-Winter noch ~3.6 EUR Aufpreis für +6.7 Prozentpunkte VE-Abdeckung.
 

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -57,7 +57,11 @@ template:
           {% set ein = states('input_number.akkusteuerung_wr_70proz_ueberschuss_grenze')|float(999999) %}
           {% set aus = ein - 1000 %}
           {% set war_an = this is defined and this.state == 'on' %}
-          {{ ok and (export_ohne_akku > ein
+          {# Grenze <= 0 = nicht konfiguriert = Funktion AUS (Repo-Idiom, wie
+             opti_balancing_spreizungs_schwelle). Ohne diesen Guard startet ein
+             frisch angelegter Helfer auf seinem min (0) und der Sensor waere
+             dauerhaft an, sobald ueberhaupt exportiert wird. #}
+          {{ ok and ein > 0 and (export_ohne_akku > ein
                      or (aus > 0 and export_ohne_akku >= aus and war_an)) }}
         attributes:
           export_ohne_akku_w: >
@@ -81,7 +85,9 @@ template:
           {% set ein = states('input_number.akkusteuerung_wr_ac_ueberschuss_grenze')|float(999999) %}
           {% set aus = ein - 300 %}
           {% set war_an = this is defined and this.state == 'on' %}
-          {{ ok and (ac_ohne_akku > ein
+          {# Grenze <= 0 = nicht konfiguriert = Funktion AUS, siehe Kommentar
+             beim 70%-Sensor oben. #}
+          {{ ok and ein > 0 and (ac_ohne_akku > ein
                      or (aus > 0 and ac_ohne_akku >= aus and war_an)) }}
         attributes:
           ac_ohne_akku_w: >

--- a/packages/sma_helpers.yaml
+++ b/packages/sma_helpers.yaml
@@ -8,8 +8,8 @@
 # ⚙️  WICHTIG: Die benutzerkonfigurierbaren Helfer haben bewusst KEIN `initial:`.
 #     Ohne `initial:` restauriert HA nach Neustarts den zuletzt gespeicherten
 #     Wert; frisch angelegte input_number starten auf ihrem Minimum. Daher nach
-#     dem ersten Anlegen einmalig die Erststart-Werte aus der Tabelle im README
-#     (Abschnitt "Schnell-Nachbau über Packages") über die HA-Oberfläche setzen.
+#     dem ersten Anlegen einmalig die Erststart-Werte aus der Tabelle in
+#     docs/installation.md (Schritt 8) über die HA-Oberfläche setzen.
 #     Ein vorhandenes `initial:` greift dagegen bei JEDEM HA-Start und verhindert
 #     die Wiederherstellung manueller Änderungen. Es wird unten nur dort benutzt,
 #     wo dieses feste Restart-Verhalten ausdrücklich Teil des Vertrags ist.
@@ -55,9 +55,14 @@ input_number:
 
   akkusteuerung_max_ladestaerke:
     name: "Akkusteuerung Max Ladestärke"
+    # step 1, damit exakte Hardware-Grenzen eintragbar sind (ein Box-Feld
+    # validiert gegen step: mit 100 waere z.B. 3018 W nicht speicherbar).
+    # Nebenwirkung: input_number.increment/decrement schrittet hier jetzt in
+    # 1-W-Schritten. Im Repo ruft das nichts auf; wer eigene Automationen damit
+    # gebaut hat, stellt sie auf input_number.set_value um.
     min: 0
     max: 10000
-    step: 100
+    step: 1
     unit_of_measurement: W
     mode: box
 
@@ -81,9 +86,10 @@ input_number:
 
   akkusteuerung_max_entladestaerke:
     name: "Akkusteuerung Max Entladestärke"
+    # step 1, siehe Max Ladestärke.
     min: 0
     max: 10000
-    step: 100
+    step: 1
     unit_of_measurement: W
     mode: box
 
@@ -132,7 +138,11 @@ input_number:
     # Wird automatisch vom aktuellen Strompreis befüllt wenn Netzladen aktiv ist.
     # Stellt den Preis dar, zu dem der Akku zuletzt netzgeladen wurde (EUR/kWh).
     # EINHEIT EUR/kWh (z.B. 0.306). opti_mindestentladepreis_ct_kwh rechnet ×100 nach ct.
-    min: 0
+    # min bewusst negativ: die Strategie schreibt hier nach dem Netzladen den
+    # zuletzt gezahlten Preis hinein. Bei negativem Boersenpreis wuerde ein
+    # min: 0 den input_number.set_value-Aufruf scheitern lassen - der Helfer
+    # bliebe auf dem alten Wert stehen. -1 deckt den EPEX-Preisboden ab.
+    min: -1
     max: 1
     step: 0.001
     unit_of_measurement: EUR/kWh

--- a/tests/test_ueberschuss_entprellung.py
+++ b/tests/test_ueberschuss_entprellung.py
@@ -153,3 +153,45 @@ def test_automation_conditions_nutzen_binaersensoren():
     assert "sensor.opti_grid_export_w" not in c70
     assert "binary_sensor.opti_ueberschuss_ac_aktiv" in cac
     assert "sensor.opti_pv_power_w" not in cac
+
+
+# --- Erststart-Guard: Grenze 0 = nicht konfiguriert = Funktion aus (2026-08-25) ---
+# Ein frisch angelegter input_number ohne `initial:` startet auf seinem Minimum.
+# Bei den Ueberschuss-Grenzen ist das 0 - ohne Guard waere der Sensor damit
+# dauerhaft an, sobald ueberhaupt exportiert wird, und der Override wuerde den
+# Ziel-SoC bei jedem Erstaufsetzer stechen (Issue #64).
+
+def test_70_grenze_null_ist_aus_trotz_export():
+    assert b70(**{"input_number.akkusteuerung_wr_70proz_ueberschuss_grenze": "0",
+                  "sensor.opti_grid_export_w": "19000"}) == "False"
+
+
+def test_ac_grenze_null_ist_aus_trotz_erzeugung():
+    assert bac(**{"input_number.akkusteuerung_wr_ac_ueberschuss_grenze": "0",
+                  "sensor.opti_pv_power_w": "10000"}) == "False"
+
+
+def test_70_grenze_null_haelt_auch_nicht_nach():
+    # Halteband darf einen bereits aktiven Sensor nicht am Leben halten,
+    # wenn die Grenze auf 0 zurueckfaellt.
+    assert b70(this_state="on",
+               **{"input_number.akkusteuerung_wr_70proz_ueberschuss_grenze": "0",
+                  "sensor.opti_grid_export_w": "19000"}) == "False"
+
+
+def test_ac_grenze_null_haelt_auch_nicht_nach():
+    assert bac(this_state="on",
+               **{"input_number.akkusteuerung_wr_ac_ueberschuss_grenze": "0",
+                  "sensor.opti_pv_power_w": "10000"}) == "False"
+
+
+def test_kleine_positive_grenze_funktioniert_weiter():
+    # Der Guard darf nur 0 (bzw. negativ) abschneiden, nicht kleine Grenzen.
+    assert b70(**{"input_number.akkusteuerung_wr_70proz_ueberschuss_grenze": "500",
+                  "sensor.opti_grid_export_w": "600"}) == "True"
+
+
+def test_fehlender_helfer_bleibt_fail_safe():
+    # Nicht existierender Helfer -> float(999999) -> praktisch nie an.
+    assert b70(**{"input_number.akkusteuerung_wr_70proz_ueberschuss_grenze": "unknown",
+                  "sensor.opti_grid_export_w": "19000"}) == "False"


### PR DESCRIPTION
Aus Issue #64: beim Abgleich der Live-Helferwerte gegen `packages/sma_helpers.yaml` sind drei Dinge aufgefallen, die nur einen **Erstaufsetzer** treffen.

**Überschuss-Override startete scharf.** Helfer ohne `initial:` starten beim ersten Anlegen auf ihrem Minimum, bei den beiden Überschuss-Grenzen also auf 0. Damit war `ein = 0`, und `binary_sensor.opti_ueberschuss_70_aktiv` / `_ac_aktiv` gingen an, sobald überhaupt etwas floss - der Override hätte bei jedem neuen Nutzer dauerhaft den Ziel-SoC gestochen, sobald er `opti_pv_ueberschuss_ladung` einschaltet (was Schritt 9 der Anleitung empfiehlt). Beide Sensoren behandeln eine Grenze <= 0 jetzt als „nicht konfiguriert = aus", analog zum etablierten `schwelle > 0` beim bedarfsgesteuerten Balancing. Bestehende Anlagen mit gesetzten Grenzen ändern ihr Verhalten nicht.

**`ladepreis` konnte nicht negativ werden.** Die Strategie schreibt dort den aktuellen Preis hinein, wenn sie den Netzlade-Booster bei SoC > 99 % abschaltet (`opti_strategie.yaml:866-886`). Bei negativem Börsenpreis scheiterte dieser `set_value`-Aufruf am `min: 0`; der Helfer wäre stale geblieben. Jetzt bis -1 EUR/kWh.

**`step: 1`** bei den Max-Stärke-Helfern, damit exakte Hardware-Grenzen wie 3018 W eintragbar sind.

Dazu Doku: die sieben in der Erststart-Tabelle fehlenden Helfer sind ergänzt, die beiden Überschuss-Signale getrennt erklärt, zwei Querverweise auf eine Tabelle „im README" korrigiert.

### Review nach REVIEW_POLICY.md

- Autor/Implementierung: Claude (Fable 5), 25.08.2026
- Unabhängige Reviews: Fable 5 (Design/Priorisierung) und GPT-5.6 Sol (Codex, Diff-Review), 25.08.2026, Basis `edb4876`
- Verdikt: Fable verwarf meinen ersten Fix-Vorschlag (`min`-Anhebung) zugunsten des Template-Guards und stufte meine Bewertung von `mindestentladepreis` als zu dramatisch ein (nur Trigger, nie Bedingung). Codex fand 4 Diff-Findings, alle behoben: Erststart-Wert von `ladepreis` in der Tabelle, Vermischung der beiden Überschuss-Signale, überdehnte Aussage zum Schreibzeitpunkt, `increment`-Nebenwirkung von `step: 1`.
- Verifikation: 437 Tests grün (6 neue für den Guard), YAML parst, Privacy-Scan sauber.
