### PR TITLE
Ladedeckel, Restlaufzeit und BYD-Sensormetadaten korrigieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Die Strategie-Automation entscheidet den **Modus** via `input_select.akkusteueru
 
 ## Entwicklung & Tests
 
+Architektur, Zuständigkeiten und offene Wartungsthemen:
+**[Projektüberblick](docs/projektueberblick.md)**.
+
 Für die reine Nutzung wird kein Python gebraucht - das Repo liefert HA-YAML aus.
 Wer aber an den Templates oder der Strategie schraubt, sollte die Testsuite laufen lassen:
 Sie rendert die Jinja-Templates aus den aktiven `packages/` und die Bedingungen aus `automations/` gegen einen nachgebauten HA-Zustand und prüft die Ergebnisse; `legacy/` und `old/` sind bewusst nicht abgedeckt, das sind Archive.
@@ -199,6 +202,7 @@ Dieses Projekt lebt von der Community. Besonderer Dank geht an:
 
 | Datum | Was |
 |---|---|
+| Sep 2026 | Ladedeckel-Hysterese mit eigenem restauriertem Merker (#68), PV-Verfügbarkeit und Restenergie-Formel der Laufzeitanzeigen korrigiert, BYD-Diagnosekurven mit kompatiblen Statistik-Klassen (#64) |
 | Aug 2026 | Überschuss-Veto mit Knappheits-Gate: laufender Netzexport sticht den Ziel-SoC-Deckel, wenn der Rest-Forecast den Akku nicht mehr füllt (bei fehlendem Forecast bleibt das Gate offen). Dazu Onboarding-Härtung aus dem ersten Fremd-Setup: unkonfigurierte Überschuss-Grenzen schalten den Override ab statt ihn scharf zu stellen, `input_number.ladepreis` verträgt negative Börsenpreise, die Erststart-Tabelle ist vollständig und `unique_id` vs. Entity-ID im Mapping klargestellt |
 | Jul 2026 | Entlade-Peak-Allokation: berechneter Reserve-SoC, Peak-Leiter, Negativpreis- und Vorladeregel (neuer Adapter-Modus "Akku Netzladen"), Backtest gegen echte Winterdaten, Test-Harness für die Jinja-Templates, Viertelstunden-Preisraster |
 | Jun 2026 | Canonical-`opti_*`-Layer: Strategie hardware-agnostisch, prognosebasierter Ziel-SoC mit echter Schmitt-Hysterese, anbieter-agnostisches Preisniveau (Midrank-Perzentil), Vorschau-Sensor für Soll/Ist-Vergleich |

--- a/automations/opti_strategie.yaml
+++ b/automations/opti_strategie.yaml
@@ -47,7 +47,7 @@
     # "Already running"-Warnungen fuer diese Automation.
     #
     # Das ist unkritisch, weil die modusabhaengigen Hysterese-Baender
-    # (Ladedeckel +3, Ziel-SoC +0/+3, L3/L4 +5/+3, Netzlade-Stopband) allesamt
+    # (Ziel-SoC +0/+3, L3/L4 +5/+3, Netzlade-Stopband) allesamt
     # Schmitt-Trigger sind: sie verbreitern die Haltezone des AKTUELLEN Modus.
     # Ein einmal erreichter Modus haelt sich damit selbst, statt zurueckzukippen.
     # In seltenen Konstellationen sind zwei Uebergaenge noetig (Beispiel aus der
@@ -58,6 +58,12 @@
       entity_id:
         - input_select.akkusteuerung_modus
       id: "Modus extern geändert"
+    # Der restaurierte Ladedeckel-Merker kann nach dem SoC-Trigger aktualisieren.
+    # Sein Update muss deshalb eine zweite Bewertung ausloesen koennen.
+    - trigger: state
+      entity_id:
+        - binary_sensor.opti_ladedeckel_aktiv
+      id: "Ladedeckel geändert"
     # Batterie-SoC (Canonical) statt Hardware-Rohsensor
     - trigger: state
       entity_id:
@@ -375,8 +381,11 @@
         # Default) den Modus auf 'Akku Dynamisch', worauf der WR freien PV-
         # Ueberschuss ueber maxsoc trickelt (beobachtet 2026-07-13: 99 % bei
         # maxsoc 95). 'Akku nur Entladen' zwingt den Adapter auf Ladeleistung 0.
-        # Asymmetrische Hysterese (rein bei >= maxsoc, drin bis < maxsoc-3) gegen
-        # Modus-Flattern an der Kante - selbe Philosophie wie der Ziel-SoC-Zweig.
+        # Asymmetrische Hysterese: rein bei >= maxsoc, halten bis < maxsoc-3.
+        # Nur der eigene Merker opti_ladedeckel_aktiv belegt einen echten Eintritt;
+        # ein fremdes "nur Entladen" aktiviert das Band nicht (#68). Der Merker
+        # muss zur aktuellen Grenze passen. Direkter SoC-Vergleich bleibt noetig:
+        # Obergrenze/Unterschreitung wirken auch vor dem naechsten Sensor-Update.
         # ---------------------------------------------------------------------
         - alias: "Modus 'nur Entladen' (Ladedeckel): SoC >= maxsoc, kein Balancing/Peak faellig"
           conditions:
@@ -393,10 +402,12 @@
               state: "off"
             - condition: template
               value_template: >-
-                {% set band = 3 if is_state('input_select.akkusteuerung_modus', 'Akku nur Entladen') else 0 %}
+                {% set maximum = states('input_number.maxsoc')|float(95) %}
+                {% set band = 3 if is_state('binary_sensor.opti_ladedeckel_aktiv', 'on')
+                    and state_attr('binary_sensor.opti_ladedeckel_aktiv', 'maxsoc')|float(-1) == maximum else 0 %}
                 {{ has_value('sensor.opti_soc')
-                   and has_value('input_number.maxsoc')
-                   and (states('sensor.opti_soc') | float) >= (states('input_number.maxsoc') | float(95) - band) }}
+                   and is_number(states('input_number.maxsoc'))
+                   and (states('sensor.opti_soc') | float) >= maximum - band }}
           sequence:
             - action: input_select.select_option
               data:

--- a/docs/byd-modul2-fruehwarnung.md
+++ b/docs/byd-modul2-fruehwarnung.md
@@ -51,6 +51,23 @@ Der Messzyklus läuft als Zustandsmaschine (`input_select.byd_knie_zyklus_status
 
 Das Attribut `sauberer_zyklus` markiert Zyklen ohne nennenswerte Zwischenladung (< 0,5 kWh geladen seit Voll); nur diese sind untereinander streng vergleichbar.
 
+### Statistik-Klassen der Diagnosekurven
+
+`byd_nettoenergie_seit_voll` und `byd_modul_2_nettoenergie_bis_knie` bleiben
+kWh-Diagnosekurven mit `state_class: measurement`, aber ohne `device_class: energy`.
+Die bisherige Kombination wurde von HA als ungültig gemeldet (#64).
+Ausgewertet werden die absoluten Zykluswerte und deren Min/Max/Mittelwerte,
+keine aufsummierten Energieumsätze. Insbesondere ein kleinerer Knie-Wert muss
+als kleinerer Messwert sichtbar bleiben. `total` oder `total_increasing` würden
+hier eine andere Statistik erzeugen. Die eigentlichen Energiezähler bleiben die
+beiden `utility_meter` mit ihren jeweiligen Quellzählern.
+
+Entity-IDs, Mess-Anker und Kurven bleiben erhalten. Nach einem Update die
+Statistik-Reparaturen in HA prüfen; vorhandene Recorder-Daten werden durch diese
+Dateiänderung weder gelöscht noch rückwirkend umgerechnet.
+Die [HA-Dokumentation zu Sensor-Statistiken](https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics)
+beschreibt die Unterscheidung zwischen Messwerten und Zählern.
+
 ### Bestätigungszähler statt `for:` - Zähler-Mechanik und Mess-Anker
 
 Die Knie-Erkennung läuft bewusst **nicht** über eine `for:`-Haltezeit.

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -387,7 +387,8 @@ des betreffenden Sensors testen — häufig ist der Quell-Sensor noch falsch ben
 | `sensor.opti_charge_power_w` | Dynamische Ladestärke (W) nach SoC-Stufe und Forecast-Score |
 | `sensor.opti_price_level` | Preisniveau-Enum (VERY_CHEAP / CHEAP / NORMAL / EXPENSIVE / VERY_EXPENSIVE); Midrank-Perzentil (Gleichstände zählen halb) - flache Preistage (viele identische Werte) landen dadurch bei NORMAL statt fälschlich bei VERY_EXPENSIVE. Fail-closed: < 4 verwertbare Preise → `unavailable` |
 | `sensor.opti_mindestentladepreis_ct_kwh` | Mindestentladepreis = Ladepreis + Preisdifferenz (ct/kWh) |
-| `sensor.opti_runtime_h` | Geschätzte Akku-Restlaufzeit (Stunden) |
+| `sensor.opti_runtime_h` | Geschätzte Akku-Restlaufzeit aus Nennkapazität × SoC oberhalb MinSOC / Hausverbrauch |
+| `binary_sensor.opti_ladedeckel_aktiv` | Restaurierter Merker: aktuelle MaxSOC-Grenze erreicht, halten bis 3 Prozentpunkte darunter; unabhängig vom Modus |
 | `binary_sensor.opti_winter_charging_allowed` | Saisonales Lade-Gate (Standard: `true`, fail-open) |
 | `sensor.opti_peak_reserve_soc` | Reserve-SoC für kommende Preisspitzen (trigger-basiert, 36h-Horizont) |
 | `binary_sensor.opti_peak_reserve_aktiv` | Gate: Peaks im Wiederauflade-Horizont vorhanden |
@@ -399,7 +400,17 @@ des betreffenden Sensors testen — häufig ist der Quell-Sensor noch falsch ben
 Gleitender 60-Minuten-Mittelwert von `sensor.opti_house_consumption_w` (Legacy-Muster, `state_characteristic: mean`).
 `opti_forecast_score`, `opti_forecast_score_tomorrow` und `opti_target_soc` lesen bevorzugt diesen geglätteten Wert statt des Momentanverbrauchs, damit kurze Lastspitzen (z. B. ein Wasserkocher) den Score nicht minütlich kippen lassen.
 Fehlt der Statistik-Sensor noch (z. B. direkt nach einem HA-Neustart), fällt die Formel auf den Momentanwert zurück.
-`sensor.opti_runtime_h` bleibt bewusst beim Momentanwert - die Restlaufzeit soll den aktuellen Verbrauchszug zeigen, keinen Mittelwert.
+`sensor.opti_runtime_h` bleibt beim momentanen Hausverbrauch. Die Formel ist
+`Kapazität_kWh * max(0, SoC - MinSOC) / 100 / Hausverbrauch_kW`.
+`maxsoc` ist eine Ladegrenze und verkleinert weder die vorhandene Energie nach einer
+Balancing-Vollladung noch vergrößert es die Nennkapazität durch Normierung.
+Bei 10 kWh, 50 % SoC, 10 % MinSOC und 1 kW Last ergibt das 4 Stunden.
+Fehlende oder nicht numerische Eingänge einschließlich PV und MinSOC ergeben
+`unavailable`; die Zustandsvorlage selbst liefert dann `none` statt eines Textwertes.
+Die bisherigen Anzeige-Konventionen bleiben: ab 100 W PV = 0, bei Last 0 = 999,
+sonst höchstens 24 Stunden. Das ist eine Schätzung ohne Verlustmodell und keine
+Garantie bis zum nächsten Netzbezug. Der Legacy-Sensor verwendet dieselbe Restenergie,
+aber weiterhin die gemittelte Akku-Entladeleistung als Nenner.
 
 > **Warnung — `opti_winter_charging_allowed`:** Dieses Gate ist **fail-open** (`{{ true }}`).
 > Solange kein realer Saisonal-Sensor gemappt ist, ist es immer `on`.

--- a/docs/canonical-layer.md
+++ b/docs/canonical-layer.md
@@ -410,7 +410,8 @@ Fehlende oder nicht numerische Eingänge einschließlich PV und MinSOC ergeben
 Die bisherigen Anzeige-Konventionen bleiben: ab 100 W PV = 0, bei Last 0 = 999,
 sonst höchstens 24 Stunden. Das ist eine Schätzung ohne Verlustmodell und keine
 Garantie bis zum nächsten Netzbezug. Der Legacy-Sensor verwendet dieselbe Restenergie,
-aber weiterhin die gemittelte Akku-Entladeleistung als Nenner.
+aber weiterhin den Betrag der gemittelten signierten Akkuleistung als Nenner,
+auch wenn die Quelle gerade Laden meldet.
 
 > **Warnung — `opti_winter_charging_allowed`:** Dieses Gate ist **fail-open** (`{{ true }}`).
 > Solange kein realer Saisonal-Sensor gemappt ist, ist es immer `on`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -212,6 +212,29 @@ HA-Oberfläche weiter an die eigene Anlage anpassen (alle als Helfer vorhanden).
 
 ---
 
+## Aktualisierung bestehender Installationen (September 2026)
+
+Strategie und `opti_derived.yaml` gemeinsam aktualisieren: der Ladedeckel verwendet
+jetzt `binary_sensor.opti_ladedeckel_aktiv` aus den abgeleiteten Sensoren. Keine
+zusätzlichen UI-Helfer und keine Änderung des Adapter-Vertrags sind erforderlich.
+Die direkte MaxSOC-Grenze wirkt auch ohne den neuen Merker; dessen Halteband ist
+aber erst mit der neuen Sensor-Datei verfügbar. Das private Mapping bleibt erhalten.
+
+Vor dem Einspielen die betroffenen Live-Dateien sichern. Bestehende Package-Wrapper
+(`automation:`), `initial_state`-Anpassungen und benutzerspezifische Include-Pfade
+beibehalten. Optionales BYD-Monitoring benötigt zusätzlich das aktualisierte
+`byd_modul2_fruehwarnung.yaml`; bei Nutzung der alten Laufzeitanzeige auch
+`sma_templates.yaml` mit den eigenen Quell-Entitäten aktualisieren.
+
+Nach HA-Konfigurationsprüfung und Freigabe der Betriebsunterbrechung neu starten,
+oder Templates vor den Automationen neu laden. Reloads verwerfen laufende
+Automationsausführungen; das deshalb in einem geeigneten Betriebsfenster tun.
+Prüfen: neuer Ladedeckel-Sensor vorhanden, Vorschau plausibel, Adapter-Keepalive
+aktuell, keine neuen Template- oder Statistik-Warnungen. Der Merker wird bei
+Neustart/Quelländerung und spätestens am nächsten Minutentick ausgewertet.
+Bei Erstinstallation unterhalb MaxSOC beginnt er ohne belegten Eintritt.
+Für Rollback die gesicherten Dateien gemeinsam wiederherstellen und erneut laden.
+
 ## Legacy-Setup (Referenz)
 
 Der frühere manuelle Weg mit Flachdateien (Modbus-Config, Sensoren, Helfer-Tabelle, Dashboard-Karte) ist umgezogen nach [`old/README.md`](../old/README.md).

--- a/docs/projektueberblick.md
+++ b/docs/projektueberblick.md
@@ -1,0 +1,95 @@
+# Projektüberblick und Wartungsstand
+
+Stand: September 2026. Die Steuerung ist ein Satz Home-Assistant-Packages,
+keine eigene Integration und kein Python-Dienst. Python dient Tests und Simulation.
+
+## Datenfluss und Zuständigkeiten
+
+```mermaid
+flowchart LR
+    Quellen[WR, Strompreis, Solcast] --> Mapping[Privates opti_mapping.yaml]
+    Mapping --> Statistik[sma_statistik.yaml]
+    Mapping --> Derived[opti_derived.yaml]
+    Statistik --> Derived
+    Derived --> Strategie[opti_strategie.yaml]
+    Helfer[sma_helpers.yaml] --> Derived
+    Helfer --> Strategie
+    Strategie --> Modus[input_select.akkusteuerung_modus]
+    Modus --> Adapter[Separater Modbus-Adapter]
+    Derived --> Adapter
+    Adapter --> WR[Wechselrichter]
+    WR --> Waechter[Adapter-Wächter]
+    Derived --> Dashboard[Dashboard und optionale KI-Analyse]
+```
+
+| Baustein | Aufgabe und wichtige Grenze |
+|---|---|
+| `opti_mapping.example.yaml` | Vorlage zur Normalisierung von Quellen auf `opti_*`, W, kWh und ct/kWh. Das ausgefüllte `packages/opti_mapping.yaml` bleibt privat. |
+| `packages/opti_derived.yaml` | Prognose-Scores, Ziel-SoC, Ladeleistung, Preisniveau, Überschuss-Signale, Peak-Reserve, Balancing-Fälligkeit, Ladedeckel-Merker und Vorschau. |
+| `automations/opti_strategie.yaml` | Priorisierte Entscheidung mit 22 Zweigen und Default; setzt den Modus und pflegt nachgelagert Booster/Ladepreis. Separater Fail-safe bei ungültigen Kerndaten. |
+| `packages/sma_helpers.yaml` | Persistente Parameter und Schalter. Ohne `initial` restauriert HA vorhandene Werte; Erststart-Minima müssen bewusst gesetzt werden. |
+| `packages/sma_statistik.yaml` | Gleitende Lastmittelwerte. Batterie-Leistung ist signiert, Hausverbrauch nicht. |
+| `automations/opti_balancing_counter.yaml` | Bestätigt den Balancing-Abschluss über Minutenticks und persistente Helfer. |
+| `packages/opti_ev_sperre.yaml` | Optionale Entladesperre bei evcc-Schnellladung, einschließlich Halten bei Datenlücken. |
+| `packages/byd_monitoring.yaml` | Native BYD-Messwerte, Frischeprüfung und Alarme. Die Ruhe-Spreizung beeinflusst optional die Balancing-Fälligkeit. |
+| `packages/byd_modul2_fruehwarnung.yaml` | Zyklusgebundene Messungen am schwächsten Modul, mit Anker, Bestätigungen und Invalidierung. |
+| `packages/byd_knie_spreizung.yaml` | Verlauf der Zellspreizung am Ladeschluss, inklusive abgeschlossener Episoden. |
+| `packages/opti_ki_analyse.yaml` und gleichnamige Automation | Kennzahlen und optionaler Tagesreport über `ai_task`; kann Benachrichtigungen senden, steuert den Akku nicht. |
+| `dashboard-template/` | Anzeige und Bedienelemente; setzt die dokumentierten Entitäten und Karten voraus. |
+| `packages/sma_templates.yaml` | Noch verwendbares Legacy-Pendant mit eigenen Quell-Platzhaltern. Nicht gleichbedeutend mit den archivierten Verzeichnissen `old/` und `legacy/`. |
+| `packages/sma_modbus.yaml` | Optionaler SMA-Hub. Nicht zusätzlich laden, wenn derselbe Hub schon aus dem Adapter-Setup kommt. |
+| Separates Adapter-Repository | Übersetzt Modi in Registerfolgen. Queued-Ausführung, Stale-Guard, Sperrfenster, Keepalive und Wirkungswächter bleiben dort. |
+
+## Korrekturen dieser Wartungsrunde
+
+- **#68:** Der Ladedeckel merkt einen tatsächlich erreichten MaxSOC unabhängig
+  vom Modus. Das Halteband bleibt 3 Prozentpunkte breit. Grenzwertänderung,
+  Datenlücke, Neustart und Reihenfolge der Sensor-Updates sind berücksichtigt.
+  Strategie, Vorschau und Simulator verwenden den Merker.
+- **Laufzeitanzeigen:** Alle benötigten Messwerte einschließlich PV werden
+  geprüft. Restenergie ist Nennkapazität mal SoC-Differenz oberhalb MinSOC.
+  Die alte Normierung auf das MinSOC/MaxSOC-Fenster entfällt. Der Legacy-Sensor
+  verwendet weiterhin den Betrag der signierten Batterielast.
+- **#64:** Die beiden BYD-Diagnosekurven behalten kWh und Messwertstatistiken,
+  verlieren aber die inkompatible Geräteklasse `energy`. IDs bleiben gleich;
+  es findet keine Löschung oder nachträgliche Umrechnung von Recorder-Daten statt.
+- Installations-, Strategie- und Sensorreferenz beschreiben die Änderungen.
+
+Die MinSOC-, Peak-, Balancing- und EV-Prioritäten wurden dabei beibehalten.
+Neue Tarifoptimierung oder zusätzliche Hardware-Modi sind nicht Teil dieser Runde.
+
+## Prüfung
+
+Die reguläre Suite rendert die tatsächlichen YAML-/Jinja-Vorlagen, prüft alle
+Strategiezweige gegen die Vorschau sowie Neustart-, Fehler- und Hysterese-Fälle.
+Die 12 Tests des privaten Mappings bleiben ohne lokale Mapping-Datei übersprungen.
+
+Zusätzlich ist eine isolierte Prüfung mit echtem HA verfügbar (Python 3.14):
+
+```bash
+python3 -m venv /tmp/opti-ha-test
+/tmp/opti-ha-test/bin/pip install homeassistant==2026.9.0
+/tmp/opti-ha-test/bin/python tools/validate_ha.py
+```
+
+Sie prüft native Template-/Automations-Schemas und führt mit synthetischen
+Sensoren Ereignisfolgen, Datenlücken und einen echten HA-Neustart durch.
+Es wird keine Verbindung zur Anlage aufgebaut. Modbus-Wirkung und Geräteverhalten
+brauchen weiterhin eine gesondert freigegebene Live-Prüfung.
+
+## Nächste sinnvolle Arbeiten
+
+| Thema | Einordnung |
+|---|---|
+| #40 Datenqualität und Schreibkontrolle | Mit vorhandenen Schutzmechanismen abgleichen: SoC/Kapazitäts-Fail-safe, Preis-Ausfallverhalten und Adapter-Wirkungswächter sind vorhanden. Vollständige Frischeprüfung und Sollwertbestätigung fehlen weiterhin. SMA-Schreibregister liefern laut Adapter-Dokumentation kein verlässliches Read-back; daher kein blindes „schreiben, zurücklesen, wiederholen“. |
+| #41 Zykluskosten | Parameter und Wirtschaftlichkeitsannahmen getrennt prüfen. Erst als nachvollziehbare Anzeige ergänzen, bevor Ladeentscheidungen verändert werden. |
+| #42 Reserve bis zum Wiederaufladen | Die bestehende Peak-Reserve erweitern statt eine konkurrierende Entladegrenze einzuführen. Zunächst mit Vergleichsdaten im Beobachtungsbetrieb. |
+| #9 SBS-Unterstützung | Braucht ein geprüftes Geräte-Mapping und einen passenden Adapter; die Canonical-Schicht allein bestätigt keine Registerkompatibilität. |
+| #11 ältere Pause-Meldung | Gegen aktuellen Adapter und die konkrete Installation abgleichen. Ein alter Kommentar oder ein gesetzter Modus beweist keine physische Sperre. |
+| Wartbarkeit | `opti_derived.yaml` und die gespiegelte Strategie sind groß. Die Paritätstests sichern Änderungen ab. Eine spätere Aufteilung braucht ein klares Upgrade-Verfahren für bestehende Packages. |
+| Backtest | Stundenweise Nacht-/Peak-Simulation mit vereinfachtem Energiefluss. Kein Beweis für PV-Tagesoptimierung, Viertelstunden-Timing, Sommer-/Winterzeit oder echtes WR-Verhalten. |
+
+Die Übernahme in eine laufende Installation ist unter
+[Aktualisierung bestehender Installationen](installation.md#aktualisierung-bestehender-installationen-september-2026)
+beschrieben. Vorhandene lokale Anpassungen und das private Mapping müssen dabei
+erhalten bleiben.

--- a/docs/strategie-logik.md
+++ b/docs/strategie-logik.md
@@ -516,8 +516,19 @@ Der Deckel schließt diese Lücke, indem er oberhalb `maxsoc` aktiv **Akku nur E
 **Bedingungen:** `binary_sensor.opti_peak_reserve_aktiv` = `off` **und** `soc >= maxsoc` (mit Hysterese).
 Das Peak-Reserve-Gate gibt der Peak-Reserve-Haltelogik (L3/L4) bei anstehender Preisspitze bewusst Vorrang - dann darf die Reserve bis knapp über `maxsoc` gehalten werden, statt sie vor dem Peak zu verlieren.
 
-**Anti-Flatter-Hysterese:** Rein bei `soc >= maxsoc`, drin bleibt der Deckel bis `soc < maxsoc − 3` (asymmetrisch, an den Modus-String gebunden - dieselbe Philosophie wie der Ziel-SoC-Entladezweig).
-So chattert der Modus nicht an der Kante.
+**Anti-Flatter-Hysterese:** Eintritt bei `soc >= maxsoc`, halten bis `soc < maxsoc - 3`.
+Den Eintritt merkt sich `binary_sensor.opti_ladedeckel_aktiv` unabhängig vom Modus.
+Ein vorheriges „Akku nur Entladen“ aus dem Ziel-SoC- oder Peak-Zweig aktiviert das Band
+nicht. Beispiel: SoC 93 %, maxsoc 95 %, Ziel steigt von 50 auf 95 %: der Deckel sperrt
+nicht, solange 95 % nicht tatsächlich erreicht wurden (Fix für #68).
+
+Der triggerbasierte Merker restauriert Zustand und zugehörige Obergrenze beim Neustart.
+Eine Änderung von `maxsoc` verlangt einen neuen Eintritt an der neuen Grenze; Datenlücken
+bewahren den Merker, berechtigen aber keine Entscheidung mit ungültigen Eingangsdaten.
+Strategie und Vorschau prüfen SoC und Grenze zusätzlich direkt. Damit wirken das Erreichen
+der Obergrenze und das Unterschreiten des Haltebands bereits vor dem nächsten Sensor-Update.
+Auch `maxsoc = 100` bleibt ein Deckel mit demselben Verhalten.
+Balancing, Peak-Prioritäten und EV-Sperre behalten ihre bisherige Reihenfolge.
 
 **Position in der Kaskade:** **nach** dem Balancing-Watchdog (der darf `maxsoc` bewusst überschreiten) und **vor** den Prognose-Ladeblöcken, Überschuss-Zweigen und dem Default - damit greift der Deckel, bevor irgendein Ladepfad über `maxsoc` hinaus aktiv werden kann.
 
@@ -526,7 +537,7 @@ So chattert der Modus nicht an der Kante.
 ## Block-für-Block-Übersicht
 
 Die Automation besteht aus mehreren Aktionsblöcken, die **sequenziell** ausgeführt werden.
-Der wichtigste ist „Zwischen Speicherszenarien wählen" mit 20 Optionen und einem Default-Pfad.
+Der wichtigste ist „Zwischen Speicherszenarien wählen" mit 22 Optionen und einem Default-Pfad.
 
 > **Hinweis — Counter-Pflege ausgelagert:** Der Zähler `counter.tage_seit_akku100` (Increment
 > täglich, Reset bei 30 min stabil über Done-SoC) liegt **nicht** in dieser Automation, sondern
@@ -537,7 +548,7 @@ Der wichtigste ist „Zwischen Speicherszenarien wählen" mit 20 Optionen und ei
 
 ---
 
-### Aktionsblock 1 — „Zwischen Speicherszenarien wählen" (20 Optionen + Default)
+### Aktionsblock 1 — „Zwischen Speicherszenarien wählen" (22 Optionen + Default)
 
 Dies ist das Herzstück. Die Optionen werden **der Reihe nach** geprüft;
 die erste, deren Bedingungen alle erfüllt sind, wird ausgeführt. Danach läuft die
@@ -917,7 +928,7 @@ verschenkte dieser Zweig genau die Energie, für die der Akku da ist (Live-Beleg
 
 #### Default — Akku Dynamisch
 
-Trifft keine der 20 Optionen zu (z. B. nachts ohne Ladegrund, Preis zu hoch),
+Trifft keine der 22 Optionen zu (z. B. nachts ohne Ladegrund, Preis zu hoch),
 wird der Modus auf **Akku Dynamisch** gesetzt. Der Adapter entscheidet dann
 situationsabhängig, ob leicht geladen oder entladen wird — ein sicherer Mittelweg.
 

--- a/packages/byd_modul2_fruehwarnung.yaml
+++ b/packages/byd_modul2_fruehwarnung.yaml
@@ -195,11 +195,12 @@ template:
           {{ ((ns.m2 | min) / 1000) | round(3) }}
 
       # Nettoenergie seit dem letzten Voll-Anker (entladen - geladen, kWh).
-      # measurement statt total_increasing (darf bei PV-Zwischenladung sinken).
+      # Diagnosewert pro Voll-Anker, kein Energiezaehler fuer das Energy-Dashboard.
+      # measurement behaelt Min/Max/Mittelwert fuer die Verlaufskurve. Die
+      # Kombination mit device_class energy ist in HA unzulaessig (#64).
       - unique_id: byd_netto_energie_seit_voll_nativ
         name: "BYD Nettoenergie seit Voll"
         unit_of_measurement: "kWh"
-        device_class: energy
         state_class: measurement
         icon: mdi:battery-minus-outline
         availability: >
@@ -465,7 +466,6 @@ template:
       - unique_id: byd_modul2_netto_bis_knie_nativ
         name: "BYD Modul-2 Nettoenergie bis Knie"
         unit_of_measurement: "kWh"
-        device_class: energy
         state_class: measurement
         icon: mdi:battery-alert-variant-outline
         state: "{{ state_attr('sensor.byd_knie_bestaetigungen', 'netto_bei_erstem_sample') }}"

--- a/packages/opti_derived.yaml
+++ b/packages/opti_derived.yaml
@@ -817,62 +817,45 @@ template:
         attributes: { ladepreis_ct: "{{ (states('input_number.ladepreis')|float(0) * 100)|round(2) }}", differenz_ct: "{{ (states('input_number.mindestpreisdifferenz_lade_entladepreis')|float(0) * 100)|round(2) }}" }
 
       # -----------------------------------------------------------------------
-      # 7. Akku-Restlaufzeit (h) — übersetzt aus house_battery_runtime_raw
-      #    (SMA-Templates Z.25-80). Logik/Schwellen unverändert, nur Quellen:
-      #      Kapazität (Wh/1000) → opti_battery_capacity_kwh (bereits kWh, kein /1000)
-      #      SoC → opti_soc; PV-Gate → opti_pv_power_w; Entladelast → opti_house_consumption_w
-      #      MinSOC/MaxSOC → input_number.minsoc / input_number.maxsoc
+      # 7. Akku-Restlaufzeit (h): vorhandene Energie oberhalb von MinSOC.
+      #    Ein SoC-Prozent entspricht 1/100 der Nennkapazitaet. maxsoc ist eine
+      #    LADEgrenze und skaliert weder die Kapazitaet noch bereits gespeicherte
+      #    Energie. Momentaner Hausverbrauch als Last, ohne Verlustmodell.
+      #    Anzeige-Konvention bleibt: PV >=100 W -> 0, Last 0 -> 999, sonst <=24 h.
       # -----------------------------------------------------------------------
       - unique_id: opti_runtime_h
         name: "Opti Runtime H"
         unit_of_measurement: "hours"
         state_class: measurement
         availability: >
-          {{ has_value('sensor.opti_soc') and
-             has_value('sensor.opti_battery_capacity_kwh') and
-             has_value('sensor.opti_house_consumption_w') }}
+          {{ is_number(states('sensor.opti_soc'))
+             and 0 <= states('sensor.opti_soc')|float(0) <= 100
+             and is_number(states('sensor.opti_battery_capacity_kwh'))
+             and states('sensor.opti_battery_capacity_kwh')|float(0) > 0
+             and is_number(states('sensor.opti_house_consumption_w'))
+             and states('sensor.opti_house_consumption_w')|float(0) >= 0
+             and is_number(states('sensor.opti_pv_power_w'))
+             and is_number(states('input_number.minsoc'))
+             and 0 <= states('input_number.minsoc')|float(0) <= 100 }}
         state: >
           {% set soc = states('sensor.opti_soc') %}
-          {% set capacity_kwh_raw = states('sensor.opti_battery_capacity_kwh') %}
-          {% set house_w = states('sensor.opti_house_consumption_w') %}
-          {% set pv_power = states('sensor.opti_pv_power_w') %}
-          {% set min_soc_helper = states('input_number.minsoc') %}
-          {% set max_soc_helper = states('input_number.maxsoc') %}
-
-          {% if soc not in ['unavailable', 'unknown', None] and
-                capacity_kwh_raw not in ['unavailable', 'unknown', None] and
-                house_w not in ['unavailable', 'unknown', None] and
-                pv_power not in ['unavailable', 'unknown', None] %}
-
-            {% set soc_value = soc|float(0) %}
-            {% set capacity_kwh = capacity_kwh_raw|float(0) %}
-            {% set pv_power_value = pv_power|float(0) %}
-
-            {% set min_soc = min_soc_helper|float(10) if min_soc_helper not in ['unavailable', 'unknown', None] else 10 %}
-            {% set max_soc = max_soc_helper|float(95) if max_soc_helper not in ['unavailable', 'unknown', None] else 95 %}
-            {% set min_soc_safe = max(0, min(100, min_soc)) %}
-            {% set max_soc_safe = max(min_soc_safe, min(100, max_soc)) %}
-
-            {% if pv_power_value < 100 %}
-              {% set discharge_power_kw = house_w|float(0) / 1000 %}
-
-              {% set current_soc_in_range = max(min_soc_safe, min(max_soc_safe, soc_value)) %}
-              {% set available_soc_percentage = (current_soc_in_range - min_soc_safe) / (max_soc_safe - min_soc_safe) * 100 if max_soc_safe > min_soc_safe else 0 %}
-              {% set available_energy_kwh = (available_soc_percentage / 100) * capacity_kwh %}
-
-              {% if discharge_power_kw > 0 and available_energy_kwh > 0 %}
-                {% set runtime_hours = available_energy_kwh / discharge_power_kw %}
-                {{ [runtime_hours, 24]|min|round(2) }}
-              {% elif discharge_power_kw == 0 %}
-                999
-              {% else %}
-                0
-              {% endif %}
-            {% else %}
-              0
-            {% endif %}
+          {% set cap = states('sensor.opti_battery_capacity_kwh') %}
+          {% set house = states('sensor.opti_house_consumption_w') %}
+          {% set pv = states('sensor.opti_pv_power_w') %}
+          {% set floor = states('input_number.minsoc') %}
+          {% if not (is_number(soc) and 0 <= soc|float(0) <= 100
+                     and is_number(cap) and cap|float(0) > 0
+                     and is_number(house) and house|float(0) >= 0
+                     and is_number(pv) and is_number(floor)
+                     and 0 <= floor|float(0) <= 100) %}
+            {{ none }}
+          {% elif pv|float(0) >= 100 %}
+            0
+          {% elif house|float(0) == 0 %}
+            999
           {% else %}
-            unavailable
+            {% set energy = [0, soc|float(0) - floor|float(0)]|max * cap|float(0) / 100 %}
+            {{ [24, energy / (house|float(0) / 1000)]|min|round(2) }}
           {% endif %}
 
       # -----------------------------------------------------------------------
@@ -1021,7 +1004,9 @@ template:
           {# hv_maxsoc spiegelt das has_value-Gate des Automation-Zweigs: ohne
              maxsoc faellt der Zweig dort ZU (fail-safe), die Vorschau muss
              dasselbe tun statt mit dem Default 95 weiterzurechnen. #}
-          {% set hv_maxsoc = has_value('input_number.maxsoc') %}
+          {% set hv_maxsoc = is_number(states('input_number.maxsoc')) %}
+          {% set deckel_band = 3 if is_state('binary_sensor.opti_ladedeckel_aktiv', 'on')
+                and state_attr('binary_sensor.opti_ladedeckel_aktiv', 'maxsoc')|float(-1) == maxsoc else 0 %}
           {% set veto = is_state('binary_sensor.opti_ueberschuss_veto_aktiv','on') %}
           {% if soc >= 0 and soc < minsoc %}Akku nur Laden
           {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) - stopband and cur < eeg and fenster %}Akku Netzladen
@@ -1030,7 +1015,7 @@ template:
           {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and soc > ve_res + band and not ev %}Akku nur Entladen
           {%- elif is_state('sensor.opti_balancing_watchdog','pv') %}Akku nur Laden
           {%- elif is_state('sensor.opti_balancing_watchdog','netz') %}Akku Netzladen
-          {%- elif not aktiv and not ev and soc >= 0 and soc >= (states('input_number.maxsoc')|float(95) - (3 if states('input_select.akkusteuerung_modus') == 'Akku nur Entladen' else 0)) %}Akku nur Entladen
+          {%- elif not aktiv and not ev and hv_maxsoc and soc >= 0 and soc >= maxsoc - deckel_band %}Akku nur Entladen
           {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}Akku nur Laden
           {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}Akku nur Laden
           {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}Akku nur Laden
@@ -1108,7 +1093,9 @@ template:
             {# hv_maxsoc spiegelt das has_value-Gate des Automation-Zweigs: ohne
                maxsoc faellt der Zweig dort ZU (fail-safe), die Vorschau muss
                dasselbe tun statt mit dem Default 95 weiterzurechnen. #}
-            {% set hv_maxsoc = has_value('input_number.maxsoc') %}
+            {% set hv_maxsoc = is_number(states('input_number.maxsoc')) %}
+            {% set deckel_band = 3 if is_state('binary_sensor.opti_ladedeckel_aktiv', 'on')
+                  and state_attr('binary_sensor.opti_ladedeckel_aktiv', 'maxsoc')|float(-1) == maxsoc else 0 %}
             {% set veto = is_state('binary_sensor.opti_ueberschuss_veto_aktiv','on') %}
             {% if soc >= 0 and soc < minsoc %}MinSOC-Schutz (SoC<{{minsoc}})
             {%- elif prog and hv_cur and hv_s and s < 3 and soc >= 0 and soc < states('input_number.maxsoc')|float(95) - stopband and cur < eeg and fenster %}Negativpreis-Laden ({{cur}}ct < EEG {{eeg}}ct)
@@ -1117,7 +1104,7 @@ template:
             {%- elif aktiv and soc >= 0 and price == 'EXPENSIVE' and soc > ve_res + band and not ev %}Peak-Leiter L2 (EXP entladen, ueber VE-Reserve {{ve_res}}%)
             {%- elif is_state('sensor.opti_balancing_watchdog','pv') %}Balancing-Watchdog (PV-Vollladung)
             {%- elif is_state('sensor.opti_balancing_watchdog','netz') %}Balancing-Watchdog (Netz-Vollladung)
-            {%- elif not aktiv and not ev and soc >= 0 and soc >= (states('input_number.maxsoc')|float(95) - (3 if states('input_select.akkusteuerung_modus') == 'Akku nur Entladen' else 0)) %}Ladedeckel (maxsoc erreicht)
+            {%- elif not aktiv and not ev and hv_maxsoc and soc >= 0 and soc >= maxsoc - deckel_band %}Ladedeckel (maxsoc erreicht)
             {%- elif prog and win and hv_s and hv_st and soc < 20 and s < 3 and st < 3 and p_e %}SOC<20 Prognose (heute+morgen schlecht)
             {%- elif prog and hv_s and hv_st and soc < 75 and s < 3 and st < 3 and p_n %}SOC<75 Prognose (Preis bis NORMAL)
             {%- elif prog and win and hv_s and hv_st and soc < 80 and s < 3 and st < 3 and p_e %}SOC<80 Wintermodus
@@ -1358,3 +1345,38 @@ template:
         state: >
           {{ peak.gueltig and has_value('sensor.opti_battery_capacity_kwh')
              and peak.benoetigt_kwh > 0 }}
+
+  # Eigenes Gedaechtnis fuer den Ladedeckel (#68). Der aktuelle Modus ist KEIN
+  # Beleg, dass maxsoc erreicht wurde. Ein geaenderter Deckel muss neu erreicht
+  # werden. Trigger-basierte Binary-Sensoren restaurieren Zustand + Attribute.
+  # Bei Datenluecken keine Neubewertung; die Verbraucher pruefen aktuelle Werte
+  # und die zum Merker gehoerende Grenze selbst, auch vor diesem Sensor-Update.
+  - triggers:
+      - trigger: state
+        entity_id:
+          - sensor.opti_soc
+          - input_number.maxsoc
+      - trigger: homeassistant
+        event: start
+      # Erstauswertung auch nach Template-Reload ohne neue Quellwerte.
+      - trigger: time_pattern
+        minutes: "/1"
+    conditions:
+      - condition: template
+        value_template: >
+          {{ is_number(states('sensor.opti_soc'))
+             and 0 <= states('sensor.opti_soc')|float(0) <= 100
+             and is_number(states('input_number.maxsoc'))
+             and 0 <= states('input_number.maxsoc')|float(0) <= 100 }}
+    binary_sensor:
+      - unique_id: opti_ladedeckel_aktiv
+        name: "Opti Ladedeckel Aktiv"
+        icon: mdi:battery-lock
+        state: >
+          {% set soc = states('sensor.opti_soc')|float(0) %}
+          {% set maximum = states('input_number.maxsoc')|float(0) %}
+          {% set gehalten = this is defined and this.state == 'on'
+              and this.attributes.get('maxsoc')|float(-1) == maximum %}
+          {{ soc >= maximum or (gehalten and soc >= maximum - 3) }}
+        attributes:
+          maxsoc: "{{ states('input_number.maxsoc')|float(0) }}"

--- a/packages/sma_templates.yaml
+++ b/packages/sma_templates.yaml
@@ -26,61 +26,41 @@
 
 template:
   - sensor:
-      - unique_id: "house_battery_runtime_raw"
+      # Gleiche Restenergie-Formel wie opti_runtime_h, hier Kapazitaet in Wh
+      # und Betrag der signierten Akku-Leistung als Nenner (Entladen negativ).
+      # Keine maxsoc-Normierung; beide Vorzeichen bleiben wie bisher auswertbar.
+      - unique_id: house_battery_runtime_raw
         name: "House Battery Runtime Raw"
         unit_of_measurement: "hours"
         state_class: measurement
         availability: >
-          {{ has_value('sensor.DEINE_BATTERIE_SOC') and
-             has_value('sensor.sma_stp_se_40187_batterie_nennkapazitaet') and
-             has_value('sensor.house_battery_load_30_mins') }}
+          {{ is_number(states('sensor.DEINE_BATTERIE_SOC'))
+             and 0 <= states('sensor.DEINE_BATTERIE_SOC')|float(0) <= 100
+             and is_number(states('sensor.sma_stp_se_40187_batterie_nennkapazitaet'))
+             and states('sensor.sma_stp_se_40187_batterie_nennkapazitaet')|float(0) > 0
+             and is_number(states('sensor.house_battery_load_30_mins'))
+             and is_number(states('sensor.DEIN_PV_POWER'))
+             and is_number(states('input_number.minsoc'))
+             and 0 <= states('input_number.minsoc')|float(0) <= 100 }}
         state: >
           {% set soc = states('sensor.DEINE_BATTERIE_SOC') %}
-          {% set nennkapazitaet = states('sensor.sma_stp_se_40187_batterie_nennkapazitaet') %}
-          {% set battery_load_raw = states('sensor.house_battery_load_30_mins') %}
-          {% set pv_power = states('sensor.DEIN_PV_POWER') %}
-          {% set min_soc_helper = states('input_number.minsoc') %}
-          {% set max_soc_helper = states('input_number.maxsoc') %}
-
-          {% if soc not in ['unavailable', 'unknown', None] and
-                nennkapazitaet not in ['unavailable', 'unknown', None] and
-                battery_load_raw not in ['unavailable', 'unknown', None] and
-                pv_power not in ['unavailable', 'unknown', None] %}
-
-            {% set soc_value = soc|float(0) %}
-            {% set capacity_kwh = nennkapazitaet|float(0) / 1000 %}
-            {% set pv_power_value = pv_power|float(0) %}
-
-            {% set min_soc = min_soc_helper|float(10) if min_soc_helper not in ['unavailable', 'unknown', None] else 10 %}
-            {% set max_soc = max_soc_helper|float(95) if max_soc_helper not in ['unavailable', 'unknown', None] else 95 %}
-            {% set min_soc_safe = max(0, min(100, min_soc)) %}
-            {% set max_soc_safe = max(min_soc_safe, min(100, max_soc)) %}
-
-            {% if pv_power_value < 100 %}
-              {% set battery_load = battery_load_raw|float(0) %}
-              {% if battery_load < 0 %}
-                {% set discharge_power_kw = -battery_load / 1000 %}
-              {% else %}
-                {% set discharge_power_kw = battery_load / 1000 %}
-              {% endif %}
-
-              {% set current_soc_in_range = max(min_soc_safe, min(max_soc_safe, soc_value)) %}
-              {% set available_soc_percentage = (current_soc_in_range - min_soc_safe) / (max_soc_safe - min_soc_safe) * 100 if max_soc_safe > min_soc_safe else 0 %}
-              {% set available_energy_kwh = (available_soc_percentage / 100) * capacity_kwh %}
-
-              {% if discharge_power_kw > 0 and available_energy_kwh > 0 %}
-                {% set runtime_hours = available_energy_kwh / discharge_power_kw %}
-                {{ [runtime_hours, 24]|min|round(2) }}
-              {% elif discharge_power_kw == 0 %}
-                999
-              {% else %}
-                0
-              {% endif %}
-            {% else %}
-              0
-            {% endif %}
+          {% set cap = states('sensor.sma_stp_se_40187_batterie_nennkapazitaet') %}
+          {% set house = states('sensor.house_battery_load_30_mins') %}
+          {% set pv = states('sensor.DEIN_PV_POWER') %}
+          {% set floor = states('input_number.minsoc') %}
+          {% if not (is_number(soc) and 0 <= soc|float(0) <= 100
+                     and is_number(cap) and cap|float(0) > 0
+                     and is_number(house)
+                     and is_number(pv) and is_number(floor)
+                     and 0 <= floor|float(0) <= 100) %}
+            {{ none }}
+          {% elif pv|float(0) >= 100 %}
+            0
+          {% elif house|float(0) == 0 %}
+            999
           {% else %}
-            unavailable
+            {% set energy = [0, soc|float(0) - floor|float(0)]|max * (cap|float(0) / 1000) / 100 %}
+            {{ [24, energy / (house|float(0)|abs / 1000)]|min|round(2) }}
           {% endif %}
 
       - unique_id: "akku_dynamische_ladestaerke_akku"

--- a/tests/ha_harness.py
+++ b/tests/ha_harness.py
@@ -3,6 +3,7 @@ mit synthetischen States. Nachbau nur der hier benutzten HA-Funktionen/Filter.""
 from __future__ import annotations
 
 import datetime as dt
+import math
 import pathlib
 import statistics
 import types
@@ -59,6 +60,14 @@ def _float(value, default=_NO_DEFAULT):
         return default
 
 
+def _is_number(value):
+    """HA lehnt auch NaN und unendliche Zahlen als Messwerte ab."""
+    try:
+        return math.isfinite(float(value))
+    except (TypeError, ValueError, OverflowError):
+        return False
+
+
 def _int(value, default=0):
     try:
         return int(float(value))
@@ -100,6 +109,7 @@ def _setup(env, hass):
     env.globals.update(
         states=hass.states, state_attr=hass.state_attr, has_value=hass.has_value,
         is_state=hass.is_state, now=hass.now, today_at=hass.today_at,
+        is_number=_is_number,
         as_timestamp=_as_timestamp,
         timedelta=dt.timedelta, min=min, max=max,
         this=types.SimpleNamespace(attributes=hass.this_attributes,

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -25,3 +25,12 @@ def test_flacher_tag_kein_unterschied():
     alt = simulate_day(FLACH_50, FLACH_50, neu=False, **kwargs)
     neu = simulate_day(FLACH_50, FLACH_50, neu=True, **kwargs)
     assert abs(neu["cost_eur"] - alt["cost_eur"]) < 0.01
+
+
+def test_backtest_fuehrt_eigenes_ladedeckel_gedaechtnis():
+    result = simulate_day(FLACH_50, FLACH_50, neu=False, load_kw=0.1,
+                          pv_kwh_per_hour=[0.0] * 24, start_soc=95,
+                          cap_kwh=10, minsoc=10, maxsoc=95)
+    # Pro Stunde etwas ueber 1 Prozentpunkt Entladung: Eintritt bei 95,
+    # halten bei ca. 93.95 und 92.89, aus bei ca. 91.84.
+    assert result["ladedeckel_verlauf"][:4] == ["on", "on", "on", "off"]

--- a/tests/test_ladedeckel.py
+++ b/tests/test_ladedeckel.py
@@ -1,0 +1,87 @@
+"""Issue #68: Das Halteband braucht einen belegten Eintritt am eigenen Deckel."""
+import pytest
+
+from .ha_harness import REPO, FakeHass, find_template_entity, load_yaml, render_native
+from .condition_eval import evaluate_condition
+from .test_strategie_paritaet import _make_hass, _evaluate_automation, _vorschau
+
+
+def _step(soc, maximum, previous=None, previous_limit=None):
+    cfg = load_yaml(REPO / "packages/opti_derived.yaml")
+    entity = find_template_entity(cfg, "binary_sensor", "opti_ladedeckel_aktiv")
+    block = next(b for b in cfg["template"] if entity in b.get("binary_sensor", []))
+    hass = FakeHass(
+        states={"sensor.opti_soc": str(soc), "input_number.maxsoc": str(maximum)},
+        this_state=previous, this_attributes={"maxsoc": previous_limit},
+    )
+    if not all(evaluate_condition(hass, c) for c in block.get("conditions", [])):
+        return previous, previous_limit
+    return ("on" if render_native(hass, entity["state"]) else "off",
+            render_native(hass, entity["attributes"]["maxsoc"]))
+
+
+@pytest.mark.parametrize("maximum,soc", [(95, 93), (100, 98)])
+def test_fremder_entlademodus_verriegelt_nicht(maximum, soc):
+    state = {"sensor.opti_soc": str(soc), "input_number.maxsoc": str(maximum),
+             "sensor.opti_target_soc": "50"}
+    assert _evaluate_automation(_make_hass(state)) == (21, "Akku nur Entladen")
+    state.update({"input_select.akkusteuerung_modus": "Akku nur Entladen",
+                  "sensor.opti_target_soc": str(maximum)})
+    hass = _make_hass(state)
+    assert _evaluate_automation(hass)[1] == "Akku Dynamisch"
+    assert _vorschau(hass, "state") == "Akku Dynamisch"
+    assert "Ladedeckel" not in _vorschau(hass, "grund")
+
+
+def test_echter_eintritt_haelt_bis_unter_untergrenze():
+    memory = (None, None)
+    for soc, expected in [(93, "off"), (95, "on"), (94, "on"),
+                          (92, "on"), (91.9, "off"), (93, "off")]:
+        memory = _step(soc, 95, *memory)
+        assert memory == (expected, 95)
+
+
+def test_neustart_und_sensorluecke_bewahren_belegten_eintritt():
+    assert _step(93, 95, "on", 95) == ("on", 95)
+    assert _step("unavailable", 95, "on", 95) == ("on", 95)
+    assert _step(91, 95, "on", 95) == ("off", 95)
+
+
+def test_geaenderter_deckel_erbt_keinen_alten_eintritt():
+    assert _step(98, 100, "on", 95) == ("off", 100)
+    assert _step(94, 93, "off", 95) == ("on", 93)
+
+
+@pytest.mark.parametrize("soc,limit,latched,old_limit,expected", [
+    (95, 95, "unknown", None, True),  # Obergrenze wirkt vor dem Sensor-Update.
+    (93, 95, "on", 95, True),
+    (92, 95, "on", 95, True),
+    (91.9, 95, "on", 95, False),    # Staler Merker darf nicht halten.
+    (98, 100, "on", 95, False),    # MaxSOC-Update vor Merker-Update.
+    (98, "unavailable", "on", 95, False),
+])
+def test_strategie_und_vorschau_beachten_gueltigen_merker(
+        soc, limit, latched, old_limit, expected):
+    hass = _make_hass({
+        "sensor.opti_soc": str(soc), "input_number.maxsoc": str(limit),
+        "sensor.opti_target_soc": "100",
+        "binary_sensor.opti_ladedeckel_aktiv": latched,
+        "_attrs": {"binary_sensor.opti_ladedeckel_aktiv": {"maxsoc": old_limit}},
+    })
+    branch, mode = _evaluate_automation(hass)
+    assert (branch == 7) is expected
+    assert ("Ladedeckel" in _vorschau(hass, "grund")) is expected
+    assert _vorschau(hass, "state") == mode
+
+
+def test_merker_hat_neustart_und_recovery_trigger():
+    cfg = load_yaml(REPO / "packages/opti_derived.yaml")
+    entity = find_template_entity(cfg, "binary_sensor", "opti_ladedeckel_aktiv")
+    block = next(b for b in cfg["template"] if entity in b.get("binary_sensor", []))
+    assert any(t.get("event") == "start" for t in block["triggers"])
+    refs = {eid for t in block["triggers"] if t.get("trigger") == "state"
+            for eid in t["entity_id"]}
+    assert refs == {"sensor.opti_soc", "input_number.maxsoc"}
+    cfg = load_yaml(REPO / "automations/opti_strategie.yaml")
+    assert any("binary_sensor.opti_ladedeckel_aktiv" in t.get("entity_id", [])
+               for t in cfg[0]["triggers"])

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,75 @@
+"""Restenergie ist Kapazitaet mal SoC-Differenz, kein normiertes SoC-Fenster."""
+import pytest
+
+from .ha_harness import REPO, FakeHass, find_template_entity, load_yaml, render_native
+
+
+BASE = {"sensor.opti_soc": "50", "sensor.opti_battery_capacity_kwh": "10",
+        "sensor.opti_house_consumption_w": "1000", "sensor.opti_pv_power_w": "0",
+        "input_number.minsoc": "10", "input_number.maxsoc": "95"}
+
+
+@pytest.fixture(params=[False, True], ids=["canonical", "legacy"])
+def layer(request):
+    return request.param
+
+
+@pytest.fixture
+def runtime(layer):
+    def evaluate(overrides, field="state"):
+        states = {**BASE, **overrides}
+        if layer:
+            mapping = {
+                "sensor.opti_soc": "sensor.DEINE_BATTERIE_SOC",
+                "sensor.opti_battery_capacity_kwh": "sensor.sma_stp_se_40187_batterie_nennkapazitaet",
+                "sensor.opti_house_consumption_w": "sensor.house_battery_load_30_mins",
+                "sensor.opti_pv_power_w": "sensor.DEIN_PV_POWER",
+            }
+            cap = states["sensor.opti_battery_capacity_kwh"]
+            try:
+                states["sensor.opti_battery_capacity_kwh"] = str(float(cap) * 1000)
+            except ValueError:
+                pass
+            states = {mapping.get(k, k): v for k, v in states.items()}
+        entity = find_template_entity(load_yaml(REPO / "packages/opti_derived.yaml"),
+                                      "sensor", "opti_runtime_h")
+        if layer:
+            entity = find_template_entity(load_yaml(REPO / "packages/sma_templates.yaml"),
+                                          "sensor", "house_battery_runtime_raw")
+        return render_native(FakeHass(states=states), entity[field])
+    return evaluate
+
+
+@pytest.mark.parametrize("source", [
+    "sensor.opti_soc", "sensor.opti_battery_capacity_kwh",
+    "sensor.opti_house_consumption_w", "sensor.opti_pv_power_w", "input_number.minsoc",
+])
+@pytest.mark.parametrize("bad", ["unknown", "unavailable", "kaputt", "nan", "inf"])
+def test_fehlende_oder_ungueltige_quelle_wird_nicht_zur_zahl(runtime, source, bad):
+    assert runtime({source: bad}, "availability") is False
+    assert runtime({source: bad}) is None
+
+
+@pytest.mark.parametrize("soc,expected", [(5, 0), (10, 0), (50, 4), (95, 8.5), (100, 9)])
+def test_restenergie_bezieht_sich_auf_nennkapazitaet(runtime, soc, expected):
+    assert runtime({"sensor.opti_soc": str(soc)}) == expected
+
+
+def test_ladeobergrenze_veraendert_nicht_vorhandene_energie(runtime):
+    assert runtime({"input_number.maxsoc": "80"}) == 4
+    assert runtime({"input_number.maxsoc": "unavailable"}) == 4
+
+
+@pytest.mark.parametrize("overrides,expected", [
+    ({"sensor.opti_house_consumption_w": "0"}, 999),
+    ({"sensor.opti_house_consumption_w": "10"}, 24),
+    ({"sensor.opti_pv_power_w": "100"}, 0),
+    ({"sensor.opti_battery_capacity_kwh": "0"}, None),
+    ({"sensor.opti_soc": "101"}, None),
+])
+def test_grenzen_und_bisheriges_anzeigeverhalten(runtime, overrides, expected):
+    assert runtime(overrides) == expected
+
+
+def test_signierte_batterielast_nur_im_legacy_layer(runtime, layer):
+    assert runtime({"sensor.opti_house_consumption_w": "-1000"}) == (4 if layer else None)

--- a/tests/test_sensor_metadata.py
+++ b/tests/test_sensor_metadata.py
@@ -1,0 +1,26 @@
+"""HA-Kompatibilitaet und Trend-Semantik der BYD-Diagnosewerte (#64)."""
+import pytest
+
+from .ha_harness import REPO, find_template_entity, load_yaml
+
+
+@pytest.mark.parametrize("path", sorted((REPO / "packages").glob("*.yaml")))
+def test_energiezaehler_haben_keine_measurement_klasse(path):
+    for block in load_yaml(path).get("template", []):
+        for entity in block.get("sensor", []):
+            if entity.get("device_class") == "energy":
+                assert entity.get("state_class") in (None, "total", "total_increasing"), (
+                    path.name, entity.get("unique_id"))
+
+
+@pytest.mark.parametrize("uid", [
+    "byd_netto_energie_seit_voll_nativ", "byd_modul2_netto_bis_knie_nativ",
+])
+def test_byd_zykluswerte_bleiben_vergleichbare_absolutwerte(uid):
+    entity = find_template_entity(load_yaml(REPO / "packages/byd_modul2_fruehwarnung.yaml"),
+                                  "sensor", uid)
+    # Eine fallende Knie-Energie muss als kleinerer Messwert erhalten bleiben;
+    # total/total_increasing wuerden Differenzen/Zaehlzyklen summieren.
+    assert entity.get("state_class") == "measurement"
+    assert entity["unit_of_measurement"] == "kWh"
+    assert entity.get("device_class") is None

--- a/tools/backtest.py
+++ b/tools/backtest.py
@@ -39,6 +39,7 @@ LADE_KW = 2.5  # angenommene Netz-Ladeleistung im Simulator
 _derived = load_yaml(REPO / "packages" / "opti_derived.yaml")
 _vorschau = find_template_entity(_derived, "sensor", "opti_strategie_vorschau")
 _peak_template = find_trigger_block_variables(_derived, "peak")
+_ladedeckel = find_template_entity(_derived, "binary_sensor", "opti_ladedeckel_aktiv")
 
 
 def _states(hour_price, soc, load_kw, neu, cap_kwh, peak, *,
@@ -117,7 +118,9 @@ def simulate_day(prices_today, prices_tomorrow, *, load_kw, pv_kwh_per_hour,
     soc = start_soc
     modus = modus_start
     cost = 0.0
-    soc_verlauf, modus_verlauf = [], []
+    soc_verlauf, modus_verlauf, ladedeckel_verlauf = [], [], []
+    deckel_state = None
+    deckel_attrs = {}
     alle_preise = list(prices_today) + list(prices_tomorrow)
     for hour in range(24):
         preis = prices_today[hour]
@@ -150,6 +153,14 @@ def simulate_day(prices_today, prices_tomorrow, *, load_kw, pv_kwh_per_hour,
         hass.now_value = now
         hass.states_map["sensor.opti_price_level"] = _price_level(alle_preise, preis)
         hass.states_map["input_select.akkusteuerung_modus"] = modus
+        # Auch das eigene Deckel-Gedaechtnis mit dem echten Template rechnen.
+        # Der Simulator hat ausschliesslich gueltige numerische SoC-/MaxSOC-Werte.
+        hass.this_state, hass.this_attributes = deckel_state, deckel_attrs
+        deckel_state = "on" if render_native(hass, _ladedeckel["state"]) else "off"
+        deckel_attrs = {"maxsoc": render_native(hass, _ladedeckel["attributes"]["maxsoc"])}
+        hass.states_map["binary_sensor.opti_ladedeckel_aktiv"] = deckel_state
+        hass.attrs_map["binary_sensor.opti_ladedeckel_aktiv"] = deckel_attrs
+        ladedeckel_verlauf.append(deckel_state)
         modus = render(hass, _vorschau["state"])
         # 3. Energiefluss der Stunde
         pv = pv_kwh_per_hour[hour]
@@ -172,7 +183,7 @@ def simulate_day(prices_today, prices_tomorrow, *, load_kw, pv_kwh_per_hour,
         soc_verlauf.append(round(soc, 1))
         modus_verlauf.append(modus)
     return {"cost_eur": round(cost, 2), "soc_verlauf": soc_verlauf,
-            "modus_verlauf": modus_verlauf}
+            "modus_verlauf": modus_verlauf, "ladedeckel_verlauf": ladedeckel_verlauf}
 
 
 SZENARIEN = {

--- a/tools/validate_ha.py
+++ b/tools/validate_ha.py
@@ -1,0 +1,98 @@
+"""Optionale Integration-Pruefung mit echtem Home Assistant, ausschliesslich lokal.
+
+In einer separaten venv mit homeassistant==2026.9.0 ausfuehren:
+    python tools/validate_ha.py
+
+Validiert alle aktiven Template-Abschnitte und Automations-Schemas. Startet dann
+zwei isolierte HA-Instanzen in einem neuen Temp-Verzeichnis mit synthetischen
+Sensorwerten, um Ladedeckel, Daten-Recovery und Restore nach Neustart zu pruefen.
+Keine Verbindung zur echten Anlage; keine Modbus-Integration wird geladen.
+Das Temp-Verzeichnis bleibt fuer die Fehlersuche erhalten.
+"""
+import asyncio
+import copy
+import pathlib
+import tempfile
+import yaml
+from homeassistant.core import HomeAssistant
+from homeassistant import loader, config_entries, bootstrap
+from homeassistant.setup import async_setup_component
+from homeassistant.components.template.config import async_validate_config_section
+from homeassistant.components.automation.config import async_validate_config_item
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+async def main():
+    config_dir = tempfile.mkdtemp(prefix='opti-ha-offline-')
+    hass = HomeAssistant(config_dir)
+    hass.config.time_zone = 'Europe/Berlin'
+    loader.async_setup(hass)
+    hass.config_entries = config_entries.ConfigEntries(hass, {})
+    await bootstrap.async_load_base_functionality(hass)
+    count = 0
+    for path in [*sorted((ROOT/'packages').glob('*.yaml')), ROOT/'opti_mapping.example.yaml']:
+        data = yaml.safe_load(path.read_text())
+        for block in data.get('template', []):
+            assert await async_validate_config_section(hass, copy.deepcopy(block)) is not None, path
+            count += 1
+        for automation in data.get('automation', []):
+            assert await async_validate_config_item(hass, 'automation', copy.deepcopy(automation)) is not None, path
+    for path in (ROOT/'automations').glob('*.yaml'):
+        for automation in yaml.safe_load(path.read_text()):
+            assert await async_validate_config_item(hass, 'automation', copy.deepcopy(automation)) is not None, path
+    print('Native HA template sections validated:', count, flush=True)
+    data = yaml.safe_load((ROOT/'packages/opti_derived.yaml').read_text())
+    latch = next(b for b in data['template'] if any(e.get('unique_id') == 'opti_ladedeckel_aktiv' for e in b.get('binary_sensor', [])))
+    runtime = next(e for b in data['template'] for e in b.get('sensor', []) if e.get('unique_id') == 'opti_runtime_h')
+    for eid, val in {'sensor.opti_soc':'93','input_number.maxsoc':'95','input_number.minsoc':'10','sensor.opti_battery_capacity_kwh':'10','sensor.opti_house_consumption_w':'1000','sensor.opti_pv_power_w':'0'}.items():
+        hass.states.async_set(eid,val)
+    assert await async_setup_component(hass, 'template', {'template':[latch, {'sensor':[runtime]}]})
+    await hass.async_start()
+    await hass.async_block_till_done()
+    async def step(soc, expected, maximum=None):
+        if maximum is not None: hass.states.async_set('input_number.maxsoc',str(maximum))
+        hass.states.async_set('sensor.opti_soc',str(soc))
+        await hass.async_block_till_done()
+        state=hass.states.get('binary_sensor.opti_ladedeckel_aktiv')
+        assert state and state.state==expected, (soc,maximum,state)
+    await step(93,'off')
+    await step(95,'on')
+    await step(93,'on')
+    await step('unavailable','on')
+    await step(93,'on')
+    await step(91.9,'off')
+    await step(93,'off')
+    await step(95,'on')
+    await step(98,'off',100)
+    await step(100,'on')
+    await step(98,'on')
+    await step(97,'on')
+    await step(96.9,'off')
+    hass.states.async_set('sensor.opti_soc','50')
+    await hass.async_block_till_done()
+    assert hass.states.get('sensor.opti_runtime_h').state=='4.0'
+    hass.states.async_set('sensor.opti_pv_power_w','unavailable')
+    await hass.async_block_till_done()
+    assert hass.states.get('sensor.opti_runtime_h').state=='unavailable'
+    await step(100,'on')
+    await step(98,'on')
+    await hass.async_stop()
+    print('Native HA event integration: latch transitions and runtime availability passed.',flush=True)
+    # Use a second actual instance with the saved restore-state store.
+    restored=HomeAssistant(config_dir)
+    restored.config.time_zone = 'Europe/Berlin'
+    loader.async_setup(restored)
+    restored.config_entries = config_entries.ConfigEntries(restored, {})
+    await bootstrap.async_load_base_functionality(restored)
+    restored.states.async_set('sensor.opti_soc','98')
+    restored.states.async_set('input_number.maxsoc','100')
+    assert await async_setup_component(restored,'template',{'template':[latch]})
+    await restored.async_start()
+    await restored.async_block_till_done()
+    state=restored.states.get('binary_sensor.opti_ladedeckel_aktiv')
+    assert state and state.state=='on' and state.attributes['maxsoc']==100, state
+    await restored.async_stop()
+    print('Native HA cold restart: latch and maxsoc restored.',flush=True)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tools/validate_ha.py
+++ b/tools/validate_ha.py
@@ -4,7 +4,7 @@ In einer separaten venv mit homeassistant==2026.9.0 ausfuehren:
     python tools/validate_ha.py
 
 Validiert alle aktiven Template-Abschnitte und Automations-Schemas. Startet dann
-zwei isolierte HA-Instanzen in einem neuen Temp-Verzeichnis mit synthetischen
+drei isolierte HA-Instanzen in einem neuen Temp-Verzeichnis mit synthetischen
 Sensorwerten, um Ladedeckel, Daten-Recovery und Restore nach Neustart zu pruefen.
 Keine Verbindung zur echten Anlage; keine Modbus-Integration wird geladen.
 Das Temp-Verzeichnis bleibt fuer die Fehlersuche erhalten.
@@ -93,6 +93,27 @@ async def main():
     assert state and state.state=='on' and state.attributes['maxsoc']==100, state
     await restored.async_stop()
     print('Native HA cold restart: latch and maxsoc restored.',flush=True)
+
+    # A different SoC is already present BEFORE listeners are registered.
+    # Restore alone leaves the latch on; only startup evaluation can clear it.
+    changed=HomeAssistant(config_dir)
+    changed.config.time_zone = 'Europe/Berlin'
+    loader.async_setup(changed)
+    changed.config_entries = config_entries.ConfigEntries(changed, {})
+    await bootstrap.async_load_base_functionality(changed)
+    changed.states.async_set('sensor.opti_soc','50')
+    changed.states.async_set('input_number.maxsoc','100')
+    startup_latch=copy.deepcopy(latch)
+    # The minute fallback must not hide a broken homeassistant-start trigger.
+    startup_latch['triggers']=[t for t in startup_latch['triggers'] if t['trigger']!='time_pattern']
+    assert await async_setup_component(changed,'template',{'template':[startup_latch]})
+    await changed.async_block_till_done()
+    assert changed.states.get('binary_sensor.opti_ladedeckel_aktiv').state=='on'
+    await changed.async_start()
+    await changed.async_block_till_done()
+    assert changed.states.get('binary_sensor.opti_ladedeckel_aktiv').state=='off'
+    await changed.async_stop()
+    print('Native HA startup: restored latch reevaluated against changed source.',flush=True)
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
Der Ladedeckel konnte das Halteband von einem anderen Strategie-Zweig übernehmen und Laden schon unterhalb von MaxSOC sperren. Ein eigener, nach Neustarts wiederhergestellter Merker aktiviert das Band jetzt erst nach Erreichen der Grenze. Strategie und Vorschau berücksichtigen Grenzwechsel und Datenlücken.

Die Restlaufzeit verwendet jetzt die vorhandene Energie oberhalb von MinSOC. Fehlende oder ungültige Quelldaten ergeben `unavailable`. Bei zwei BYD-Diagnosekurven entfällt die inkompatible Geräteklasse `energy`; kWh und die Messwertstatistik bleiben erhalten.

Fixes #68. Behebt außerdem die Metadatenwarnungen aus #64; dessen übrige Fragen bleiben offen.

### Aktualisierung

`opti_derived.yaml` und Strategie gemeinsam aktualisieren, für das optionale BYD-Monitoring auch `byd_modul2_fruehwarnung.yaml`. Die Legacy-Laufzeitkorrektur liegt in `sma_templates.yaml`. Eigene Mappings, Helfer und Package-Wrapper beibehalten; siehe [Aktualisierungsanleitung](https://github.com/Optic00/ha-opti-akkusteuerung/blob/main/docs/installation.md#aktualisierung-bestehender-installationen-september-2026).

### Prüfung

[CI bestanden](https://github.com/Optic00/ha-opti-akkusteuerung/actions/runs/33951828848). Die dokumentierte lokale Prüfung umfasst Regressionstests sowie isolierte HA-Validierung mit Datenlücken, Recovery und Neustart. Template-Reload und physische Hysterese-Grenzfälle wurden nicht nativ getestet.

### Cross-model review

- [x] Required and completed

Implementierung: GPT-6 (`gpt-6-astra`). Reviewer: `gpt-5.6-sol` und Claude Fable 5.1 (`claude-fable-5-1`, Anthropic). Datum: 05.09.2026. Geprüfter Gesamtbereich: `668745ce130d7ea5c80c2e62c29c1b2ed5c70427..c74ac186853a1299aa966372ba68c884c72b86a8`; Claude hat die abschließenden Test- und Dokumentationsänderungen nachgeprüft.

Ergebnis: keine verbleibenden Critical-/Important-Befunde. Korrigiert wurden Legacy-Lastvorzeichen, HA-Plattformvalidierung, veraltete Optionsangaben, die Neustart-Neubewertung im Test und die Erklärung des Legacy-Nenners.

Beibehalten und begründet: eigene Merker-Trigger zur Neubewertung, strikte Availability für ungültige Messwerte und gepinnte interne HA-Test-APIs. Die unterschiedliche Prüfung mit `is_number` und `has_value` bleibt für `input_number` funktional gleichwertig. Der Einwand zum gleichen Anbieter war nach der Policy unbegründet, da eine andere Modellfamilie zulässig ist.