### PR TITLE
docs: Ueberschuss-Veto und Erststart-Guard in README und Referenz nachziehen

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Der frühere manuelle Weg mit Flachdateien liegt zur Referenz unter [`old/README
 
 ## Strategie-Logik
 
-Die Strategie-Automation entscheidet den **Modus** via `input_select.akkusteuerung_modus` und berührt keine Hardware direkt; ein nachgelagerter Cleanup pflegt nur Booster und Ladepreis. Eine vollständige, laienverständliche Block-für-Block-Erklärung aller Entscheidungsoptionen, der Preisstufenlogik (`sensor.opti_price_level`), des MinSOC-Schutzes, der Wintermodus-Blöcke und der Bausteine (P10-Sicherheitsnetz, Decision-Trace, Balancing-Watchdog):
+Die Strategie-Automation entscheidet den **Modus** via `input_select.akkusteuerung_modus` und berührt keine Hardware direkt; ein nachgelagerter Cleanup pflegt nur Booster und Ladepreis. Eine vollständige, laienverständliche Block-für-Block-Erklärung aller Entscheidungsoptionen, der Preisstufenlogik (`sensor.opti_price_level`), des MinSOC-Schutzes, der Wintermodus-Blöcke und der Bausteine (P10-Sicherheitsnetz, Decision-Trace, Balancing-Watchdog, Überschuss-Veto mit Knappheits-Gate):
 **[docs/strategie-logik.md](docs/strategie-logik.md)**
 
 ---
@@ -199,6 +199,7 @@ Dieses Projekt lebt von der Community. Besonderer Dank geht an:
 
 | Datum | Was |
 |---|---|
+| Aug 2026 | Überschuss-Veto mit Knappheits-Gate: laufender Netzexport sticht den Ziel-SoC-Deckel, wenn der Rest-Forecast den Akku nicht mehr füllt (bei fehlendem Forecast bleibt das Gate offen). Dazu Onboarding-Härtung aus dem ersten Fremd-Setup: unkonfigurierte Überschuss-Grenzen schalten den Override ab statt ihn scharf zu stellen, `input_number.ladepreis` verträgt negative Börsenpreise, die Erststart-Tabelle ist vollständig und `unique_id` vs. Entity-ID im Mapping klargestellt |
 | Jul 2026 | Entlade-Peak-Allokation: berechneter Reserve-SoC, Peak-Leiter, Negativpreis- und Vorladeregel (neuer Adapter-Modus "Akku Netzladen"), Backtest gegen echte Winterdaten, Test-Harness für die Jinja-Templates, Viertelstunden-Preisraster |
 | Jun 2026 | Canonical-`opti_*`-Layer: Strategie hardware-agnostisch, prognosebasierter Ziel-SoC mit echter Schmitt-Hysterese, anbieter-agnostisches Preisniveau (Midrank-Perzentil), Vorschau-Sensor für Soll/Ist-Vergleich |
 | Sep 2025 | Neue Modbus-Adressen für direkte Lade-/Entladeleistungssteuerung - Steuerlogik stark vereinfacht, dynamischer Ziel-SoC und Prognose-Bewertung |

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -391,6 +391,8 @@ des betreffenden Sensors testen — häufig ist der Quell-Sensor noch falsch ben
 | `binary_sensor.opti_winter_charging_allowed` | Saisonales Lade-Gate (Standard: `true`, fail-open) |
 | `sensor.opti_peak_reserve_soc` | Reserve-SoC für kommende Preisspitzen (trigger-basiert, 36h-Horizont) |
 | `binary_sensor.opti_peak_reserve_aktiv` | Gate: Peaks im Wiederauflade-Horizont vorhanden |
+| `binary_sensor.opti_ueberschuss_70_aktiv` / `_ac_aktiv` | Überschuss-Override (30 s entprellt, mit Hysterese). Eine Grenze ≤ 0 gilt als *nicht konfiguriert* und schaltet den jeweiligen Override ab |
+| `binary_sensor.opti_ueberschuss_veto_aktiv` | Laufender Netzexport sticht den Ziel-SoC-Deckel, wenn der Rest-Forecast den Akku nicht mehr sicher füllt (Knappheits-Gate). Nur positiv belegter Überfluss sperrt das Veto; fehlt oder taugt der Forecast nicht, bleibt das Gate offen - siehe [strategie-logik.md](strategie-logik.md#das-überschuss-veto-knappheit-entscheidet-über-den-ziel-soc-deckel-option-19) |
 | `sensor.opti_balancing_watchdog` | Balancing-/Deep-Charge-Watchdog (`aus`/`pv`/`netz`): erzwingt einen Voll-Zyklus fürs BMS, wenn `counter.tage_seit_akku100` ≥ `input_number.opti_balancing_intervall_tage` (Default 14; 0 = aus). Staffelt PV (tagsüber) → Gratis-/Negativ-Netz → bezahltes Netz erst nach `opti_balancing_karenz_tage` und nur ≤ `opti_balancing_max_ct`. Beide `netz`-Zweige hängen am eigenen Schalter `input_boolean.opti_balancing_netzladen` (Default aus, PV ungegatet). Die Fälligkeit bleibt bis zu 30 bestätigten Minuten über dem Done-SoC aktiv; persistente Minuten-, Zeitstempel- und Gültigkeits-Helfer machen den Ablauf restartfest, unterscheiden HA-Erstwerte von echten Abschlüssen und begrenzen ihn auf einen Abschluss pro Tag. |
 
 **Baustein `sensor.opti_house_consumption_60min_w` (`packages/sma_statistik.yaml`):**
@@ -429,7 +431,7 @@ Details: `docs/superpowers/specs/2026-07-10-ki-analyse-schicht-design.md` (lokal
 |---|---|---|---|
 | **Nacht / Reserve halten (Entladesperre)** | `opti_forecast_score` ≤ 2, SoC < 30 %, `opti_price_level` CHEAP | **Akku nur Laden** | Gate `input_boolean.opti_prognose_netzladen` muss `on` sein |
 | **Nacht / kein Ladegrund** | Score ≤ 2, SoC > 60 %, Preis EXPENSIVE | **Akku Dynamisch** (Default) | Kein Ladeblock greift → Default-Pfad |
-| **Sonne / PV-Überschuss** | `binary_sensor.opti_ueberschuss_70_aktiv` = on (Export + Batterieleistung > 70%-Grenze, 30 s entprellt, 1 kW Hysterese), SoC < 100 % | **Akku Dynamisch** | Gate `input_boolean.opti_pv_ueberschuss_ladung` muss `on` sein |
+| **Sonne / PV-Überschuss** | `binary_sensor.opti_ueberschuss_70_aktiv` = on (Export + Batterieleistung > 70%-Grenze, 30 s entprellt, 1 kW Hysterese), SoC < 100 % | **Akku Dynamisch** | Gate `input_boolean.opti_pv_ueberschuss_ladung` muss `on` sein; eine Grenze von 0 schaltet den Override ab, statt ihn dauernd auszulösen |
 | **Tagsüber unter Ziel-SoC** | SoC < `opti_target_soc` **− 3 %**, nach Sonnenaufgang | **Akku Dynamisch** | Option „Dynamisch laden wenn SOC < ZielSoC"; das ±3 %-Band verhindert Modus-Pendeln direkt an der Ziel-Kante — siehe [strategie-logik.md](strategie-logik.md#der-intelligente-ziel-soc--herzstück-der-akkuschonung) |
 | **Entladen über Ziel-SoC** | SoC > `opti_target_soc` **+ 3 %** | **Akku nur Entladen** | Option „Nur Entladen wenn SOC > DynZielSoC" |
 | **MinSOC-Schutz** | SoC < `input_number.minsoc` | **Akku nur Laden** | Höchste Priorität, überstimmt alle anderen Blöcke |

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -778,7 +778,7 @@ Netzladen parallel zur Schnellladung ist bewusst erlaubt (Anschlussleistung reic
 
 | Eigenschaft | Wert |
 |---|---|
-| Bedingung | `binary_sensor.opti_ueberschuss_70_aktiv` = on (Export **plus Batterieleistung** über der 70%-Grenze, 30 s entprellt, 1 kW Hysterese), SoC < 100 %, tagsüber |
+| Bedingung | `binary_sensor.opti_ueberschuss_70_aktiv` = on (Export **plus Batterieleistung** über der 70%-Grenze, 30 s entprellt, 1 kW Hysterese), SoC < 100 %, tagsüber. Eine Grenze ≤ 0 gilt als nicht konfiguriert und hält den Sensor aus - sonst wäre er beim Erstaufsetzer dauerhaft an |
 | Preis | irrelevant |
 | Tageszeit | nach Sonnenaufgang bis Sonnenuntergang |
 | Gesetzter Modus | **Akku Dynamisch** |


### PR DESCRIPTION
Beide August-Änderungen waren gemergt, aber nur in `strategie-logik.md` beschrieben. Dieser PR zieht README und Referenz nach.

**`canonical-layer.md`** führt die drei Überschuss-Binärsensoren jetzt in der Sensor-Referenz. Beim Veto steht ausdrücklich die Fail-Richtung dabei: nur positiv belegter Überfluss sperrt es, ein fehlender oder untauglicher Forecast lässt es zu. Die Zweig-Tabellen in beiden Doku-Dateien sagen außerdem, dass eine Überschuss-Grenze <= 0 als „nicht konfiguriert" gilt und den Override abschaltet - vorher beschrieben sie das Verhalten vor #66.

**README**: Changelog-Zeile für August (Veto mit Knappheits-Gate, Onboarding-Härtung, negativer Ladepreis, `unique_id`-Klarstellung) und das Veto in der Bausteine-Aufzählung des Strategie-Abschnitts.

Reine Dokumentation, kein Template und keine Automation angefasst.

### Review nach REVIEW_POLICY.md

- Autor: Claude (Fable 5), 25.08.2026
- Unabhängiger Review: GPT-5.6 Sol (Codex), 25.08.2026, Basis `c336c9c`
- Verdikt: 2 Findings, beide behoben. Meine erste Formulierung „nur wenn der Rest-Forecast den Akku nicht mehr füllt" war zu absolut - das Gate ist bei fehlendem Forecast bewusst fail-open. Die Changelog-Zeile ließ zwei im August gemergte Änderungen aus (#65, negativer Ladepreis aus #66).
- Verifikation: 467 Tests grün, Anker-Link auf `strategie-logik.md` geprüft.
